### PR TITLE
fix(swift-eval): accept fluent webAuth().start() chain in L5 grader

### DIFF
--- a/apps/auth0-evals/src/evals/quickstarts/swift/graders.ts
+++ b/apps/auth0-evals/src/evals/quickstarts/swift/graders.ts
@@ -36,8 +36,11 @@ export function defineGraders() {
     ),
 
     // ── L5: Version-specific API correctness ──────────────────────────────────
+    // Allow chained builder calls (e.g. `.scope(...)`, `.useEphemeralSession()`)
+    // and newlines between webAuth() and .start() — the idiomatic fluent form
+    // `Auth0.webAuth().scope("...").start()` is correct async/await usage.
     matches(
-      String.raw`webAuth\(\)\.start\(\)`,
+      String.raw`webAuth\(\)(?:\s*\.\w+\([^)]*\))*\s*\.start\(\)`,
       'Uses async/await webAuth().start() syntax (not completion handlers)',
       GraderLevel.L5,
     ),


### PR DESCRIPTION
### Description

The L5 "uses async/await webAuth().start()" grader required webAuth() and .start() to be directly adjacent, so it failed on the idiomatic fluent form the agent skills sometimes

    try await Auth0.webAuth().scope("...").start()

Loosen the regex to allow chained builder calls (e.g. .scope(...), .useEphemeralSession()) and newlines between webAuth() and .start(), while still rejecting webAuth().clearSession() (no .start()). Verified against real generated agent output.


