### PR TITLE
fix(gemini-cli): normalize mcp_ tool names to the mcp__ convention

### DIFF
--- a/packages/eval/src/runners/gemini-cli/translator.ts
+++ b/packages/eval/src/runners/gemini-cli/translator.ts
@@ -32,7 +32,13 @@ export class GeminiCliTranslator extends BaseToolTranslator {
   }
 
   protected override mapMcpName(name: string): string {
-    return name;
+    // Gemini CLI (>=0.46) emits MCP tool names as `mcp_<server>_<tool>` with a
+    // single-underscore prefix; the framework convention used by the trace-based
+    // MCP graders (and every other runner) is the double-underscore `mcp__`
+    // prefix. Normalize the prefix so `calledTool`/`calledToolOneOf` match.
+    // Idempotent: names already on the `mcp__` convention are left untouched.
+    if (name.startsWith('mcp__')) return name;
+    return `mcp__${name.slice('mcp_'.length)}`;
   }
 
   override isDocLookup(name: string): boolean {

--- a/packages/eval/tests/runners/gemini-cli-agent.test.ts
+++ b/packages/eval/tests/runners/gemini-cli-agent.test.ts
@@ -218,6 +218,28 @@ describe('tool events', () => {
     expect(record.toolCalls[0].isDocLookup).toBe(true);
   });
 
+  it('normalizes Gemini single-underscore mcp_ names to the mcp__ convention', async () => {
+    // Gemini CLI >=0.46 emits `mcp_<server>_<tool>` (single underscore); the
+    // trace-based MCP graders require the `mcp__` double-underscore prefix.
+    mockSpawn.mockReturnValue(
+      makeChild([
+        {
+          type: 'tool_use',
+          tool_id: 't1',
+          tool_name: 'mcp_auth0-hosted-mcp_auth0_list_applications',
+          parameters: {},
+        },
+        { type: 'tool_result', tool_id: 't1', status: 'success', output: '{"applications":[]}' },
+        { type: 'message', role: 'assistant', content: 'Done.', delta: true },
+        resultEvent(),
+      ]),
+    );
+
+    const record = await runGeminiCliAgent(evalDef, workspace);
+    expect(record.toolCalls[0].name).toBe('mcp__auth0-hosted-mcp_auth0_list_applications');
+    expect(record.toolCalls[0].name.startsWith('mcp__')).toBe(true);
+  });
+
   it('web_fetch tool is classified as a doc lookup', async () => {
     mockSpawn.mockReturnValue(
       makeChild([

--- a/packages/eval/tests/tool-translator.test.ts
+++ b/packages/eval/tests/tool-translator.test.ts
@@ -166,6 +166,13 @@ describe('GeminiCliTranslator — mapping', () => {
     expect(translator.mapName('mcp__anything__tool')).toBe('mcp__anything__tool');
   });
 
+  it('normalizes single-underscore mcp_ names (Gemini >=0.46) to the mcp__ prefix', () => {
+    expect(translator.mapName('mcp_auth0-hosted-mcp_auth0_list_applications')).toBe(
+      'mcp__auth0-hosted-mcp_auth0_list_applications',
+    );
+    expect(translator.mapName('mcp_server_tool')).toBe('mcp__server_tool');
+  });
+
   it('passes through unknown tool names', () => {
     expect(translator.mapName('some_unknown_tool')).toBe('some_unknown_tool');
   });


### PR DESCRIPTION
## Summary

Gemini CLI ≥0.46 emits MCP tool names as `mcp_<server>_<tool>` (single-underscore prefix — see `generateValidName` in the bundle). Every other runner and the trace-based MCP graders use the double-underscore `mcp__` convention:

- **Claude Code** emits `mcp__server__tool` natively (Anthropic's MCP wire format).
- **Codex** synthesizes it from structured fields: `mcp__${item.server}__${item.tool}`.
- **Copilot** prefixes its `server-tool` form: `mcp__${key}`.
- **Gemini** — its translator's `mapMcpName` was identity, so single-underscore names passed through and never matched `calledTool` / `calledToolOneOf`.

Net effect: a Gemini MCP call that **succeeded** (returned real data) was scored 0% by the grader, because the recorded name was `mcp_...` not `mcp__...`. 

## Fix

Normalize the prefix in `GeminiCliTranslator.mapMcpName` (`mcp_` → `mcp__`), idempotent for names already on the `mcp__` convention. This mirrors what the Copilot translator already does.

## Test plan

- [x] New unit test in `tool-translator.test.ts` — `mapName('mcp_server_tool')` → `mcp__server_tool`
- [x] New runner test in `gemini-cli-agent.test.ts` — a `mcp_<server>_<tool>` `tool_use` event is recorded with a `mcp__` prefix
- [x] `npm run build` + full `vitest` suite pass (155 tests in `@a0/eval`)