### PR TITLE
ci: use ubuntu-latest runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on:
-      labels: ubuntu-22.04-4cpu-16ram-150ssd
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read
@@ -27,8 +26,7 @@ jobs:
         run: npm run build
 
   test:
-    runs-on:
-      labels: ubuntu-22.04-4cpu-16ram-150ssd
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read
@@ -47,8 +45,7 @@ jobs:
         run: npm run test:ci
 
   lint:
-    runs-on:
-      labels: ubuntu-22.04-4cpu-16ram-150ssd
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Switch all CI jobs (`build`, `test`, `lint`) from the custom self-hosted runner labels (`ubuntu-22.04-4cpu-16ram-150ssd`) to the standard GitHub-hosted `ubuntu-latest` runner.

## Test plan
- [x] CI runs green on `ubuntu-latest`