### PR TITLE
feat: inject compile_command guidance into agent context files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,7 @@ When you make a change, update every doc whose described behavior is affected. T
 |---|---|
 | New eval added (`PROMPT.md` + `graders.ts`) | `AGENTS.md` eval list (if maintaining one); `docs/ADDING_EVALS.md` if the change reveals a gap in the guide |
 | `setup_command` behaviour changed (e.g. new syntax supported) | `docs/ADDING_EVALS.md` — frontmatter table and example; `AGENTS.md` checklist if relevant |
+| `compile_command` added to an eval or its context-injection behaviour changed | `docs/ADDING_EVALS.md` — frontmatter table and example; `AGENTS.md` checklist if relevant |
 | New skill added or skill resolution logic changed | `docs/TESTING_SKILLS.md`; `AGENTS.md` if skill tooling or config changed |
 | New CLI flag or runner added | `AGENTS.md` CLI flags table and Agent runners table; `README.md` quick-start if the flag is commonly used |
 | Scoring dimension added, changed, or removed | `docs/SCORING_METHODOLOGY.md` first (per the workflow); then `AGENTS.md` scoring section once merged |
@@ -151,7 +152,7 @@ When you make a change, update every doc whose described behavior is affected. T
 ## Adding an eval — checklist
 
 1. `src/evals/<category>/<eval-dir>/PROMPT.md` + `graders.ts`
