### PR TITLE
chore: group @openai/codex and codex-sdk dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,10 @@ updates:
       include: scope
     labels:
       - "dependencies"
+    groups:
+      # Keep the Codex CLI and its SDK in lockstep — the SDK spawns the codex
+      # binary it pins, so bumping one without the other has no effect.
+      openai-codex:
+        patterns:
+          - "@openai/codex"
+          - "@openai/codex-sdk"


### PR DESCRIPTION
## Summary
- Adds a dependabot `groups` block so `@openai/codex` and `@openai/codex-sdk` always update together in a single PR.

## Why
The `@openai/codex-sdk` spawns the `codex` binary it pins (resolved from the SDK's own install location). Bumping `@openai/codex` alone — as a recent dependabot PR did — has **no runtime effect**: the SDK keeps running the binary version it pins. Keeping the two in lockstep ensures a codex upgrade actually takes effect.