### PR TITLE
fix(core): don't apply Bedrock model map to judge and recommendations

### DIFF
--- a/packages/eval-core/src/graders/engine.ts
+++ b/packages/eval-core/src/graders/engine.ts
@@ -10,7 +10,6 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { getFrameworkConfig } from '../config/framework-config.js';
-import { getModelIdMap } from '../config/settings.js';
 import { collectFiles as collectFilePaths } from '../workspace/index.js';
 import type { GraderDef, GraderResult, EventToolCall } from '@a0/eval-graders';
 import { GraderLevel } from '@a0/eval-graders';
@@ -122,7 +121,6 @@ export async function runGraders(
   const judgeMaxCodeChars = config.judge.maxCodeChars ?? 32_768;
   const judgeMaxTokens = config.judge.maxTokens ?? 1024;
   const judgeBaseUrl = config.proxy.baseUrl;
-  const judgeModelMap = getModelIdMap();
   const active = allowedLevels
     ? graderDefs.filter((g) => g.level === undefined || allowedLevels.has(g.level))
     : graderDefs;
@@ -143,7 +141,6 @@ export async function runGraders(
       baseUrl: judgeBaseUrl,
       maxTokens: judgeMaxTokens,
       maxCodeChars: judgeMaxCodeChars,
-      modelMap: judgeModelMap,
       enforceMaxChars,
     },
     toolCalls,

--- a/packages/eval-core/src/graders/executors/llm-judge.ts
+++ b/packages/eval-core/src/graders/executors/llm-judge.ts
@@ -48,7 +48,7 @@ export const llmJudgeExecutor: GraderExecutor = {
       };
     }
 
-    const { model, baseUrl, maxTokens, maxCodeChars, modelMap, enforceMaxChars } = ctx.judge;
+    const { model, baseUrl, maxTokens, maxCodeChars, enforceMaxChars } = ctx.judge;
 
     const judgeEntries = Object.entries(ctx.files).filter(([k]) => !isJudgeExcluded(k));
     const judgeText = judgeEntries.map(([k, v]) => `// FILE: ${k}\n${v}`).join('\n\n');
@@ -68,7 +68,6 @@ export const llmJudgeExecutor: GraderExecutor = {
       model,
       baseUrl,
       maxTokens,
-      modelMap,
       enforceMaxChars,
       maxCodeChars,
     });