-2. Add `id` (required) and optionally `name`/`category` to `PROMPT.md` frontmatter — the framework auto-discovers evals from `evalsDir`
+2. Add `id` (required) and optionally `name`/`category`/`compile_command` to `PROMPT.md` frontmatter — the framework auto-discovers evals from `evalsDir`. Set `compile_command` to point the agent at a verify-compiles command (injected into the agent's context file, e.g. `CLAUDE.md`); omit for evals with no CLI compile step (e.g. mobile).
 3. All imports use `.js` extensions; `import type` for type-only
 4. All graders have `GraderLevel`; one final holistic `judge` with no level
 5. `npm run build && npm test` passes

--- a/apps/auth0-evals/src/evals/quickstarts/angular/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/angular/PROMPT.md
@@ -3,6 +3,7 @@ id: angular_quickstart
 name: Angular Quickstart
 skills: auth0-angular
 setup_command: npm install
+compile_command: npm run build
 ---
 
 ## Task

--- a/apps/auth0-evals/src/evals/quickstarts/express/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/express/PROMPT.md
@@ -3,6 +3,7 @@ id: express_quickstart
 name: Express Quickstart
 skills: auth0-express
 setup_command: npm install
+compile_command: node --check server.js
 ---
 
 ## Task

--- a/apps/auth0-evals/src/evals/quickstarts/fastapi/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/fastapi/PROMPT.md
@@ -3,6 +3,7 @@ id: fastapi_quickstart
 name: FastAPI Quickstart
 skills: auth0-fastapi-api
 setup_command: python3 -m venv .venv && .venv/bin/pip install -r requirements.txt
+compile_command: .venv/bin/python -m py_compile main.py
 ---
 
 ## Task

--- a/apps/auth0-evals/src/evals/quickstarts/fastify-api/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/fastify-api/PROMPT.md
@@ -3,6 +3,7 @@ id: fastify_api_quickstart
 name: Fastify API Quickstart
 skills: auth0-fastify-api
 setup_command: npm install
+compile_command: node --check server.js
 ---
 
 ## Task

--- a/apps/auth0-evals/src/evals/quickstarts/flask/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/flask/PROMPT.md
@@ -3,6 +3,7 @@ id: flask_quickstart
 name: Flask Quickstart
 skills: auth0-flask
 setup_command: python3 -m venv .venv && .venv/bin/pip install -r requirements.txt
+compile_command: .venv/bin/python -m py_compile app.py
 ---
 
 ## Task

--- a/apps/auth0-evals/src/evals/quickstarts/nextjs/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/nextjs/PROMPT.md
@@ -3,6 +3,7 @@ id: nextjs_quickstart
 name: Next.js App Router Quickstart
 skills: auth0-nextjs
 setup_command: npm install
+compile_command: npm run build
 ---
 
 ## Task

--- a/apps/auth0-evals/src/evals/quickstarts/nuxt/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/nuxt/PROMPT.md
@@ -3,6 +3,7 @@ id: nuxt_quickstart
 name: Nuxt Quickstart
 skills: auth0-nuxt
 setup_command: npm install
+compile_command: npm run build
 ---
 
 ## Task

--- a/apps/auth0-evals/src/evals/quickstarts/react/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/react/PROMPT.md
@@ -4,6 +4,7 @@ name: React Quickstart
 scaffold: src/evals/scaffolds/react/basic
 skills: auth0-react
 setup_command: npm install
+compile_command: npm run build
 ---
 
 ## Task

--- a/apps/auth0-evals/src/evals/quickstarts/spa-js/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/spa-js/PROMPT.md
@@ -3,6 +3,7 @@ id: spa_js_quickstart
 name: SPA JS Quickstart
 skills: auth0-spa-js
 setup_command: npm install
+compile_command: npm run build
 ---
 
 ## Task

--- a/apps/auth0-evals/src/evals/quickstarts/vue/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/vue/PROMPT.md
@@ -3,6 +3,7 @@ id: vue_quickstart
 name: Vue Quickstart
 skills: auth0-vue
 setup_command: npm install
+compile_command: npm run build
 ---
 
 ## Task

--- a/docs/ADDING_EVALS.md
+++ b/docs/ADDING_EVALS.md
@@ -31,6 +31,7 @@ id: my_new_eval
 name: My New Eval
 skills: auth0-react
 setup_command: npm install
+compile_command: npm run build
 ---
 ```
 
@@ -41,6 +42,7 @@ setup_command: npm install
 | `category` | no | Defaults to the parent directory name (e.g. `quickstarts`) |
 | `skills` | no | Comma-separated skill names from [auth0/agent-skills](https://github.com/auth0/agent-skills). Injected into agent context when running with `--tools skills` |
 | `setup_command` | no | Command run before the agent starts (e.g. `npm install`). Split on whitespace and executed directly via `spawnSync` — no shell, no operators (`&&`, `\|`, etc.), no quoting. One command only. |
+| `compile_command` | no | Compile/build command (e.g. `npm run build`, `node --check server.js`, `.venv/bin/python -m py_compile main.py`). When set, an instruction pointing the agent at this command is appended to the agent's native context file (`CLAUDE.md` / `GEMINI.md` / `AGENTS.md` / `.github/copilot-instructions.md`) alongside the "no docs files" guidance, so the agent verifies the project compiles and the command shows up in the tool trace. Agent modes only — baseline ignores it. Omit for evals with no CLI compile step (e.g. mobile). |
 
 To test a skill before it is pushed to the remote repo, see [TESTING_SKILLS.md](TESTING_SKILLS.md).
 
@@ -61,6 +63,7 @@ id: react_quickstart
 name: React Quickstart
 skills: auth0-react
 setup_command: npm install
+compile_command: npm run build
 ---
 
 ## Task

--- a/packages/eval-core/src/index.ts
+++ b/packages/eval-core/src/index.ts
@@ -82,6 +82,7 @@ export {
   writeAgentGuidance,
   AGENT_GUIDANCE,
   AGENT_CONTEXT_FILENAMES,
+  compileGuidance,
   collectFiles,
   readWorkspaceFile,
   isPathInside,

--- a/packages/eval-core/src/loader.ts
+++ b/packages/eval-core/src/loader.ts
@@ -63,6 +63,7 @@ export async function loadEval(
     .filter(Boolean);
 
   const setupCommand = meta.setup_command || undefined;
+  const compileCommand = meta.compile_command || undefined;
 
   return {
     id: evalConfig.id,
@@ -74,6 +75,7 @@ export async function loadEval(
     graders,
     scaffold,
     setupCommand,
+    compileCommand,
     skills,
     metadata: {
       provider_name: meta.provider_name ?? 'Auth0',

--- a/packages/eval-core/src/types/eval.ts
+++ b/packages/eval-core/src/types/eval.ts
@@ -19,6 +19,7 @@ export interface EvalDefinition {
   graders: GraderDef[];
   scaffold: Record<string, string>;
   setupCommand?: string;
+  compileCommand?: string;
   skills: string[];
   metadata: Record<string, string>;
 }

--- a/packages/eval-core/src/workspace/index.ts
+++ b/packages/eval-core/src/workspace/index.ts
@@ -5,6 +5,7 @@ export {
   writeAgentGuidance,
   AGENT_GUIDANCE,
   AGENT_CONTEXT_FILENAMES,
+  compileGuidance,
 } from './workspace.js';
 export type { SetupWorkspaceOptions, RunSetupCommandOptions } from './workspace.js';
 export { collectFiles, readWorkspaceFile } from './file-utils.js';

--- a/packages/eval-core/src/workspace/workspace.ts
+++ b/packages/eval-core/src/workspace/workspace.ts
@@ -33,6 +33,15 @@ export const AGENT_GUIDANCE = `Do not create any documentation files (README.md,
 `;
 
 /**
+ * Builds the compile-verification guidance appended to the agent's context file
+ * when the eval declares a `compileCommand`. Pointing the agent at the command
+ * means it appears in the tool trace and the agent can fix any failures.
+ */
+export function compileGuidance(compileCommand: string): string {
+  return `To verify your integration compiles, you can use this command:\n\n\`${compileCommand}\`\n`;
+}
+
+/**
  * The context/memory file each runner reads, relative to the workspace root.
  * Writing guidance to the wrong file means the agent silently ignores it:
  *   - Claude Code reads CLAUDE.md.
@@ -51,11 +60,14 @@ export const AGENT_CONTEXT_FILENAMES: Record<AgentType, string> = {
 /**
  * Writes {@link AGENT_GUIDANCE} into the context file the given runner reads.
  * Appends (preserving any scaffold-provided content) when the file already
- * exists; creates it otherwise.
+ * exists; creates it otherwise. When `compileCommand` is provided, the
+ * compile-verification guidance (see {@link compileGuidance}) is appended too.
  */
-export function writeAgentGuidance(workspace: string, agentType: AgentType): void {
+export function writeAgentGuidance(workspace: string, agentType: AgentType, compileCommand?: string): void {
   const filename = AGENT_CONTEXT_FILENAMES[agentType];
   const dest = join(workspace, filename);
+
+  const guidance = compileCommand ? `${AGENT_GUIDANCE}\n${compileGuidance(compileCommand)}` : AGENT_GUIDANCE;
 
   // If the scaffold shipped AGENTS.md but the active runner reads a different
   // file, rename it so the guidance reaches the right runner.
@@ -66,10 +78,10 @@ export function writeAgentGuidance(workspace: string, agentType: AgentType): voi
   }
 
   if (existsSync(dest)) {
-    appendFileSync(dest, `\n${AGENT_GUIDANCE}`, 'utf-8');
+    appendFileSync(dest, `\n${guidance}`, 'utf-8');
   } else {
     mkdirSync(join(dest, '..'), { recursive: true });
-    writeFileSync(dest, AGENT_GUIDANCE, 'utf-8');
+    writeFileSync(dest, guidance, 'utf-8');
   }
 }
 

--- a/packages/eval-core/src/workspace/workspace.ts
+++ b/packages/eval-core/src/workspace/workspace.ts
@@ -38,7 +38,7 @@ export const AGENT_GUIDANCE = `Do not create any documentation files (README.md,
  * means it appears in the tool trace and the agent can fix any failures.
  */
 export function compileGuidance(compileCommand: string): string {
-  return `To verify your integration compiles, you can use this command:\n\n\`${compileCommand}\`\n`;
+  return `After making your changes, you MUST run this command to verify your integration compiles, and fix any errors it reports before finishing:\n\n\`${compileCommand}\`\n`;
 }
 
 /**

--- a/packages/eval-core/tests/loader.test.ts
+++ b/packages/eval-core/tests/loader.test.ts
@@ -151,6 +151,26 @@ describe('loadEval - setupCommand', () => {
   });
 });
 
+// ── compile_command frontmatter tests ────────────────────────────────────────
+
+describe('loadEval - compileCommand', () => {
+  it('parses compile_command from frontmatter', async () => {
+    makeEvalDir(tmpBase, '---\nskills: auth0-react\ncompile_command: npm run build\n---\n\n## Task\nDo the task.\n');
+
+    const result = await loadEval(EVAL_CONFIG, tmpBase);
+
+    expect(result.compileCommand).toBe('npm run build');
+  });
+
+  it('returns undefined when compile_command is absent', async () => {
+    makeEvalDir(tmpBase, '---\nskills: auth0-react\n---\n\n## Task\nDo the task.\n');
+
+    const result = await loadEval(EVAL_CONFIG, tmpBase);
+
+    expect(result.compileCommand).toBeUndefined();
+  });
+});
+
 // ── System prompt tests ───────────────────────────────────────────────────────
 
 describe('loadEval - system prompt', () => {
@@ -239,9 +259,7 @@ describe('loadEval - scaffold loading', () => {
     expect(result.scaffold['readable.txt']).toBe('this is fine');
     expect(result.scaffold['unreadable.txt']).toBeUndefined();
   });
-
 });
-
 
 // ── frontmatter scaffold field tests ─────────────────────────────────────────
 

--- a/packages/eval-core/tests/workspace.test.ts
+++ b/packages/eval-core/tests/workspace.test.ts
@@ -172,6 +172,13 @@ describe('compileGuidance', () => {
     expect(result).toContain('npm run build');
     expect(result).toContain('verify your integration compiles');
   });
+
+  it('phrases the instruction as mandatory, not optional', () => {
+    const result = compileGuidance('npm run build');
+
+    expect(result).toContain('MUST');
+    expect(result).not.toContain('you can use');
+  });
 });
 
 describe('resolveInside - symlink escape protection', () => {

--- a/packages/eval-core/tests/workspace.test.ts
+++ b/packages/eval-core/tests/workspace.test.ts
@@ -8,6 +8,7 @@ import {
   writeAgentGuidance,
   AGENT_GUIDANCE,
   AGENT_CONTEXT_FILENAMES,
+  compileGuidance,
 } from '../src/workspace/workspace.js';
 import { resolveInside } from '../src/workspace/path-utils.js';
 
@@ -138,6 +139,38 @@ describe('writeAgentGuidance - runner-aware context file', () => {
     expect(content.endsWith(AGENT_GUIDANCE)).toBe(true);
 
     cleanupWorkspace(workspace);
+  });
+
+  it('appends compile guidance containing the command when compileCommand is provided', () => {
+    const workspace = setupWorkspace({ 'index.js': 'ok' });
+    writeAgentGuidance(workspace, 'claude-code', 'npm run build');
+
+    const content = readFileSync(join(workspace, 'CLAUDE.md'), 'utf-8');
+    expect(content).toContain(AGENT_GUIDANCE);
+    expect(content).toContain('npm run build');
+    expect(content).toContain('verify your integration compiles');
+
+    cleanupWorkspace(workspace);
+  });
+
+  it('omits compile guidance when compileCommand is not provided', () => {
+    const workspace = setupWorkspace({ 'index.js': 'ok' });
+    writeAgentGuidance(workspace, 'claude-code');
+
+    const content = readFileSync(join(workspace, 'CLAUDE.md'), 'utf-8');
+    expect(content).toBe(AGENT_GUIDANCE);
+    expect(content).not.toContain('verify your integration compiles');
+
+    cleanupWorkspace(workspace);
+  });
+});
+
+describe('compileGuidance', () => {
+  it('embeds the command and the verification instruction', () => {
+    const result = compileGuidance('npm run build');
+
+    expect(result).toContain('npm run build');
+    expect(result).toContain('verify your integration compiles');
   });
 });
 

--- a/packages/eval/src/cli/run.ts
+++ b/packages/eval/src/cli/run.ts
@@ -134,7 +134,7 @@ async function runAgentJob(
   // Inject "no docs files" guidance into the context file this runner reads
   // (CLAUDE.md / GEMINI.md / AGENTS.md). Must run before both the docker and
   // local execution paths so every runner picks it up.
-  writeAgentGuidance(workspace, agentType);
+  writeAgentGuidance(workspace, agentType, evalDef.compileCommand);
   try {
     if (!sandbox && evalDef.setupCommand) {
       runSetupCommand(workspace, evalDef.setupCommand);


### PR DESCRIPTION
## Summary

- Inject `compile_command` (from `PROMPT.md` frontmatter) into the agent's context file (`CLAUDE.md` / `GEMINI.md` / `AGENTS.md`) before each run, so the agent is guided to compile and verify its output
- Enable build-verification graders for all frontend quickstarts (react, vue, angular, spa-js, nextjs, nuxt)
- Make guidance text imperative so agents actually run the command rather than treating it as optional

## Test plan
- [x] `npm run build && npm test` passes
- [x] Verify `writeAgentGuidance` injects compile guidance when `compileCommand` is set