### PR TITLE
Strengthen express-api graders: verify issuer/audience via .env event, not source substrings

### DIFF
--- a/apps/auth0-evals/src/evals/quickstarts/express-api/graders.ts
+++ b/apps/auth0-evals/src/evals/quickstarts/express-api/graders.ts
@@ -4,8 +4,6 @@ export function defineGraders() {
   return [
     // ── L1: Positive presence ──────────────────────────────────────────────────
     contains('express-oauth2-jwt-bearer', 'Uses express-oauth2-jwt-bearer SDK', GraderLevel.L1),
-    contains('issuerBaseURL', 'Configures issuerBaseURL', GraderLevel.L1),
-    contains('audience', 'Configures audience claim', GraderLevel.L1),
     contains('requiredScopes', 'Uses requiredScopes() for scope-based route protection', GraderLevel.L1),
     contains('req.auth', 'Accesses JWT data via req.auth', GraderLevel.L1),
 
@@ -64,16 +62,19 @@ export function defineGraders() {
     notContains('req.user', 'No req.user (express-oauth2-jwt-bearer uses req.auth, not req.user)', GraderLevel.L5),
     judge(
       'Does the solution use current express-oauth2-jwt-bearer patterns? ' +
-        'Specifically: does it configure auth() with issuerBaseURL and audience, ' +
+        'Specifically: does it apply the auth() middleware to protect routes, ' +
         'use requiredScopes() for scope checks (not manual payload inspection), ' +
-        'and access token data via req.auth.payload (not req.user or manually decoded tokens)?',
+        'and access token data via req.auth.payload (not req.user or manually decoded tokens)? ' +
+        'Judge only from the source code; the issuer and audience may be supplied via ' +
+        'environment variables (ISSUER_BASE_URL / AUDIENCE), so do not assume the contents of any .env file.',
       GraderLevel.L5,
     ),
 
     // ── Holistic judge ────────────────────────────────────────────────────────
     judge(
       'Does the solution correctly protect an Express.js API using express-oauth2-jwt-bearer? ' +
-        'It should configure auth() middleware with issuerBaseURL and audience, ' +
+        'It should apply the auth() middleware (issuer and audience may come from ISSUER_BASE_URL / AUDIENCE ' +
+        'environment variables — judge only from the source code and do not assume the contents of any .env file), ' +
         'protect GET /api/messages with read:messages scope, ' +
         'protect POST /api/messages with write:messages scope, ' +
         'and return user profile info from req.auth.payload at GET /api/profile.',


### PR DESCRIPTION
## Summary

Strengthens the `express-api` quickstart graders so they verify Auth0 issuer/audience configuration the right way — and stops the LLM judges from penalizing valid env-var-based solutions.

## Motivation

The L1 `contains('issuerBaseURL')` / `contains('audience')` checks were fragile. `express-oauth2-jwt-bearer`'s `auth()` auto-reads the `ISSUER_BASE_URL` / `AUDIENCE` environment variables, so a perfectly correct solution that configures via `.env` omits those literal strings from source — and false-fails the grader.

Separately, two judges asked whether the code "configures `auth()` with issuerBaseURL and audience." But `.env` files are excluded from the judge's input (`/^\.env(\..*)?$/` in `llm-judge.ts`), so the judge can't see those values and would penalize a correct env-var setup.

## Changes

- **Remove the two weak L1 substring checks** for `issuerBaseURL` / `audience`. These values are now verified deterministically by the existing L4 `wroteFile('.env', ['dev-barkbook.us.auth0.com', 'api.barkbook.com'])` grader — an event-based check that confirms the real config values were written, mirroring the `nextjs` eval.
- **Reword the L5 and holistic judges** to assess only source-visible behavior (that `auth()` middleware is applied and routes are scope-protected) and to explicitly allow issuer/audience to be supplied via `ISSUER_BASE_URL` / `AUDIENCE` env vars — following the `nextjs` L5 judge's "judge only from the source code; do not assume the contents of any .env file" convention.
- The L4 judge was left unchanged (it only references routes, scopes, and `req.auth.payload`, all source-visible).

## Result

The verification chain is now consistent and non-overlapping:
- issuer/audience **values** → L4 `wroteFile('.env', [...])` event
- secret-absence-in-source → L3 `notContainsInSource`
- judges → source-visible behavior only, no dependency on unreadable `.env` contents

## Testing

- `npm run build`, `npm run lint`, `npm run format` — all pass
- `npm test` — 687 passed
