### PR TITLE
fix: define useBedrock in eval config

### DIFF
--- a/apps/auth0-evals/eval.config.js
+++ b/apps/auth0-evals/eval.config.js
@@ -12,6 +12,10 @@ const CLAUDE_PROXY_BASE_URL = process.env.CLAUDE_PROXY_BASE_URL ?? PROXY_BASE_UR
 const GEMINI_PROXY_BASE_URL = process.env.GEMINI_PROXY_BASE_URL ?? PROXY_BASE_URL;
 const CODEX_PROXY_BASE_URL = process.env.CODEX_PROXY_BASE_URL ?? PROXY_BASE_URL;
 
+// When set, route Claude models through the Bedrock proxy, which needs full
+// `global.anthropic.*` model IDs instead of the short aliases.
+const useBedrock = process.env.CLAUDE_CODE_USE_BEDROCK_PROXY === '1';
+
 /** @type {import('@a0/eval').FrameworkConfig} */
 export default {
   evalsDir: 'src/evals',


### PR DESCRIPTION
## Summary
- `apps/auth0-evals/eval.config.js` referenced `useBedrock` in the `modelIds` map but never defined it, causing **every config load to crash** with `ReferenceError: useBedrock is not defined`.
- This blocks all eval runs (the CLI fails fast on config load).
- Fix: derive `useBedrock` from the `CLAUDE_CODE_USE_BEDROCK_PROXY` env var, matching the behaviour documented in `AGENTS.md`.

Introduced in `f639ed7` ("collapse bedrock and litellm model maps into one modelIds map"). Present on `main`.

## Test plan
- [x] `node -e "import('./apps/auth0-evals/eval.config.js')"` loads without error
- [x] Ran an eval end-to-end (`react_quickstart`, codex, gpt-5.4) — config loads and run completes (grade A)