--- a/packages/eval-core/src/graders/executors/types.ts
+++ b/packages/eval-core/src/graders/executors/types.ts
@@ -32,8 +32,6 @@ export interface GraderContext {
     baseUrl: string;
     /** Maximum tokens for judge response. */
     maxTokens: number;
-    /** LiteLLM model alias map resolved from FrameworkConfig. */
-    modelMap: Record<string, string>;
     /** Maximum code characters for judge input. */
     maxCodeChars: number;
     /** Whether to enforce the max chars limit (throws vs warns). */

--- a/packages/eval-core/src/graders/llm-judge.ts
+++ b/packages/eval-core/src/graders/llm-judge.ts
@@ -21,8 +21,6 @@ export interface LlmJudgeOptions {
   maxTokens?: number;
   enforceMaxChars?: boolean;
   maxCodeChars?: number;
-  /** LiteLLM model alias map. When provided, model is resolved via this map before the API call. */
-  modelMap?: Record<string, string>;
 }
 
 export interface LlmJudgeResult {
@@ -61,10 +59,11 @@ export async function llmJudge(opts: LlmJudgeOptions): Promise<LlmJudgeResult> {
     logger.warn(`[judge] Code corpus exceeds limit (${code.length} > ${judgeMaxCodeChars} chars) — proceeding anyway`);
   }
   const user = USER_TEMPLATE.replace('{question}', question).replace('{code}', code);
-  const apiModel = (opts.modelMap ?? {})[model] ?? model;
 
+  // The judge hits the /chat/completions endpoint, which serves models under
+  // their plain alias, so the model is sent as-is (no Bedrock ID mapping).
   const payload = JSON.stringify({
-    model: apiModel,
+    model,
     messages: [
       { role: 'system', content: system },
       { role: 'user', content: user },

--- a/packages/eval-core/tests/graders/engine.test.ts
+++ b/packages/eval-core/tests/graders/engine.test.ts
@@ -465,6 +465,28 @@ describe('llmJudge', () => {
     expect(capturedBody?.max_tokens).toBe(512);
   });
 
+  it('sends the model as-is (no Bedrock ID mapping on the chat endpoint)', async () => {
+    // Regression: the judge hits the /chat/completions endpoint, which serves
+    // models under their plain alias. Mapping the alias to a Bedrock ID here
+    // produced model="global.anthropic.*" → 400.
+    let capturedBody: Record<string, unknown> | undefined;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (_url: string, opts: RequestInit) => {
+        capturedBody = JSON.parse(opts.body as string) as Record<string, unknown>;
+        return { ok: true, json: async () => ({ choices: [{ message: { content: 'yes' } }] }) };
+      }),
+    );
+    await llmJudge({
+      question: 'question',
+      code: 'code',
+      apiKey: 'key',
+      model: 'claude-opus-4-8',
+      baseUrl: 'http://test',
+    });
+    expect(capturedBody?.model).toBe('claude-opus-4-8');
+  });
+
   it('throws JudgeError when baseUrl is empty', async () => {
     await expect(
       llmJudge({ question: 'question', code: 'code', apiKey: 'key', model: 'model', baseUrl: '' }),

--- a/packages/eval/src/recommendations/generator.ts
+++ b/packages/eval/src/recommendations/generator.ts
@@ -5,7 +5,7 @@
 
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { collectFiles, logger, getModelIdMap } from '@a0/eval-core';
+import { collectFiles, logger } from '@a0/eval-core';
 import type { RunRecord, ScoredResult, Recommendations, Recommendation } from '@a0/eval-core';
 
 /** Maximum characters of workspace code to include in the prompt. */
@@ -165,11 +165,12 @@ Analyze this run and provide your recommendations as JSON.`;
 // ── LLM call ──────────────────────────────────────────────────────────────────
 
 async function callLlm(system: string, user: string, apiKey: string, baseUrl: string, model: string): Promise<string> {
-  const modelMap = getModelIdMap();
-  const apiModel = modelMap[model] ?? model;
+  // The modelIds map holds Bedrock IDs for the agent runner's /anthropic
+  // endpoint. This call hits the /chat/completions endpoint, which serves
+  // models under their plain alias — so the alias is sent as-is.
   const url = `${baseUrl}/chat/completions`;
   const body = {
-    model: apiModel,
+    model,
     messages: [
       { role: 'system', content: system },
       { role: 'user', content: user },

--- a/packages/eval/tests/recommendations.test.ts
+++ b/packages/eval/tests/recommendations.test.ts
@@ -329,24 +329,43 @@ describe('generateRecommendations', () => {
     expect(result).toBeUndefined();
   });
 
-  it('resolves model through LiteLLM model map when present', async () => {
-    const { generateRecommendations } = await import('../src/recommendations/generator.js');
-    const dir = tmpDir();
-
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        choices: [{ message: { content: JSON.stringify({ recommendations: [], summary: '' }) } }],
-      }),
+  it('sends the model alias as-is, ignoring the Bedrock modelIds map', async () => {
+    // The modelIds map holds Bedrock IDs for the agent runner's /anthropic
+    // endpoint. Recommendations hit the /chat/completions endpoint, which serves
+    // models under their plain alias — so even when a Bedrock map is configured,
+    // the alias must be sent unchanged (regression: applying the map here
+    // produced model="global.anthropic.claude-opus-4-8" → 400).
+    const { setFrameworkConfig } = await import('@a0/eval-core');
+    const { TEST_CONFIG } = await import('./test-config.js');
+    setFrameworkConfig({
+      ...TEST_CONFIG,
+      models: {
+        ...TEST_CONFIG.models,
+        modelIds: { 'claude-sonnet-4-6': 'global.anthropic.claude-sonnet-4-6' },
+      },
     });
-    globalThis.fetch = fetchMock;
 
-    const input = makeInput(dir);
-    input.judgeModel = 'claude-sonnet-4-6';
-    await generateRecommendations(input);
+    try {
+      const { generateRecommendations } = await import('../src/recommendations/generator.js');
+      const dir = tmpDir();
 
-    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
-    expect(body.model).toBe('claude-sonnet-4-6'); // empty modelIds map → alias passes through
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          choices: [{ message: { content: JSON.stringify({ recommendations: [], summary: '' }) } }],
+        }),
+      });
+      globalThis.fetch = fetchMock;
+
+      const input = makeInput(dir);
+      input.judgeModel = 'claude-sonnet-4-6';
+      await generateRecommendations(input);
+
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(body.model).toBe('claude-sonnet-4-6');
+    } finally {
+      setFrameworkConfig(TEST_CONFIG);
+    }
   });
 
   it('truncates workspace files at MAX_WORKSPACE_CHARS', async () => {


### PR DESCRIPTION
## Summary

The `modelIds` map holds Bedrock IDs (`global.anthropic.*`) that are needed **only** by the Claude Code agent runner, which routes through the proxy's `/anthropic` pass-through endpoint. The **LLM judge** and the **recommendation generator** both POST to the configured proxy, which serves models under their plain alias.

Applying the map on those two paths rewrote e.g. `claude-opus-4-8` → `global.anthropic.claude-opus-4-8`, which the proxy rejects.

This only surfaces with `CLAUDE_CODE_USE_BEDROCK_PROXY=1` (the map is empty otherwise).

## Changes

- `llm-judge.ts` / `engine.ts` — send the judge model alias as-is; drop the now-unused `modelMap` plumbing (and the dangling field on `GraderContext.judge`).
- `recommendations/generator.ts` — send the model alias as-is; remove `getModelIdMap` usage.
- Regression tests in both packages that install a Bedrock-style map and assert the alias is sent **unchanged**.

The agent runner path is untouched — it still resolves Bedrock IDs for the `/anthropic` endpoint.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (incl. new regression tests in `engine.test.ts` and `recommendations.test.ts`)
- [x] `npm run lint` clean
- [x] Manually verified end-to-end: `react_quickstart` agent run with `CLAUDE_CODE_USE_BEDROCK_PROXY=1` no longer 400s on recommendations; recommendations generate (5 items) and the judge runs normally