### PR TITLE
feat: add claude-fable-5 to model registry

### DIFF
--- a/apps/auth0-evals/eval.config.js
+++ b/apps/auth0-evals/eval.config.js
@@ -83,7 +83,7 @@ export default {
   },
 
   models: {
-    known: ['gpt-5.4', 'gpt-5.4-mini', 'claude-sonnet-4-6', 'claude-opus-4-6', 'claude-opus-4-7', 'claude-opus-4-8', 'claude-haiku-4-5', 'gemini-3.1-pro-preview', 'gemini-3.5-flash'],
+    known: ['gpt-5.4', 'gpt-5.4-mini', 'claude-sonnet-4-6', 'claude-opus-4-6', 'claude-opus-4-7', 'claude-opus-4-8', 'claude-fable-5', 'claude-haiku-4-5', 'gemini-3.1-pro-preview', 'gemini-3.5-flash'],
     default: 'gpt-5.4',
     // Maps short model aliases to the IDs the active proxy expects.
     // Bedrock proxy needs full `global.anthropic.*` IDs; LiteLLM proxy serves
@@ -94,6 +94,7 @@ export default {
           'claude-opus-4-6': 'global.anthropic.claude-opus-4-6-v1',
           'claude-opus-4-7': 'global.anthropic.claude-opus-4-7',
           'claude-opus-4-8': 'global.anthropic.claude-opus-4-8',
+          'claude-fable-5': 'global.anthropic.claude-fable-5',
           'claude-opus-4-5': 'global.anthropic.claude-opus-4-5-20251101-v1:0',
           'claude-haiku-4-5': 'global.anthropic.claude-haiku-4-5-20251001-v1:0',
         }

--- a/packages/eval-core/src/config/costs.ts
+++ b/packages/eval-core/src/config/costs.ts
@@ -7,6 +7,7 @@ export const COST_TABLE: Record<string, [number, number]> = {
   'claude-opus-4-6': [5.0, 25.0],
   'claude-opus-4-7': [5.0, 25.0],
   'claude-opus-4-8': [5.0, 25.0],
+  'claude-fable-5': [10.0, 50.0],
   'claude-haiku-4-5': [1.0, 5.0],
   'gemini-3.1-pro-preview': [2.0, 12.0],
   'gemini-3.5-flash': [1.5, 9.0],

--- a/packages/eval-core/src/config/settings.ts
+++ b/packages/eval-core/src/config/settings.ts
@@ -14,6 +14,7 @@ export const CLAUDE_EFFORT_MODELS = new Set([
   'claude-opus-4-7',
   'claude-opus-4-8',
   'claude-opus-4-5',
+  'claude-fable-5',
 ]);
 
 // Model name prefixes that use the older functions/function_call API

--- a/packages/eval/src/cli/constants.ts
+++ b/packages/eval/src/cli/constants.ts
@@ -16,6 +16,7 @@ export const KNOWN_WORKING_MODELS = [
   'claude-opus-4-6',
   'claude-opus-4-7',
   'claude-opus-4-8',
+  'claude-fable-5',
   'claude-haiku-4-5',
   'gemini-3.1-pro-preview',
   'gemini-3.5-flash',


### PR DESCRIPTION
## What

Registers `claude-fable-5` across all model registry locations.

**Files changed:**

- `packages/eval-core/src/config/costs.ts` — adds pricing `[10.0, 50.0]` ($10/M input, $50/M output)
- `packages/eval-core/src/config/settings.ts` — adds `claude-fable-5` to `CLAUDE_EFFORT_MODELS`
- `packages/eval/src/cli/constants.ts` — adds `claude-fable-5` to `KNOWN_WORKING_MODELS` (included in `--model all` runs)
- `apps/auth0-evals/eval.config.js` — adds `claude-fable-5` to `models.known` and maps the alias to `global.anthropic.claude-fable-5` in the Bedrock `modelIds` map

## Why

Adds `claude-fable-5` so it can be targeted with `--model claude-fable-5` and included in `--model all` runs across all eval configurations.

