### PR TITLE
feat(mcp): add protected HTTP MCP server support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -360,6 +360,8 @@ All agent runners have access to file/shell tools in their respective environmen
 
 When MCP tools are enabled (`--tools mcp`), MCP server tool definitions are appended to the tool list.
 
+Authenticated HTTP MCP servers are configured with an `auth` block (`tokenUrl`, `clientId`, `clientSecret`, `audience`). The framework mints a Management API token per agent job via a client-credentials exchange and forwards it to the MCP server. All four runners support this: claude-code, copilot, and gemini-cli forward it as an `Authorization: Bearer` header in their server config; codex passes it via a `bearer_token_env_var` reference in `config.toml` (Codex rejects an inline token, so the secret stays out of the file). A failed token mint skips the server with a warning rather than registering it unauthenticated. Full setup guide: [docs/PROTECTED_MCP.md](docs/PROTECTED_MCP.md).
+
 ---
 
 ## Models

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -360,7 +360,7 @@ All agent runners have access to file/shell tools in their respective environmen
 
 When MCP tools are enabled (`--tools mcp`), MCP server tool definitions are appended to the tool list.
 
-Authenticated HTTP MCP servers are configured with an `auth` block (`tokenUrl`, `clientId`, `clientSecret`, `audience`). The framework mints a Management API token per agent job via a client-credentials exchange and forwards it to the MCP server. All four runners support this: claude-code, copilot, and gemini-cli forward it as an `Authorization: Bearer` header in their server config; codex passes it via a `bearer_token_env_var` reference in `config.toml` (Codex rejects an inline token, so the secret stays out of the file). A failed token mint skips the server with a warning rather than registering it unauthenticated. Full setup guide: [docs/PROTECTED_MCP.md](docs/PROTECTED_MCP.md).
+Authenticated HTTP MCP servers are configured with an `auth` block (`tokenUrl`, `clientId`, `clientSecret`, `audience`). The framework mints a Management API token per agent job via a client-credentials exchange and forwards it to the MCP server. All four runners support this: claude-code and copilot forward it as an `Authorization: Bearer` header in their in-memory server config; codex and gemini-cli keep the token off disk by referencing an `MCP_BEARER_<SERVER>` env var — codex via `bearer_token_env_var` in `config.toml`, gemini-cli via a `Bearer ${MCP_BEARER_<SERVER>}` header in `settings.json` that the CLI expands from the process env at load time. A failed token mint skips the server with a warning rather than registering it unauthenticated. Full setup guide: [docs/PROTECTED_MCP.md](docs/PROTECTED_MCP.md).
 
 ---
 

--- a/apps/auth0-evals/eval.config.js
+++ b/apps/auth0-evals/eval.config.js
@@ -48,6 +48,22 @@ export default {
         type: 'http',
         url: 'https://auth0.com/docs/mcp',
       },
+      ...(process.env.MCP_TENANT_DOMAIN &&
+      process.env.MCP_CLIENT_ID &&
+      process.env.MCP_CLIENT_SECRET
+        ? {
+            'auth0-hosted-mcp': {
+              type: 'http',
+              url: `https://${process.env.MCP_TENANT_DOMAIN}/v1/mcp`,
+              auth: {
+                tokenUrl: `https://${process.env.MCP_TENANT_DOMAIN}/oauth/token`,
+                clientId: process.env.MCP_CLIENT_ID,
+                clientSecret: process.env.MCP_CLIENT_SECRET,
+                audience: `https://${process.env.MCP_TENANT_DOMAIN}/api/v2/`,
+              },
+            },
+          }
+        : {}),
     },
   },
 
@@ -84,6 +100,13 @@ export default {
     ],
   },
 
+
+  sandbox: {
+    // Host env vars forwarded into the Docker sandbox (names only; values resolved
+    // from process.env at launch). Needed so the authenticated auth0-hosted-mcp
+    // server can mint its token inside the container.
+    passthroughEnv: ['MCP_TENANT_DOMAIN', 'MCP_CLIENT_ID', 'MCP_CLIENT_SECRET'],
+  },
 
   braintrust: {
     projectId: '38395851-dd41-46ec-a971-a30402db6921',

--- a/docs/PROTECTED_MCP.md
+++ b/docs/PROTECTED_MCP.md
@@ -91,7 +91,9 @@ You don't write any token code — the framework does it per job:
 
 The token is minted **per job**, not at config-load time, so a long `--model all --mode all` matrix never reuses an expired token.
 
-**Loud failure:** if the token mint fails (bad creds, network error, missing field), the server is **skipped with a `logger.warn`** rather than registered unauthenticated. This makes a misconfigured run look like "MCP wasn't available" — not a silent "the agent chose not to use MCP."
+**Loud failure:** if the token mint fails (bad creds, network error, missing field), the server is **skipped with a `logger.warn`** rather than registered unauthenticated. This makes a misconfigured run look like "MCP wasn't available" — not a silent "the agent chose not to use MCP." When `--tools mcp` is requested but **every** server ends up unavailable, each runner also logs a `--tools mcp requested but no MCP servers are available` warning, so an all-fail run doesn't read identically to "MCP was never requested."
+
+**Fail fast:** the token request carries a 10s `AbortSignal.timeout`, so a token endpoint that accepts the connection but never responds can't hang job startup until the 30-min task timeout. The failure log includes the token endpoint URL (to distinguish a DNS/TLS/network failure from a misconfigured URL) and preserves the raw response body even for a `200` with a non-JSON payload (e.g. a proxy/gateway HTML error page).
 
 ### Where the token lives, per runner
 

--- a/docs/PROTECTED_MCP.md
+++ b/docs/PROTECTED_MCP.md
@@ -9,7 +9,7 @@ This guide covers how to wire up a **protected HTTP MCP server** — one that re
 - You want an agent to use an MCP server that requires an `Authorization: Bearer` token rather than being publicly reachable.
 - The credentials come from a Machine-to-Machine (client-credentials) application, and you want a fresh token minted per job rather than a long-lived secret baked into config.
 
-> **Runner support:** token forwarding is implemented for **all runners** — claude-code, copilot, gemini-cli, and codex. The first three forward the token as an `Authorization: Bearer` header in their MCP server config; codex passes it via a `bearer_token_env_var` reference in `config.toml` (Codex rejects an inline token, so the secret never lands in the file).
+> **Runner support:** token forwarding is implemented for **all runners** — claude-code, copilot, gemini-cli, and codex. claude-code and copilot forward the token as an `Authorization: Bearer` header in their in-memory MCP server config. codex and gemini-cli keep the token off disk by referencing an env var: codex via a `bearer_token_env_var` key in `config.toml`, gemini-cli via a `Bearer ${MCP_BEARER_*}` header in `settings.json` that the CLI expands from the process env at load time. Either way the raw token is injected into the runner's process env, never written to a file.
 
 ---
 
@@ -70,12 +70,12 @@ mcp: {
 
 To wire up **a different** protected HTTP MCP server, add another entry with an `auth` block. The `auth` field is typed as `MCPOAuthConfig`:
 
-| Field | Meaning |
-|---|---|
-| `tokenUrl` | OAuth token endpoint, e.g. `https://TENANT/oauth/token` |
-| `clientId` | Client ID for the client-credentials grant |
-| `clientSecret` | Client secret for the client-credentials grant |
-| `audience` | API audience the token is minted for, e.g. `https://TENANT/api/v2/` |
+| Field          | Meaning                                                             |
+| -------------- | ------------------------------------------------------------------- |
+| `tokenUrl`     | OAuth token endpoint, e.g. `https://TENANT/oauth/token`             |
+| `clientId`     | Client ID for the client-credentials grant                          |
+| `clientSecret` | Client secret for the client-credentials grant                      |
+| `audience`     | API audience the token is minted for, e.g. `https://TENANT/api/v2/` |
 
 Servers **without** an `auth` block (like `auth0-docs`) continue to work unauthenticated.
 
@@ -87,11 +87,24 @@ You don't write any token code — the framework does it per job:
 
 1. When a job starts with `--tools mcp`, the active runner walks the configured MCP servers.
 2. For each HTTP server with an `auth` block, it calls `mintMcpToken(auth)` — a **client-credentials** exchange (`grant_type=client_credentials`) against `tokenUrl` for the given `audience`.
-3. The resulting token is forwarded to the MCP server. claude-code, copilot, and gemini-cli set it as an `Authorization: Bearer <token>` header in the server config; codex writes a `bearer_token_env_var` reference into `config.toml` and injects the token into the Codex process env under that name (Codex rejects an inline `bearer_token`, so the secret stays out of the config file).
+3. The resulting token is forwarded to the MCP server. claude-code and copilot set it as an `Authorization: Bearer <token>` header in their in-memory server config. codex and gemini-cli inject the token into the runner's process env under an `MCP_BEARER_<SERVER>` name and reference it indirectly so the secret stays out of on-disk config: codex writes a `bearer_token_env_var` reference into `config.toml` (Codex rejects an inline `bearer_token`), and gemini-cli writes an `Authorization: Bearer ${MCP_BEARER_<SERVER>}` header into `settings.json` that the CLI expands from the env at settings-load time.
 
 The token is minted **per job**, not at config-load time, so a long `--model all --mode all` matrix never reuses an expired token.
 
 **Loud failure:** if the token mint fails (bad creds, network error, missing field), the server is **skipped with a `logger.warn`** rather than registered unauthenticated. This makes a misconfigured run look like "MCP wasn't available" — not a silent "the agent chose not to use MCP."
+
+### Where the token lives, per runner
+
+The runners don't handle the minted token identically, and the difference is worth knowing:
+
+| Runner      | How the token is passed                                                                                                                  | On-disk exposure                                                                   |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| claude-code | In-memory to the Agent SDK server config                                                                                                 | None                                                                               |
+| copilot     | In-memory to the Copilot SDK server config                                                                                               | None                                                                               |
+| codex       | Env var referenced by `bearer_token_env_var` in `config.toml` (`$CODEX_HOME`, **outside** the workspace)                                 | Token value never written to a file                                                |
+| gemini-cli  | Env var referenced by `Bearer ${MCP_BEARER_<SERVER>}` in `<workspace>/.gemini/settings.json`, expanded from the process env at load time | Only the env-var reference is on disk — the token value is never written to a file |
+
+The Gemini CLI only discovers MCP config from a settings file, but it expands environment variables in every settings string at load time (`$VAR`, `${VAR}`, `${VAR:-default}` — its `resolveEnvVarsInObject`/`resolveEnvVarsInString`), headers included. So the runner writes a `Bearer ${MCP_BEARER_<SERVER>}` reference into `settings.json` and injects the minted token into the subprocess env under that name, keeping the raw token off disk — the same indirection codex uses. As a defence-in-depth note, `.gemini` is also excluded from the grading corpus and the workspace is ephemeral (deleted at the end of every run via `cleanupWorkspace` unless `--keep-workspace` is passed).
 
 ---
 
@@ -111,12 +124,12 @@ Only the **names** are listed here; values are resolved from `process.env` at jo
 
 ## Troubleshooting
 
-| Symptom | Likely cause |
-|---|---|
-| Log: `MCP server 'auth0-hosted-mcp' skipped — token mint failed or creds missing` | One of `MCP_TENANT_DOMAIN` / `MCP_CLIENT_ID` / `MCP_CLIENT_SECRET` is unset, or the token endpoint rejected the credentials. |
-| `auth0-hosted-mcp` not registered at all (only `auth0-docs`) | The env-var gate in `eval.config.js` evaluated false — at least one of the three vars is empty. |
-| Token mint returns `access_denied` | `audience` points at `/v1/mcp` instead of `/api/v2/`, or the M2M app isn't authorized for the Management API. |
-| `401` late in a very long job | The minted token's TTL expired mid-job. Management API tokens are typically long-lived (hours) vs. the 30-min job timeout, so this is rare. |
+| Symptom                                                                           | Likely cause                                                                                                                                |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Log: `MCP server 'auth0-hosted-mcp' skipped — token mint failed or creds missing` | One of `MCP_TENANT_DOMAIN` / `MCP_CLIENT_ID` / `MCP_CLIENT_SECRET` is unset, or the token endpoint rejected the credentials.                |
+| `auth0-hosted-mcp` not registered at all (only `auth0-docs`)                      | The env-var gate in `eval.config.js` evaluated false — at least one of the three vars is empty.                                             |
+| Token mint returns `access_denied`                                                | `audience` points at `/v1/mcp` instead of `/api/v2/`, or the M2M app isn't authorized for the Management API.                               |
+| `401` late in a very long job                                                     | The minted token's TTL expired mid-job. Management API tokens are typically long-lived (hours) vs. the 30-min job timeout, so this is rare. |
 
 ---
 

--- a/docs/PROTECTED_MCP.md
+++ b/docs/PROTECTED_MCP.md
@@ -1,0 +1,126 @@
+# Protected MCP Servers
+
+This guide covers how to wire up a **protected HTTP MCP server** — one that requires an `Authorization: Bearer` token, such as the Auth0 hosted MCP server which authenticates with a Management API token. It explains the credentials you need, the config to add, and how the framework mints and forwards the token to every runner.
+
+---
+
+## When to use this
+
+- You want an agent to use an MCP server that requires an `Authorization: Bearer` token rather than being publicly reachable.
+- The credentials come from a Machine-to-Machine (client-credentials) application, and you want a fresh token minted per job rather than a long-lived secret baked into config.
+
+> **Runner support:** token forwarding is implemented for **all runners** — claude-code, copilot, gemini-cli, and codex. The first three forward the token as an `Authorization: Bearer` header in their MCP server config; codex passes it via a `bearer_token_env_var` reference in `config.toml` (Codex rejects an inline token, so the secret never lands in the file).
+
+---
+
+## Prerequisites
+
+You need an Auth0 tenant with a **Machine-to-Machine application** authorized for the **Management API**:
+
+1. In the Auth0 Dashboard, create (or reuse) an M2M application.
+2. Authorize it for the **Auth0 Management API** (`https://YOUR_TENANT/api/v2/`) with the scopes the task needs — e.g. `read:clients` to list applications.
+3. Note the application's **Client ID** and **Client Secret**.
+
+> **Audience matters.** The hosted MCP server authenticates with a **Management API** token (`/api/v2/` audience). The `/v1/mcp` audience is reserved by Auth0 and returns `access_denied` for client credentials — so the `audience` field below points at `/api/v2/`, not at the MCP URL.
+
+---
+
+## Step 1 — Set the environment variables
+
+The server entry in `eval.config.js` is gated on three env vars. If any is missing, the server is omitted (see [Troubleshooting](#troubleshooting)).
+
+```bash
+export MCP_TENANT_DOMAIN="your-tenant.us.auth0.com"   # no scheme, no trailing slash
+export MCP_CLIENT_ID="your-m2m-client-id"
+export MCP_CLIENT_SECRET="your-m2m-client-secret"
+```
+
+You can also set the LLM `--model` you intend to run; the proxy/model setup is unchanged from any other eval.
+
+---
+
+## Step 2 — Register the MCP server in `eval.config.js`
+
+The Auth0 hosted MCP server is already registered in `apps/auth0-evals/eval.config.js`, gated on the env vars above:
+
+```js
+mcp: {
+  servers: {
+    'auth0-docs': { type: 'http', url: 'https://auth0.com/docs/mcp' },
+
+    ...(process.env.MCP_TENANT_DOMAIN &&
+    process.env.MCP_CLIENT_ID &&
+    process.env.MCP_CLIENT_SECRET
+      ? {
+          'auth0-hosted-mcp': {
+            type: 'http',
+            url: `https://${process.env.MCP_TENANT_DOMAIN}/v1/mcp`,
+            auth: {
+              tokenUrl: `https://${process.env.MCP_TENANT_DOMAIN}/oauth/token`,
+              clientId: process.env.MCP_CLIENT_ID,
+              clientSecret: process.env.MCP_CLIENT_SECRET,
+              audience: `https://${process.env.MCP_TENANT_DOMAIN}/api/v2/`,
+            },
+          },
+        }
+      : {}),
+  },
+},
+```
+
+To wire up **a different** protected HTTP MCP server, add another entry with an `auth` block. The `auth` field is typed as `MCPOAuthConfig`:
+
+| Field | Meaning |
+|---|---|
+| `tokenUrl` | OAuth token endpoint, e.g. `https://TENANT/oauth/token` |
+| `clientId` | Client ID for the client-credentials grant |
+| `clientSecret` | Client secret for the client-credentials grant |
+| `audience` | API audience the token is minted for, e.g. `https://TENANT/api/v2/` |
+
+Servers **without** an `auth` block (like `auth0-docs`) continue to work unauthenticated.
+
+---
+
+## Step 3 — How the token is minted and forwarded
+
+You don't write any token code — the framework does it per job:
+
+1. When a job starts with `--tools mcp`, the active runner walks the configured MCP servers.
+2. For each HTTP server with an `auth` block, it calls `mintMcpToken(auth)` — a **client-credentials** exchange (`grant_type=client_credentials`) against `tokenUrl` for the given `audience`.
+3. The resulting token is forwarded to the MCP server. claude-code, copilot, and gemini-cli set it as an `Authorization: Bearer <token>` header in the server config; codex writes a `bearer_token_env_var` reference into `config.toml` and injects the token into the Codex process env under that name (Codex rejects an inline `bearer_token`, so the secret stays out of the config file).
+
+The token is minted **per job**, not at config-load time, so a long `--model all --mode all` matrix never reuses an expired token.
+
+**Loud failure:** if the token mint fails (bad creds, network error, missing field), the server is **skipped with a `logger.warn`** rather than registered unauthenticated. This makes a misconfigured run look like "MCP wasn't available" — not a silent "the agent chose not to use MCP."
+
+---
+
+## Sandbox credential passthrough
+
+When evals run in the Docker sandbox (the default), the framework can only mint a token inside the container if the credentials reach it. The three `MCP_*` vars are forwarded via `sandbox.passthroughEnv` in `eval.config.js`:
+
+```js
+sandbox: {
+  passthroughEnv: ['MCP_TENANT_DOMAIN', 'MCP_CLIENT_ID', 'MCP_CLIENT_SECRET'],
+},
+```
+
+Only the **names** are listed here; values are resolved from `process.env` at job launch and never stored in config. Vars that aren't currently set on the host are skipped.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| Log: `MCP server 'auth0-hosted-mcp' skipped — token mint failed or creds missing` | One of `MCP_TENANT_DOMAIN` / `MCP_CLIENT_ID` / `MCP_CLIENT_SECRET` is unset, or the token endpoint rejected the credentials. |
+| `auth0-hosted-mcp` not registered at all (only `auth0-docs`) | The env-var gate in `eval.config.js` evaluated false — at least one of the three vars is empty. |
+| Token mint returns `access_denied` | `audience` points at `/v1/mcp` instead of `/api/v2/`, or the M2M app isn't authorized for the Management API. |
+| `401` late in a very long job | The minted token's TTL expired mid-job. Management API tokens are typically long-lived (hours) vs. the 30-min job timeout, so this is rare. |
+
+---
+
+## Related docs
+
+- [docs/ADDING_EVALS.md](ADDING_EVALS.md) — grader primitives and how evals are structured.
+- [AGENTS.md](../AGENTS.md) — framework overview, runner details, and the MCP auth summary.

--- a/packages/eval-core/src/config/defaults.ts
+++ b/packages/eval-core/src/config/defaults.ts
@@ -51,4 +51,6 @@ export const DEFAULT_FRAMEWORK_CONFIG: Required<FrameworkConfig> = {
   },
 
   scoring: {},
+
+  sandbox: {},
 };

--- a/packages/eval-core/src/config/framework.ts
+++ b/packages/eval-core/src/config/framework.ts
@@ -37,11 +37,28 @@ export interface MCPStdioServerConfig {
   env?: Record<string, string>;
 }
 
+export interface MCPOAuthConfig {
+  /** OAuth token endpoint, e.g. https://TENANT/oauth/token */
+  tokenUrl: string;
+  /** OAuth client ID for the client-credentials grant. */
+  clientId: string;
+  /** OAuth client secret for the client-credentials grant. */
+  clientSecret: string;
+  /** API audience the token is requested for, e.g. https://TENANT/api/v2/ */
+  audience: string;
+}
+
 export interface MCPHttpServerConfig {
   /** URL-based MCP server. */
   type: 'http';
   /** HTTP URL for the remote MCP server. */
   url: string;
+  /**
+   * Optional OAuth config. When present, the framework mints a fresh Bearer
+   * token per agent job and injects it as an Authorization header. If any
+   * field is empty (e.g. a missing env var), the server is omitted with a warning.
+   */
+  auth?: MCPOAuthConfig;
 }
 
 /** Discriminated union — either a stdio (command-based) or http (URL-based) MCP server. */
@@ -121,6 +138,16 @@ export interface ScoringConfig {
 
 // ── Root config ──────────────────────────────────────────────────────────────
 
+export interface SandboxConfig {
+  /**
+   * Names of host environment variables to forward into the Docker sandbox.
+   * Each name is resolved from `process.env` at job launch; only currently-set
+   * vars are forwarded. Use for app-specific secrets the framework can't know
+   * about (e.g. MCP server credentials). Names only — values are never stored here.
+   */
+  passthroughEnv?: string[];
+}
+
 export interface FrameworkConfig {
   /** Directory containing evaluation definitions (required). */
   evalsDir: string;
@@ -142,4 +169,6 @@ export interface FrameworkConfig {
   braintrust?: BraintrustConfig;
   /** Scoring behaviour overrides (e.g. custom doc URL allowlist). */
   scoring?: ScoringConfig;
+  /** Docker sandbox settings (e.g. env vars to forward into the container). */
+  sandbox?: SandboxConfig;
 }

--- a/packages/eval-core/src/config/mcp-auth.ts
+++ b/packages/eval-core/src/config/mcp-auth.ts
@@ -8,6 +8,9 @@
 import type { MCPOAuthConfig } from './framework.js';
 import { logger } from '../utils/logger.js';
 
+/** Fail-fast budget for the token endpoint — a hung endpoint must not block job startup. */
+const TOKEN_REQUEST_TIMEOUT_MS = 10_000;
+
 /**
  * Derives the environment-variable name a runner uses to pass a minted Bearer
  * token to an MCP server, keeping the secret out of on-disk config files.
@@ -42,23 +45,39 @@ export async function mintMcpToken(auth: MCPOAuthConfig): Promise<string | undef
         client_secret: auth.clientSecret,
         audience: auth.audience,
       }),
+      // Fail fast: a token endpoint that accepts the connection but never
+      // responds would otherwise block job startup until the 30-min task
+      // timeout. AbortSignal.timeout rejects the fetch after 10s instead.
+      signal: AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
     });
+    // Read the raw body once so it's preserved for diagnosis whether the
+    // status is an error OR a 200 with a non-JSON payload (e.g. a proxy/gateway
+    // HTML error page) — res.json() would consume it and leave nothing to log.
+    const body = await res.text().catch(() => '');
     if (!res.ok) {
-      // Include the response body — for the documented access_denied case it
-      // carries the error/error_description, making misconfig far easier to
-      // diagnose.
-      const body = await res.text().catch(() => '');
+      // For the documented access_denied case the body carries the
+      // error/error_description, making misconfig far easier to diagnose.
       logger.warn(`[mcp-auth] Token request failed: ${res.status}${body ? ` — ${body}` : ''}`);
       return undefined;
     }
-    const { access_token } = (await res.json()) as { access_token?: string };
+    let access_token: string | undefined;
+    try {
+      ({ access_token } = JSON.parse(body) as { access_token?: string });
+    } catch {
+      logger.warn(`[mcp-auth] Token response was not valid JSON${body ? ` — ${body}` : ''}`);
+      return undefined;
+    }
     if (!access_token) {
       logger.warn('[mcp-auth] Token response missing access_token');
       return undefined;
     }
     return access_token;
   } catch (err) {
-    logger.warn(`[mcp-auth] Token request error: ${err instanceof Error ? err.message : String(err)}`);
+    // Include the token endpoint so a DNS/TLS/network failure is
+    // distinguishable from a misconfigured URL.
+    logger.warn(
+      `[mcp-auth] Token request error for ${auth.tokenUrl}: ${err instanceof Error ? err.message : String(err)}`,
+    );
     return undefined;
   }
 }

--- a/packages/eval-core/src/config/mcp-auth.ts
+++ b/packages/eval-core/src/config/mcp-auth.ts
@@ -8,16 +8,35 @@
 import type { MCPOAuthConfig } from './framework.js';
 import { logger } from '../utils/logger.js';
 
+/**
+ * Derives the environment-variable name a runner uses to pass a minted Bearer
+ * token to an MCP server, keeping the secret out of on-disk config files.
+ * Runners reference this name indirectly — Codex via `bearer_token_env_var` in
+ * config.toml, Gemini CLI via `$VAR` expansion in settings.json.
+ *
+ * Assumes server names are distinct after normalization: uppercasing and
+ * mapping non-alphanumerics to `_` means names like `auth0-hosted` and
+ * `auth0.hosted` would collide to the same env var. Config keys are authored by
+ * hand and never differ only by punctuation, so this holds.
+ */
+export function mcpBearerTokenEnvVar(serverName: string): string {
+  return `MCP_BEARER_${serverName.replace(/[^A-Za-z0-9]/g, '_').toUpperCase()}`;
+}
+
 export async function mintMcpToken(auth: MCPOAuthConfig): Promise<string | undefined> {
   if (!auth.tokenUrl || !auth.clientId || !auth.clientSecret || !auth.audience) {
     logger.warn('[mcp-auth] Incomplete OAuth config — skipping token mint');
     return undefined;
   }
   try {
+    // Form-encode the request: RFC 6749 §4.4.2 mandates
+    // application/x-www-form-urlencoded for the client-credentials grant, so
+    // this is the most broadly compatible format for an arbitrary protected
+    // MCP server's token endpoint. Auth0's /oauth/token accepts it too.
     const res = await fetch(auth.tokenUrl, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
         grant_type: 'client_credentials',
         client_id: auth.clientId,
         client_secret: auth.clientSecret,
@@ -25,7 +44,11 @@ export async function mintMcpToken(auth: MCPOAuthConfig): Promise<string | undef
       }),
     });
     if (!res.ok) {
-      logger.warn(`[mcp-auth] Token request failed: ${res.status}`);
+      // Include the response body — for the documented access_denied case it
+      // carries the error/error_description, making misconfig far easier to
+      // diagnose.
+      const body = await res.text().catch(() => '');
+      logger.warn(`[mcp-auth] Token request failed: ${res.status}${body ? ` — ${body}` : ''}`);
       return undefined;
     }
     const { access_token } = (await res.json()) as { access_token?: string };

--- a/packages/eval-core/src/config/mcp-auth.ts
+++ b/packages/eval-core/src/config/mcp-auth.ts
@@ -1,0 +1,41 @@
+/**
+ * OAuth token minting for authenticated HTTP MCP servers.
+ *
+ * Performs a client-credentials exchange to obtain a short-lived Bearer token.
+ * Called once per agent job so a long matrix run never reuses an expired token.
+ */
+
+import type { MCPOAuthConfig } from './framework.js';
+import { logger } from '../utils/logger.js';
+
+export async function mintMcpToken(auth: MCPOAuthConfig): Promise<string | undefined> {
+  if (!auth.tokenUrl || !auth.clientId || !auth.clientSecret || !auth.audience) {
+    logger.warn('[mcp-auth] Incomplete OAuth config — skipping token mint');
+    return undefined;
+  }
+  try {
+    const res = await fetch(auth.tokenUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'client_credentials',
+        client_id: auth.clientId,
+        client_secret: auth.clientSecret,
+        audience: auth.audience,
+      }),
+    });
+    if (!res.ok) {
+      logger.warn(`[mcp-auth] Token request failed: ${res.status}`);
+      return undefined;
+    }
+    const { access_token } = (await res.json()) as { access_token?: string };
+    if (!access_token) {
+      logger.warn('[mcp-auth] Token response missing access_token');
+      return undefined;
+    }
+    return access_token;
+  } catch (err) {
+    logger.warn(`[mcp-auth] Token request error: ${err instanceof Error ? err.message : String(err)}`);
+    return undefined;
+  }
+}

--- a/packages/eval-core/src/index.ts
+++ b/packages/eval-core/src/index.ts
@@ -62,6 +62,7 @@ export type {
   MCPServerConfig,
   MCPStdioServerConfig,
   MCPHttpServerConfig,
+  MCPOAuthConfig,
   SkillsConfig,
   RemoteSkillRepo,
   JudgeConfig,
@@ -69,10 +70,12 @@ export type {
   WorkspaceConfig,
   BraintrustConfig,
   ScoringConfig,
+  SandboxConfig,
 } from './config/framework.js';
 export { DEFAULT_FRAMEWORK_CONFIG } from './config/defaults.js';
 export { defineConfig, loadConfig, deepMerge } from './config/loader.js';
 export type { LoadConfigOptions } from './config/loader.js';
+export { mintMcpToken } from './config/mcp-auth.js';
 
 // Workspace
 export {

--- a/packages/eval-core/src/index.ts
+++ b/packages/eval-core/src/index.ts
@@ -75,7 +75,7 @@ export type {
 export { DEFAULT_FRAMEWORK_CONFIG } from './config/defaults.js';
 export { defineConfig, loadConfig, deepMerge } from './config/loader.js';
 export type { LoadConfigOptions } from './config/loader.js';
-export { mintMcpToken } from './config/mcp-auth.js';
+export { mintMcpToken, mcpBearerTokenEnvVar } from './config/mcp-auth.js';
 
 // Workspace
 export {

--- a/packages/eval-core/tests/config/mcp-auth.test.ts
+++ b/packages/eval-core/tests/config/mcp-auth.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { mintMcpToken } from '../../src/config/mcp-auth.js';
+import { mintMcpToken, mcpBearerTokenEnvVar } from '../../src/config/mcp-auth.js';
+import { logger } from '../../src/utils/logger.js';
 import type { MCPOAuthConfig } from '../../src/config/framework.js';
 
 const validAuth: MCPOAuthConfig = {
@@ -27,8 +28,13 @@ describe('mintMcpToken', () => {
     expect(fetchMock).toHaveBeenCalledOnce();
     const [url, init] = fetchMock.mock.calls[0]!;
     expect(url).toBe(validAuth.tokenUrl);
-    const body = JSON.parse((init as RequestInit).body as string);
-    expect(body).toMatchObject({
+    // Form-encoded per RFC 6749 §4.4.2, not JSON.
+    expect((init as RequestInit).headers).toMatchObject({
+      'content-type': 'application/x-www-form-urlencoded',
+    });
+    const body = (init as RequestInit).body as URLSearchParams;
+    expect(body).toBeInstanceOf(URLSearchParams);
+    expect(Object.fromEntries(body)).toMatchObject({
       grant_type: 'client_credentials',
       client_id: 'client-id',
       client_secret: 'client-secret',
@@ -37,8 +43,24 @@ describe('mintMcpToken', () => {
   });
 
   it('returns undefined when the response is not ok', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) }));
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 403, text: async () => '' }));
     expect(await mintMcpToken(validAuth)).toBeUndefined();
+  });
+
+  it('logs the response body on failure to aid diagnosis', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        text: async () => '{"error":"access_denied","error_description":"Service not enabled"}',
+      }),
+    );
+
+    expect(await mintMcpToken(validAuth)).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('access_denied'));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('403'));
   });
 
   it('returns undefined without calling fetch when a credential is missing', async () => {
@@ -52,5 +74,16 @@ describe('mintMcpToken', () => {
   it('returns undefined when the body has no access_token', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }));
     expect(await mintMcpToken(validAuth)).toBeUndefined();
+  });
+});
+
+describe('mcpBearerTokenEnvVar', () => {
+  it('uppercases and prefixes a simple server name', () => {
+    expect(mcpBearerTokenEnvVar('auth0docs')).toBe('MCP_BEARER_AUTH0DOCS');
+  });
+
+  it('maps non-alphanumerics to underscores', () => {
+    expect(mcpBearerTokenEnvVar('auth0-hosted-mcp')).toBe('MCP_BEARER_AUTH0_HOSTED_MCP');
+    expect(mcpBearerTokenEnvVar('auth0.hosted')).toBe('MCP_BEARER_AUTH0_HOSTED');
   });
 });

--- a/packages/eval-core/tests/config/mcp-auth.test.ts
+++ b/packages/eval-core/tests/config/mcp-auth.test.ts
@@ -18,7 +18,7 @@ describe('mintMcpToken', () => {
   it('returns the access_token on a successful exchange', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ access_token: 'tok-123' }),
+      text: async () => JSON.stringify({ access_token: 'tok-123' }),
     });
     vi.stubGlobal('fetch', fetchMock);
 
@@ -40,6 +40,8 @@ describe('mintMcpToken', () => {
       client_secret: 'client-secret',
       audience: validAuth.audience,
     });
+    // Fails fast on a hung endpoint rather than blocking job startup.
+    expect((init as RequestInit).signal).toBeInstanceOf(AbortSignal);
   });
 
   it('returns undefined when the response is not ok', async () => {
@@ -72,8 +74,29 @@ describe('mintMcpToken', () => {
   });
 
   it('returns undefined when the body has no access_token', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }));
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, text: async () => JSON.stringify({}) }));
     expect(await mintMcpToken(validAuth)).toBeUndefined();
+  });
+
+  it('returns undefined and preserves the body when a 200 response is not valid JSON', async () => {
+    // A proxy/gateway can return 200 with an HTML error page; JSON.parse throws
+    // but the raw body must still be logged for diagnosis.
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, text: async () => '<html>Bad Gateway</html>' }));
+
+    expect(await mintMcpToken(validAuth)).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('not valid JSON'));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Bad Gateway'));
+  });
+
+  it('returns undefined and logs the tokenUrl when fetch throws a network error', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')));
+
+    expect(await mintMcpToken(validAuth)).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('network error'));
+    // The endpoint is included so a DNS/TLS failure is distinguishable from misconfig.
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(validAuth.tokenUrl));
   });
 });
 
@@ -85,5 +108,10 @@ describe('mcpBearerTokenEnvVar', () => {
   it('maps non-alphanumerics to underscores', () => {
     expect(mcpBearerTokenEnvVar('auth0-hosted-mcp')).toBe('MCP_BEARER_AUTH0_HOSTED_MCP');
     expect(mcpBearerTokenEnvVar('auth0.hosted')).toBe('MCP_BEARER_AUTH0_HOSTED');
+  });
+
+  it('collides for names differing only by punctuation (runners guard against this)', () => {
+    // Documents the known collision the runner-level guard protects against.
+    expect(mcpBearerTokenEnvVar('auth0-hosted')).toBe(mcpBearerTokenEnvVar('auth0.hosted'));
   });
 });

--- a/packages/eval-core/tests/config/mcp-auth.test.ts
+++ b/packages/eval-core/tests/config/mcp-auth.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { mintMcpToken } from '../../src/config/mcp-auth.js';
+import type { MCPOAuthConfig } from '../../src/config/framework.js';
+
+const validAuth: MCPOAuthConfig = {
+  tokenUrl: 'https://tenant.us.auth0.com/oauth/token',
+  clientId: 'client-id',
+  clientSecret: 'client-secret',
+  audience: 'https://tenant.us.auth0.com/api/v2/',
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('mintMcpToken', () => {
+  it('returns the access_token on a successful exchange', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ access_token: 'tok-123' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const token = await mintMcpToken(validAuth);
+
+    expect(token).toBe('tok-123');
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe(validAuth.tokenUrl);
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body).toMatchObject({
+      grant_type: 'client_credentials',
+      client_id: 'client-id',
+      client_secret: 'client-secret',
+      audience: validAuth.audience,
+    });
+  });
+
+  it('returns undefined when the response is not ok', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) }));
+    expect(await mintMcpToken(validAuth)).toBeUndefined();
+  });
+
+  it('returns undefined without calling fetch when a credential is missing', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const token = await mintMcpToken({ ...validAuth, clientSecret: '' });
+    expect(token).toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when the body has no access_token', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }));
+    expect(await mintMcpToken(validAuth)).toBeUndefined();
+  });
+});

--- a/packages/eval/src/cli/run.ts
+++ b/packages/eval/src/cli/run.ts
@@ -154,6 +154,7 @@ async function runAgentJob(
         agentType,
         apiKey,
         ghToken: process.env.GH_TOKEN,
+        passthroughEnv: getFrameworkConfig().sandbox.passthroughEnv,
       });
     }
 

--- a/packages/eval/src/runners/claude-code/agent.ts
+++ b/packages/eval/src/runners/claude-code/agent.ts
@@ -161,6 +161,12 @@ export async function runClaudeCodeAgent(
       }
     }
     if (Object.keys(httpServers).length > 0) mcpServers = httpServers;
+    else {
+      // MCP was requested but no server became available (all mints failed or
+      // none configured). Log it so an all-fail run doesn't read identically to
+      // "MCP was never requested."
+      logger.warn(`[ClaudeCode] --tools mcp requested but no MCP servers are available`);
+    }
   }
 
   logger.info(`\n[ClaudeCode] Starting task: ${evalDef.id}`);

--- a/packages/eval/src/runners/claude-code/agent.ts
+++ b/packages/eval/src/runners/claude-code/agent.ts
@@ -30,6 +30,7 @@ import {
   logger,
   makeSessionId,
   filteredEnv,
+  mintMcpToken,
 } from '@a0/eval-core';
 import { classifyActionType, classifyErrorCategory, detectRetry } from '@a0/eval-core';
 import { LLM_API_KEY_ENV } from '../../cli/constants.js';
@@ -137,12 +138,25 @@ export async function runClaudeCodeAgent(
   }
 
   // Build MCP server config when --tools mcp is requested.
-  let mcpServers: Record<string, { type: 'http'; url: string }> | undefined;
+  // Token is minted here (job start) so a long matrix run never reuses an expired token.
+  let mcpServers: Record<string, { type: 'http'; url: string; headers?: Record<string, string> }> | undefined;
   if (tools.includes('mcp')) {
     const configServers = getFrameworkConfig().mcp.servers;
-    const httpServers: Record<string, { type: 'http'; url: string }> = {};
+    const httpServers: Record<string, { type: 'http'; url: string; headers?: Record<string, string> }> = {};
     for (const [name, server] of Object.entries(configServers)) {
-      if (server.type === 'http') {
+      if (server.type !== 'http') continue;
+      if (server.auth) {
+        const token = await mintMcpToken(server.auth);
+        if (!token) {
+          logger.warn(`[ClaudeCode] MCP server '${name}' skipped — token mint failed or creds missing`);
+          continue;
+        }
+        httpServers[name] = {
+          type: 'http' as const,
+          url: server.url,
+          headers: { Authorization: `Bearer ${token}` },
+        };
+      } else {
         httpServers[name] = { type: 'http' as const, url: server.url };
       }
     }
@@ -305,9 +319,7 @@ export function handleMessage(
 
     const usage = msg.usage;
     const turnInput =
-      (usage?.input_tokens ?? 0) +
-      (usage?.cache_read_input_tokens ?? 0) +
-      (usage?.cache_creation_input_tokens ?? 0);
+      (usage?.input_tokens ?? 0) + (usage?.cache_read_input_tokens ?? 0) + (usage?.cache_creation_input_tokens ?? 0);
     const turnOutput = usage?.output_tokens ?? 0;
     record.inputTokens += turnInput;
     record.outputTokens += turnOutput;

--- a/packages/eval/src/runners/codex/agent.ts
+++ b/packages/eval/src/runners/codex/agent.ts
@@ -38,6 +38,7 @@ import {
   readWorkspaceFile,
   makeSessionId,
   mintMcpToken,
+  mcpBearerTokenEnvVar,
 } from '@a0/eval-core';
 import { classifyActionType, classifyErrorCategory, detectRetry } from '@a0/eval-core';
 import { LLM_API_KEY_ENV } from '../../cli/constants.js';
@@ -487,7 +488,7 @@ export async function runCodexAgent(
         logger.warn(`[Codex] MCP server '${name}' skipped — token mint failed or creds missing`);
         continue;
       }
-      const envVar = `MCP_BEARER_${name.replace(/[^A-Za-z0-9]/g, '_').toUpperCase()}`;
+      const envVar = mcpBearerTokenEnvVar(name);
       bearerTokenEnvVars[name] = envVar;
       bearerTokens[envVar] = token;
     }

--- a/packages/eval/src/runners/codex/agent.ts
+++ b/packages/eval/src/runners/codex/agent.ts
@@ -37,6 +37,7 @@ import {
   filteredEnv,
   readWorkspaceFile,
   makeSessionId,
+  mintMcpToken,
 } from '@a0/eval-core';
 import { classifyActionType, classifyErrorCategory, detectRetry } from '@a0/eval-core';
 import { LLM_API_KEY_ENV } from '../../cli/constants.js';
@@ -57,12 +58,27 @@ function tomlEscape(s: string): string {
   return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 }
 
-function buildMcpToml(servers: Record<string, MCPServerConfig>): string {
+/**
+ * Builds the `[mcp_servers.*]` TOML blocks.
+ *
+ * For HTTP servers with an entry in `bearerTokenEnvVars`, emits
+ * `bearer_token_env_var = "<NAME>"` so Codex reads the Bearer token from that
+ * env var at runtime. Codex rejects an inline `bearer_token` key, so the token
+ * is never written to the config file — only the env-var name is.
+ */
+function buildMcpToml(
+  servers: Record<string, MCPServerConfig>,
+  bearerTokenEnvVars: Record<string, string> = {},
+): string {
   let toml = '';
   for (const [name, server] of Object.entries(servers)) {
     const safeName = tomlEscape(name);
     if (server.type === 'http') {
       toml += `\n[mcp_servers."${safeName}"]\nurl = "${tomlEscape(server.url)}"\n`;
+      const envVar = bearerTokenEnvVars[name];
+      if (envVar) {
+        toml += `bearer_token_env_var = "${tomlEscape(envVar)}"\n`;
+      }
     } else {
       toml += `\n[mcp_servers."${safeName}"]\ncommand = "${tomlEscape(server.command)}"\n`;
       if (server.args && server.args.length > 0) {
@@ -85,6 +101,7 @@ function writeCodexConfig(
   proxyBaseUrl: string,
   workspace: string,
   mcpServers: Record<string, MCPServerConfig> = {},
+  bearerTokenEnvVars: Record<string, string> = {},
 ): void {
   mkdirSync(codexHome, { recursive: true });
   // Resolve canonical path — on macOS /var is a symlink to /private/var.
@@ -102,7 +119,7 @@ wire_api = "responses"
 
 [projects."${resolvedWorkspace}"]
 trust_level = "trusted"
-${buildMcpToml(mcpServers)}`;
+${buildMcpToml(mcpServers, bearerTokenEnvVars)}`;
   writeFileSync(join(codexHome, 'config.toml'), configToml, 'utf-8');
 }
 
@@ -450,11 +467,36 @@ export async function runCodexAgent(
   mkdirSync(codexHome, { recursive: true });
 
   // Resolve MCP servers from framework config when --tools mcp is requested.
-  const mcpServers: Record<string, MCPServerConfig> = tools.includes('mcp') ? getFrameworkConfig().mcp.servers : {};
+  const configuredServers: Record<string, MCPServerConfig> = tools.includes('mcp')
+    ? getFrameworkConfig().mcp.servers
+    : {};
+
+  // Mint a Bearer token per HTTP server that declares an `auth` block. The token
+  // is passed to Codex via an env var (referenced by `bearer_token_env_var` in
+  // config.toml) — Codex rejects an inline `bearer_token`, so the secret never
+  // touches the config file. Minting per job avoids reusing an expired token on
+  // a long matrix run. A failed mint drops the server rather than registering it
+  // unauthenticated, so a misconfigured run looks like "MCP wasn't available".
+  const mcpServers: Record<string, MCPServerConfig> = {};
+  const bearerTokenEnvVars: Record<string, string> = {};
+  const bearerTokens: Record<string, string> = {};
+  for (const [name, server] of Object.entries(configuredServers)) {
+    if (server.type === 'http' && server.auth) {
+      const token = await mintMcpToken(server.auth);
+      if (!token) {
+        logger.warn(`[Codex] MCP server '${name}' skipped — token mint failed or creds missing`);
+        continue;
+      }
+      const envVar = `MCP_BEARER_${name.replace(/[^A-Za-z0-9]/g, '_').toUpperCase()}`;
+      bearerTokenEnvVars[name] = envVar;
+      bearerTokens[envVar] = token;
+    }
+    mcpServers[name] = server;
+  }
 
   const normalizedBaseUrl = proxyBaseUrl.replace(/\/+$/, '');
   const codexApiUrl = normalizedBaseUrl.endsWith('/v1') ? normalizedBaseUrl : `${normalizedBaseUrl}/v1`;
-  writeCodexConfig(codexHome, codexApiUrl, workspace, mcpServers);
+  writeCodexConfig(codexHome, codexApiUrl, workspace, mcpServers, bearerTokenEnvVars);
   logger.info(`[Codex] Proxy: ${proxyBaseUrl}`);
   logger.info(`[Codex] CODEX_HOME: ${codexHome}`);
   if (Object.keys(mcpServers).length > 0) {
@@ -477,6 +519,12 @@ export async function runCodexAgent(
         codexEnv[key] = value;
       }
     }
+  }
+
+  // Inject minted Bearer tokens so Codex can resolve each authed server's
+  // `bearer_token_env_var` reference at runtime.
+  for (const [key, value] of Object.entries(bearerTokens)) {
+    codexEnv[key] = value;
   }
 
   // Skills are injected into the workspace by CodexRunner.prepareSkills().

--- a/packages/eval/src/runners/codex/agent.ts
+++ b/packages/eval/src/runners/codex/agent.ts
@@ -489,6 +489,16 @@ export async function runCodexAgent(
         continue;
       }
       const envVar = mcpBearerTokenEnvVar(name);
+      // Guard against two server names normalizing to the same env var (e.g.
+      // `auth0-hosted` and `auth0.hosted`), which would silently clobber the
+      // first server's token. Hand-authored configs don't hit this today, but
+      // fail loudly rather than leave a confusing future debugging session.
+      if (bearerTokens[envVar] !== undefined) {
+        logger.warn(
+          `[Codex] MCP server '${name}' skipped — env var ${envVar} already used by another server (name collision)`,
+        );
+        continue;
+      }
       bearerTokenEnvVars[name] = envVar;
       bearerTokens[envVar] = token;
     }
@@ -502,6 +512,11 @@ export async function runCodexAgent(
   logger.info(`[Codex] CODEX_HOME: ${codexHome}`);
   if (Object.keys(mcpServers).length > 0) {
     logger.info(`[Codex] MCP servers: ${Object.keys(mcpServers).join(', ')}`);
+  } else if (tools.includes('mcp')) {
+    // MCP was requested but no server became available (all mints failed or
+    // none configured). Log it so an all-fail run doesn't read identically to
+    // "MCP was never requested."
+    logger.warn(`[Codex] --tools mcp requested but no MCP servers are available`);
   }
 
   // Build environment — inherit from process, injecting the API key for the proxy.

--- a/packages/eval/src/runners/copilot/agent.ts
+++ b/packages/eval/src/runners/copilot/agent.ts
@@ -163,7 +163,14 @@ export async function runCopilotAgent(
 
   // Mint tokens once per job so a long matrix run never reuses an expired token.
   const mcpServers = tools.includes('mcp') ? await getMcpServers() : {};
-  if (tools.includes('mcp')) logger.info(`[Copilot] MCP: ${Object.keys(mcpServers).join(', ')}`);
+  if (tools.includes('mcp')) {
+    const mcpNames = Object.keys(mcpServers);
+    // Warn when MCP was requested but no server became available (all mints
+    // failed or none configured), so an all-fail run doesn't read identically
+    // to "MCP was never requested."
+    if (mcpNames.length > 0) logger.info(`[Copilot] MCP: ${mcpNames.join(', ')}`);
+    else logger.warn(`[Copilot] --tools mcp requested but no MCP servers are available`);
+  }
   if (tools.includes('skills')) logger.info('[Copilot] Skills: .github/skills/');
 
   const session = await client.createSession({

--- a/packages/eval/src/runners/copilot/agent.ts
+++ b/packages/eval/src/runners/copilot/agent.ts
@@ -27,6 +27,7 @@ import {
   logger,
   makeSessionId,
   filteredEnv,
+  mintMcpToken,
 } from '@a0/eval-core';
 import { classifyActionType, classifyErrorCategory, detectRetry } from '@a0/eval-core';
 import { LLM_API_KEY_ENV } from '../../cli/constants.js';
@@ -51,12 +52,33 @@ export interface CopilotRunOptions {
   model?: string;
 }
 
-/** Returns MCP server config for the Auth0 docs server. */
-export function getMcpServers(): Record<string, MCPServerConfig> {
+/**
+ * Builds the Copilot MCP server config from the framework config.
+ *
+ * For HTTP servers with an `auth` block, mints a fresh Bearer token per job
+ * (client-credentials exchange) and forwards it as an `Authorization` header.
+ * If the token mint fails, the server is skipped with a warning rather than
+ * registered unauthenticated — a misconfigured run looks like "MCP wasn't
+ * available", not a silent "the agent chose not to use MCP".
+ */
+export async function getMcpServers(): Promise<Record<string, MCPServerConfig>> {
   const servers = getFrameworkConfig().mcp.servers;
   const result: Record<string, MCPServerConfig> = {};
   for (const [name, server] of Object.entries(servers)) {
-    if (server.type === 'http') {
+    if (server.type !== 'http') continue;
+    if (server.auth) {
+      const token = await mintMcpToken(server.auth);
+      if (!token) {
+        logger.warn(`[Copilot] MCP server '${name}' skipped — token mint failed or creds missing`);
+        continue;
+      }
+      result[name] = {
+        type: 'http',
+        url: server.url,
+        tools: ['*'],
+        headers: { Authorization: `Bearer ${token}` },
+      };
+    } else {
       result[name] = { type: 'http', url: server.url, tools: ['*'] };
     }
   }
@@ -138,7 +160,10 @@ export async function runCopilotAgent(
   if (model) {
     logger.info(`[Copilot] Model: ${model}`);
   }
-  if (tools.includes('mcp')) logger.info(`[Copilot] MCP: ${Object.keys(getMcpServers()).join(', ')}`);
+
+  // Mint tokens once per job so a long matrix run never reuses an expired token.
+  const mcpServers = tools.includes('mcp') ? await getMcpServers() : {};
+  if (tools.includes('mcp')) logger.info(`[Copilot] MCP: ${Object.keys(mcpServers).join(', ')}`);
   if (tools.includes('skills')) logger.info('[Copilot] Skills: .github/skills/');
 
   const session = await client.createSession({
@@ -157,7 +182,7 @@ export async function runCopilotAgent(
     } satisfies ProviderConfig,
     // Suppress ask_user to prevent eval runs from blocking on interactive input.
     excludedTools: ['ask_user'],
-    ...(tools.includes('mcp') ? { mcpServers: getMcpServers() } : {}),
+    ...(tools.includes('mcp') ? { mcpServers } : {}),
     // Skill files are pre-copied to .github/skills/ by CopySkillsStrategy.
     ...(tools.includes('skills') ? { skillDirectories: [join(workspace, '.github', 'skills')] } : {}),
     // Disable infinite sessions — each eval run is a clean, isolated session.

--- a/packages/eval/src/runners/gemini-cli/agent.ts
+++ b/packages/eval/src/runners/gemini-cli/agent.ts
@@ -30,6 +30,7 @@ import {
   filteredEnv,
   makeSessionId,
   mintMcpToken,
+  mcpBearerTokenEnvVar,
 } from '@a0/eval-core';
 import { classifyActionType, classifyErrorCategory, detectRetry } from '@a0/eval-core';
 import { LLM_API_KEY_ENV } from '../../cli/constants.js';
@@ -79,11 +80,17 @@ function isAutoCancelled(output: string): boolean {
  * using the format `mcp__<serverName>__<toolName>` (e.g. `mcp__auth0-docs__search_auth0_docs`).
  *
  * For HTTP servers with an `auth` block, mints a fresh Bearer token per job
- * (client-credentials exchange) and writes it as an `Authorization` header into
- * the server config. If the token mint fails, the server is skipped with a
- * warning rather than registered unauthenticated.
+ * (client-credentials exchange). The token is NOT written to settings.json —
+ * instead the `Authorization` header references an env var (`Bearer ${VAR}`),
+ * which Gemini CLI expands at settings-load time from the subprocess env. This
+ * keeps the secret out of the on-disk config file, matching the Codex runner.
+ * (Gemini CLI's `resolveEnvVarsInObject` expands `$VAR`/`${VAR}`/`${VAR:-def}`
+ * in every settings string, headers included.) If the token mint fails, the
+ * server is skipped with a warning rather than registered unauthenticated.
  *
- * Returns the names of the registered MCP servers (empty when MCP is disabled).
+ * Returns the registered MCP server names plus the minted Bearer tokens keyed
+ * by the env var each references, so the caller can inject them into the
+ * subprocess env. Both are empty when MCP is disabled.
  */
 interface GeminiMcpServer {
   httpUrl: string;
@@ -91,7 +98,14 @@ interface GeminiMcpServer {
   headers?: Record<string, string>;
 }
 
-async function writeGeminiSettings(workspace: string, includeMcp: boolean): Promise<string[]> {
+interface GeminiMcpSettings {
+  /** Names of the registered MCP servers. */
+  serverNames: string[];
+  /** Minted Bearer tokens keyed by the env var name each `${VAR}` reference resolves to. */
+  bearerTokens: Record<string, string>;
+}
+
+async function writeGeminiSettings(workspace: string, includeMcp: boolean): Promise<GeminiMcpSettings> {
   const settings: {
     security: { auth: { selectedType: string } };
     mcpServers?: Record<string, GeminiMcpServer>;
@@ -100,6 +114,7 @@ async function writeGeminiSettings(workspace: string, includeMcp: boolean): Prom
   };
 
   const mcpServers: Record<string, GeminiMcpServer> = {};
+  const bearerTokens: Record<string, string> = {};
   if (includeMcp) {
     const configServers = getFrameworkConfig().mcp.servers;
     for (const [name, server] of Object.entries(configServers)) {
@@ -110,10 +125,12 @@ async function writeGeminiSettings(workspace: string, includeMcp: boolean): Prom
           logger.warn(`[GeminiCLI] MCP server '${name}' skipped — token mint failed or creds missing`);
           continue;
         }
+        const envVar = mcpBearerTokenEnvVar(name);
+        bearerTokens[envVar] = token;
         mcpServers[name] = {
           httpUrl: server.url,
           timeout: 30000,
-          headers: { Authorization: `Bearer ${token}` },
+          headers: { Authorization: `Bearer \${${envVar}}` },
         };
       } else {
         mcpServers[name] = { httpUrl: server.url, timeout: 30000 };
@@ -125,7 +142,7 @@ async function writeGeminiSettings(workspace: string, includeMcp: boolean): Prom
   const geminiDir = join(workspace, '.gemini');
   mkdirSync(geminiDir, { recursive: true });
   writeFileSync(join(geminiDir, 'settings.json'), JSON.stringify(settings, null, 2), 'utf-8');
-  return Object.keys(mcpServers);
+  return { serverNames: Object.keys(mcpServers), bearerTokens };
 }
 
 /**
@@ -179,7 +196,10 @@ export async function runGeminiCliAgent(
   logger.info(`\n[GeminiCLI] Starting task: ${evalDef.id}`);
   logger.info(`[GeminiCLI] Workspace: ${workspace}`);
   logger.info(`[GeminiCLI] Model: ${model}`);
-  const mcpNames = await writeGeminiSettings(workspace, tools.includes('mcp'));
+  const { serverNames: mcpNames, bearerTokens: mcpBearerTokens } = await writeGeminiSettings(
+    workspace,
+    tools.includes('mcp'),
+  );
   if (mcpNames.length > 0) logger.info(`[GeminiCLI] MCP: ${mcpNames.join(', ')}`);
 
   // Trust only this workspace so YOLO mode isn't overridden in CI/headless environments.
@@ -194,6 +214,12 @@ export async function runGeminiCliAgent(
   };
   if (process.env.GH_TOKEN) {
     geminiEnv.GH_TOKEN = process.env.GH_TOKEN;
+  }
+  // Inject minted Bearer tokens so Gemini CLI can resolve each authed server's
+  // `${MCP_BEARER_*}` header reference at settings-load time — the token stays
+  // out of the on-disk settings.json.
+  for (const [key, value] of Object.entries(mcpBearerTokens)) {
+    geminiEnv[key] = value;
   }
   if (process.env[LLM_API_KEY_ENV]) {
     geminiEnv.GOOGLE_GEMINI_BASE_URL = getAgentProxyBaseUrl('gemini-cli');

--- a/packages/eval/src/runners/gemini-cli/agent.ts
+++ b/packages/eval/src/runners/gemini-cli/agent.ts
@@ -29,6 +29,7 @@ import {
   logger,
   filteredEnv,
   makeSessionId,
+  mintMcpToken,
 } from '@a0/eval-core';
 import { classifyActionType, classifyErrorCategory, detectRetry } from '@a0/eval-core';
 import { LLM_API_KEY_ENV } from '../../cli/constants.js';
@@ -77,21 +78,44 @@ function isAutoCancelled(output: string): boolean {
  * MCP tool calls appear in the stream-json output as tool_use events with names
  * using the format `mcp__<serverName>__<toolName>` (e.g. `mcp__auth0-docs__search_auth0_docs`).
  *
+ * For HTTP servers with an `auth` block, mints a fresh Bearer token per job
+ * (client-credentials exchange) and writes it as an `Authorization` header into
+ * the server config. If the token mint fails, the server is skipped with a
+ * warning rather than registered unauthenticated.
+ *
  * Returns the names of the registered MCP servers (empty when MCP is disabled).
  */
-function writeGeminiSettings(workspace: string, includeMcp: boolean): string[] {
+interface GeminiMcpServer {
+  httpUrl: string;
+  timeout: number;
+  headers?: Record<string, string>;
+}
+
+async function writeGeminiSettings(workspace: string, includeMcp: boolean): Promise<string[]> {
   const settings: {
     security: { auth: { selectedType: string } };
-    mcpServers?: Record<string, { httpUrl: string; timeout: number }>;
+    mcpServers?: Record<string, GeminiMcpServer>;
   } = {
     security: { auth: { selectedType: GEMINI_AUTH_TYPE } },
   };
 
-  const mcpServers: Record<string, { httpUrl: string; timeout: number }> = {};
+  const mcpServers: Record<string, GeminiMcpServer> = {};
   if (includeMcp) {
     const configServers = getFrameworkConfig().mcp.servers;
     for (const [name, server] of Object.entries(configServers)) {
-      if (server.type === 'http') {
+      if (server.type !== 'http') continue;
+      if (server.auth) {
+        const token = await mintMcpToken(server.auth);
+        if (!token) {
+          logger.warn(`[GeminiCLI] MCP server '${name}' skipped — token mint failed or creds missing`);
+          continue;
+        }
+        mcpServers[name] = {
+          httpUrl: server.url,
+          timeout: 30000,
+          headers: { Authorization: `Bearer ${token}` },
+        };
+      } else {
         mcpServers[name] = { httpUrl: server.url, timeout: 30000 };
       }
     }
@@ -155,7 +179,7 @@ export async function runGeminiCliAgent(
   logger.info(`\n[GeminiCLI] Starting task: ${evalDef.id}`);
   logger.info(`[GeminiCLI] Workspace: ${workspace}`);
   logger.info(`[GeminiCLI] Model: ${model}`);
-  const mcpNames = writeGeminiSettings(workspace, tools.includes('mcp'));
+  const mcpNames = await writeGeminiSettings(workspace, tools.includes('mcp'));
   if (mcpNames.length > 0) logger.info(`[GeminiCLI] MCP: ${mcpNames.join(', ')}`);
 
   // Trust only this workspace so YOLO mode isn't overridden in CI/headless environments.

--- a/packages/eval/src/runners/gemini-cli/agent.ts
+++ b/packages/eval/src/runners/gemini-cli/agent.ts
@@ -126,6 +126,16 @@ async function writeGeminiSettings(workspace: string, includeMcp: boolean): Prom
           continue;
         }
         const envVar = mcpBearerTokenEnvVar(name);
+        // Guard against two server names normalizing to the same env var (e.g.
+        // `auth0-hosted` and `auth0.hosted`), which would silently clobber the
+        // first server's token. Hand-authored configs don't hit this today, but
+        // fail loudly rather than leave a confusing future debugging session.
+        if (bearerTokens[envVar] !== undefined) {
+          logger.warn(
+            `[GeminiCLI] MCP server '${name}' skipped — env var ${envVar} already used by another server (name collision)`,
+          );
+          continue;
+        }
         bearerTokens[envVar] = token;
         mcpServers[name] = {
           httpUrl: server.url,
@@ -201,6 +211,12 @@ export async function runGeminiCliAgent(
     tools.includes('mcp'),
   );
   if (mcpNames.length > 0) logger.info(`[GeminiCLI] MCP: ${mcpNames.join(', ')}`);
+  else if (tools.includes('mcp')) {
+    // MCP was requested but no server became available (all mints failed or
+    // none configured). Log it so an all-fail run doesn't read identically to
+    // "MCP was never requested."
+    logger.warn(`[GeminiCLI] --tools mcp requested but no MCP servers are available`);
+  }
 
   // Trust only this workspace so YOLO mode isn't overridden in CI/headless environments.
   const trustedFoldersPath = writeTrustedFolders(workspace);

--- a/packages/eval/src/sandbox/docker.ts
+++ b/packages/eval/src/sandbox/docker.ts
@@ -156,11 +156,25 @@ export async function runJobInDocker(options: DockerRunOptions): Promise<JobResu
 
   // Forward app-declared passthrough env vars (e.g. MCP server credentials).
   // Only vars currently set on the host are forwarded; missing ones are skipped.
+  const forwardedEnv: string[] = [];
+  const skippedEnv: string[] = [];
   for (const name of passthroughEnv ?? []) {
     const value = process.env[name];
     if (value !== undefined) {
       envFlags.push('-e', `${name}=${value}`);
+      forwardedEnv.push(name);
+    } else {
+      skippedEnv.push(name);
     }
+  }
+  // Log names only (never values) so the most common misconfig — a forgotten
+  // `export MCP_CLIENT_SECRET` — is obvious from run output instead of
+  // surfacing later as a mysterious token-mint failure inside the container.
+  if (forwardedEnv.length > 0) {
+    logger.info(`[sandbox] Forwarding passthrough env: ${forwardedEnv.join(', ')}`);
+  }
+  if (skippedEnv.length > 0) {
+    logger.warn(`[sandbox] Passthrough env not set on host (skipped): ${skippedEnv.join(', ')}`);
   }
 
   // Mount host CA certificates for corporate SSL inspection (MITM proxies)

--- a/packages/eval/src/sandbox/docker.ts
+++ b/packages/eval/src/sandbox/docker.ts
@@ -30,6 +30,11 @@ export interface DockerRunOptions {
   apiKey: string;
   /** Optional GitHub token (for copilot runner). */
   ghToken?: string;
+  /**
+   * Names of host env vars to forward into the container (from `sandbox.passthroughEnv`).
+   * Each is resolved from `process.env` here; only currently-set vars are forwarded.
+   */
+  passthroughEnv?: string[];
 }
 
 // Serialises concurrent ensureDockerImage calls so only one build runs at a time.
@@ -114,7 +119,7 @@ function findRepoRoot(): string {
  * after the container exits.
  */
 export async function runJobInDocker(options: DockerRunOptions): Promise<JobResult> {
-  const { workspace, evalId, model, mode, tools, agentType, apiKey, ghToken } = options;
+  const { workspace, evalId, model, mode, tools, agentType, apiKey, ghToken, passthroughEnv } = options;
 
   await ensureDockerImage();
 
@@ -147,6 +152,15 @@ export async function runJobInDocker(options: DockerRunOptions): Promise<JobResu
 
   if (ghToken) {
     envFlags.push('-e', `GH_TOKEN=${ghToken}`);
+  }
+
+  // Forward app-declared passthrough env vars (e.g. MCP server credentials).
+  // Only vars currently set on the host are forwarded; missing ones are skipped.
+  for (const name of passthroughEnv ?? []) {
+    const value = process.env[name];
+    if (value !== undefined) {
+      envFlags.push('-e', `${name}=${value}`);
+    }
   }
 
   // Mount host CA certificates for corporate SSL inspection (MITM proxies)

--- a/packages/eval/tests/docker.test.ts
+++ b/packages/eval/tests/docker.test.ts
@@ -330,6 +330,47 @@ describe('runJobInDocker — results parsing', () => {
 
     rmSync(workspace, { recursive: true, force: true });
   });
+
+  it('forwards passthroughEnv vars that are set on the host and skips unset ones', async () => {
+    const runJobInDocker = await getRunJobInDocker();
+    const workspace = mkdtempSync(join(tmpdir(), 'docker-passthrough-'));
+
+    const origDomain = process.env.MCP_TENANT_DOMAIN;
+    const origSecret = process.env.MCP_CLIENT_SECRET;
+    process.env.MCP_TENANT_DOMAIN = 'tenant.us.auth0.com';
+    delete process.env.MCP_CLIENT_SECRET;
+
+    mockExecFileSync.mockReturnValue('');
+
+    let capturedArgs: string[] = [];
+    mockSpawn.mockImplementation((_cmd: string, args: string[]) => {
+      capturedArgs = args;
+      writeFileSync(join(workspace, '.eval-results.json'), JSON.stringify({ ok: true }));
+      return makeCloseEmitter();
+    });
+
+    await runJobInDocker({
+      workspace,
+      evalId: 'test_eval',
+      model: 'gpt-5.4',
+      mode: 'agent' as const,
+      tools: ['mcp'],
+      agentType: 'claude-code' as const,
+      apiKey: 'test-key',
+      passthroughEnv: ['MCP_TENANT_DOMAIN', 'MCP_CLIENT_SECRET'],
+    });
+
+    const envPairs = extractEnvPairs(capturedArgs);
+
+    // Set var is forwarded; unset var is skipped entirely.
+    expect(envPairs).toContain('MCP_TENANT_DOMAIN=tenant.us.auth0.com');
+    expect(envPairs.some((e) => e.startsWith('MCP_CLIENT_SECRET='))).toBe(false);
+
+    if (origDomain === undefined) delete process.env.MCP_TENANT_DOMAIN;
+    else process.env.MCP_TENANT_DOMAIN = origDomain;
+    if (origSecret !== undefined) process.env.MCP_CLIENT_SECRET = origSecret;
+    rmSync(workspace, { recursive: true, force: true });
+  });
 });
 
 // ── Host-side timeout ────────────────────────────────────────────────────────

--- a/packages/eval/tests/runners/claude-code-agent.test.ts
+++ b/packages/eval/tests/runners/claude-code-agent.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
-import { setFrameworkConfig } from '@a0/eval-core';
+import { setFrameworkConfig, logger } from '@a0/eval-core';
 import { TEST_CONFIG } from '../test-config.js';
 
 beforeAll(() => {
@@ -30,6 +30,15 @@ const mockQuery = vi.hoisted(() => vi.fn());
 
 vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
   query: mockQuery,
+}));
+
+// Partially mock eval-core so we can control token minting while keeping the
+// real setFrameworkConfig/getFrameworkConfig, logger, and everything else.
+const mintMcpTokenMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@a0/eval-core', async () => ({
+  ...(await vi.importActual('@a0/eval-core')),
+  mintMcpToken: mintMcpTokenMock,
 }));
 
 // Must import after vi.mock so the mock is in place
@@ -297,7 +306,12 @@ describe('handleMessage — assistant', () => {
     const record = makeRecord();
     record.inputTokens = 0;
     handleMessage(
-      makeAssistantMsg({ input_tokens: 6, output_tokens: 3, cache_read_input_tokens: 4800, cache_creation_input_tokens: 200 }),
+      makeAssistantMsg({
+        input_tokens: 6,
+        output_tokens: 3,
+        cache_read_input_tokens: 4800,
+        cache_creation_input_tokens: 200,
+      }),
       record,
       makePending(),
       0,
@@ -602,7 +616,12 @@ describe('handleMessage — result', () => {
     const record = makeRecord();
     record.inputTokens = 999;
     handleMessage(
-      makeResultMsg({ input_tokens: 100, output_tokens: 50, cache_read_input_tokens: 4000, cache_creation_input_tokens: 500 }),
+      makeResultMsg({
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 4000,
+        cache_creation_input_tokens: 500,
+      }),
       record,
       makePending(),
       0,
@@ -883,6 +902,91 @@ describe('runClaudeCodeAgent proxy env injection', () => {
     vi.stubEnv('GH_TOKEN', '');
     await runClaudeCodeAgent(evalDef, workspace);
     expect(capturedEnv()).not.toHaveProperty('GH_TOKEN');
+  });
+});
+
+// ── Authenticated MCP flow ────────────────────────────────────────────────────
+
+describe('runClaudeCodeAgent — authenticated MCP', () => {
+  const AUTHED_CONFIG = {
+    ...TEST_CONFIG,
+    agents: {
+      'claude-code': { proxy: { baseUrl: 'https://llm.example.com/anthropic' } },
+    },
+    mcp: {
+      servers: {
+        'auth0-docs': { type: 'http' as const, url: 'https://auth0.com/docs/mcp' },
+        'auth0-hosted-mcp': {
+          type: 'http' as const,
+          url: 'https://tenant.auth0.com/v1/mcp',
+          auth: {
+            tokenUrl: 'https://tenant.auth0.com/oauth/token',
+            clientId: 'cid',
+            clientSecret: 'secret',
+            audience: 'https://tenant.auth0.com/api/v2/',
+          },
+        },
+      },
+    },
+  };
+
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mintMcpTokenMock.mockReset();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockQuery.mockReturnValue(fakeQuery([makeResultMsg({ subtype: 'success' }) as SDKMessage]));
+    setFrameworkConfig(AUTHED_CONFIG);
+  });
+
+  afterEach(() => {
+    // Restore the shared config so a failing assertion can't leak MCP servers.
+    setFrameworkConfig({
+      ...TEST_CONFIG,
+      agents: { 'claude-code': { proxy: { baseUrl: 'https://llm.example.com/anthropic' } } },
+    });
+    vi.restoreAllMocks();
+  });
+
+  function capturedMcpServers(): Record<string, { type: string; url: string; headers?: Record<string, string> }> {
+    const call = mockQuery.mock.calls[0] as [{ options: { mcpServers?: Record<string, never> } }];
+    return call[0].options.mcpServers ?? {};
+  }
+
+  it('mints a token and injects an Authorization header for authed servers', async () => {
+    mintMcpTokenMock.mockResolvedValueOnce('minted-token');
+
+    await runClaudeCodeAgent(evalDef, workspace, { tools: ['mcp'] });
+
+    const mcpServers = capturedMcpServers();
+    expect(mcpServers['auth0-hosted-mcp']).toEqual({
+      type: 'http',
+      url: 'https://tenant.auth0.com/v1/mcp',
+      headers: { Authorization: 'Bearer minted-token' },
+    });
+    // The unauthed server is registered without a header.
+    expect(mcpServers['auth0-docs']).toEqual({ type: 'http', url: 'https://auth0.com/docs/mcp' });
+    expect(mintMcpTokenMock).toHaveBeenCalledOnce();
+  });
+
+  it('skips an authed server and warns when the token mint fails', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    mintMcpTokenMock.mockResolvedValueOnce(undefined);
+
+    await runClaudeCodeAgent(evalDef, workspace, { tools: ['mcp'] });
+
+    const mcpServers = capturedMcpServers();
+    expect(mcpServers).not.toHaveProperty('auth0-hosted-mcp');
+    // The unauthed server still registers.
+    expect(mcpServers).toHaveProperty('auth0-docs');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('auth0-hosted-mcp'));
+  });
+
+  it('registers no MCP servers when --tools mcp is not requested', async () => {
+    await runClaudeCodeAgent(evalDef, workspace);
+
+    const call = mockQuery.mock.calls[0] as [{ options: { mcpServers?: Record<string, never> } }];
+    expect(call[0].options.mcpServers).toBeUndefined();
+    expect(mintMcpTokenMock).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/eval/tests/runners/codex-agent.test.ts
+++ b/packages/eval/tests/runners/codex-agent.test.ts
@@ -916,4 +916,32 @@ describe('MCP integration', () => {
     const toml = written[1] as string;
     expect(toml).not.toContain('mcp_servers');
   });
+
+  it('skips the second of two servers whose names collide to the same env var', async () => {
+    // `auth0-hosted` and `auth0.hosted` both normalize to MCP_BEARER_AUTH0_HOSTED.
+    // The guard forwards the first and skips the second rather than clobbering.
+    mintMcpTokenMock.mockResolvedValueOnce('token-a').mockResolvedValueOnce('token-b');
+    const authBlock = {
+      tokenUrl: 'https://tenant.auth0.com/oauth/token',
+      clientId: 'cid',
+      clientSecret: 'secret',
+      audience: 'https://tenant.auth0.com/api/v2/',
+    };
+    mockGetFrameworkConfig.mockReturnValue({
+      proxy: { baseUrl: 'https://your-llm-proxy.example.com/v1' },
+      mcp: {
+        servers: {
+          'auth0-hosted': { type: 'http', url: 'https://tenant.auth0.com/a/mcp', auth: authBlock },
+          'auth0.hosted': { type: 'http', url: 'https://tenant.auth0.com/b/mcp', auth: authBlock },
+        },
+      },
+    });
+    queueTurns([{ type: 'item.completed', item: { type: 'agent_message', text: 'Done.' } }, turnCompleted()]);
+
+    await runCodexAgent(evalDef, workspace, { tools: ['mcp'] });
+
+    // Only the first server's token is injected under the shared env var.
+    const env = sdk.state.constructorCalls[0].env as Record<string, string>;
+    expect(env['MCP_BEARER_AUTH0_HOSTED']).toBe('token-a');
+  });
 });

--- a/packages/eval/tests/runners/codex-agent.test.ts
+++ b/packages/eval/tests/runners/codex-agent.test.ts
@@ -51,10 +51,13 @@ const mockGetFrameworkConfig = vi.hoisted(() =>
   }),
 );
 
+const mintMcpTokenMock = vi.hoisted(() => vi.fn());
+
 vi.mock('@a0/eval-core', async () => ({
   ...(await vi.importActual('@a0/eval-core')),
   getAgentProxyBaseUrl: vi.fn().mockReturnValue('https://your-llm-proxy.example.com'),
   getFrameworkConfig: mockGetFrameworkConfig,
+  mintMcpToken: mintMcpTokenMock,
 }));
 
 // ── Mock @openai/codex-sdk ──────────────────────────────────────────────────
@@ -817,6 +820,79 @@ describe('MCP integration', () => {
     const codexOptions = sdk.state.constructorCalls[0];
     const env = codexOptions.env as Record<string, string>;
     expect(env['MY_SECRET_TOKEN']).toBe('secret123');
+  });
+
+  it('mints a token and writes bearer_token_env_var for authed http servers', async () => {
+    mintMcpTokenMock.mockResolvedValueOnce('minted-token');
+    mockGetFrameworkConfig.mockReturnValue({
+      proxy: { baseUrl: 'https://your-llm-proxy.example.com/v1' },
+      mcp: {
+        servers: {
+          'auth0-hosted-mcp': {
+            type: 'http',
+            url: 'https://tenant.auth0.com/v1/mcp',
+            auth: {
+              tokenUrl: 'https://tenant.auth0.com/oauth/token',
+              clientId: 'cid',
+              clientSecret: 'secret',
+              audience: 'https://tenant.auth0.com/api/v2/',
+            },
+          },
+        },
+      },
+    });
+    queueTurns([{ type: 'item.completed', item: { type: 'agent_message', text: 'Done.' } }, turnCompleted()]);
+
+    await runCodexAgent(evalDef, workspace, { tools: ['mcp'] });
+
+    const written = (writeFileSync as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).endsWith('config.toml'),
+    );
+    expect(written).toBeDefined();
+    if (!written) return;
+    const toml = written[1] as string;
+    expect(toml).toContain('[mcp_servers."auth0-hosted-mcp"]');
+    expect(toml).toContain('url = "https://tenant.auth0.com/v1/mcp"');
+    expect(toml).toContain('bearer_token_env_var = "MCP_BEARER_AUTH0_HOSTED_MCP"');
+    // The token itself must never be written to the config file.
+    expect(toml).not.toContain('minted-token');
+
+    // The minted token is injected into the Codex env under the referenced name.
+    const codexOptions = sdk.state.constructorCalls[0];
+    const env = codexOptions.env as Record<string, string>;
+    expect(env['MCP_BEARER_AUTH0_HOSTED_MCP']).toBe('minted-token');
+  });
+
+  it('skips an authed server when the token mint fails', async () => {
+    mintMcpTokenMock.mockResolvedValueOnce(undefined);
+    mockGetFrameworkConfig.mockReturnValue({
+      proxy: { baseUrl: 'https://your-llm-proxy.example.com/v1' },
+      mcp: {
+        servers: {
+          'auth0-hosted-mcp': {
+            type: 'http',
+            url: 'https://tenant.auth0.com/v1/mcp',
+            auth: {
+              tokenUrl: 'https://tenant.auth0.com/oauth/token',
+              clientId: 'cid',
+              clientSecret: 'secret',
+              audience: 'https://tenant.auth0.com/api/v2/',
+            },
+          },
+        },
+      },
+    });
+    queueTurns([{ type: 'item.completed', item: { type: 'agent_message', text: 'Done.' } }, turnCompleted()]);
+
+    await runCodexAgent(evalDef, workspace, { tools: ['mcp'] });
+
+    const written = (writeFileSync as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).endsWith('config.toml'),
+    );
+    expect(written).toBeDefined();
+    if (!written) return;
+    const toml = written[1] as string;
+    expect(toml).not.toContain('auth0-hosted-mcp');
   });
 
   it('does not write MCP sections when tools does not include mcp', async () => {

--- a/packages/eval/tests/runners/copilot-agent.test.ts
+++ b/packages/eval/tests/runners/copilot-agent.test.ts
@@ -8,6 +8,14 @@
 
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'node:events';
+
+// Mock only mintMcpToken so authed-server tests don't perform a real OAuth fetch.
+const mintMcpTokenMock = vi.hoisted(() => vi.fn());
+vi.mock('@a0/eval-core', async () => ({
+  ...(await vi.importActual('@a0/eval-core')),
+  mintMcpToken: mintMcpTokenMock,
+}));
+
 import { setFrameworkConfig } from '@a0/eval-core';
 import { TEST_CONFIG } from '../test-config.js';
 
@@ -123,16 +131,71 @@ describe('COPILOT_DEFAULT_MODEL', () => {
 });
 
 describe('getMcpServers', () => {
-  it('returns auth0-docs remote MCP server config', () => {
-    const servers = getMcpServers();
+  it('returns auth0-docs remote MCP server config', async () => {
+    const servers = await getMcpServers();
     expect(servers).toHaveProperty('auth0-docs');
     expect(servers['auth0-docs'].type).toBe('http');
-    expect(servers['auth0-docs'].url).toBe('https://auth0.com/docs/mcp');
+    expect((servers['auth0-docs'] as { url: string }).url).toBe('https://auth0.com/docs/mcp');
   });
 
-  it('includes all tools via wildcard', () => {
-    const servers = getMcpServers();
-    expect(servers['auth0-docs'].tools).toContain('*');
+  it('includes all tools via wildcard', async () => {
+    const servers = await getMcpServers();
+    expect((servers['auth0-docs'] as { tools: string[] }).tools).toContain('*');
+  });
+
+  it('does not set an Authorization header for unauthenticated servers', async () => {
+    const servers = await getMcpServers();
+    expect((servers['auth0-docs'] as { headers?: Record<string, string> }).headers).toBeUndefined();
+  });
+
+  it('mints a token and forwards it as an Authorization header for authed servers', async () => {
+    mintMcpTokenMock.mockResolvedValueOnce('minted-token');
+    setFrameworkConfig({
+      ...TEST_CONFIG,
+      mcp: {
+        servers: {
+          'auth0-hosted-mcp': {
+            type: 'http',
+            url: 'https://tenant.auth0.com/v1/mcp',
+            auth: {
+              tokenUrl: 'https://tenant.auth0.com/oauth/token',
+              clientId: 'cid',
+              clientSecret: 'secret',
+              audience: 'https://tenant.auth0.com/api/v2/',
+            },
+          },
+        },
+      },
+    });
+    const servers = await getMcpServers();
+    expect((servers['auth0-hosted-mcp'] as { headers?: Record<string, string> }).headers).toEqual({
+      Authorization: 'Bearer minted-token',
+    });
+    setFrameworkConfig(TEST_CONFIG);
+  });
+
+  it('skips an authed server when the token mint fails', async () => {
+    mintMcpTokenMock.mockResolvedValueOnce(undefined);
+    setFrameworkConfig({
+      ...TEST_CONFIG,
+      mcp: {
+        servers: {
+          'auth0-hosted-mcp': {
+            type: 'http',
+            url: 'https://tenant.auth0.com/v1/mcp',
+            auth: {
+              tokenUrl: 'https://tenant.auth0.com/oauth/token',
+              clientId: 'cid',
+              clientSecret: 'secret',
+              audience: 'https://tenant.auth0.com/api/v2/',
+            },
+          },
+        },
+      },
+    });
+    const servers = await getMcpServers();
+    expect(servers).not.toHaveProperty('auth0-hosted-mcp');
+    setFrameworkConfig(TEST_CONFIG);
   });
 });
 

--- a/packages/eval/tests/runners/copilot-agent.test.ts
+++ b/packages/eval/tests/runners/copilot-agent.test.ts
@@ -131,6 +131,12 @@ describe('COPILOT_DEFAULT_MODEL', () => {
 });
 
 describe('getMcpServers', () => {
+  // Several tests below mutate the shared framework config. Reset it here so a
+  // failing assertion can't leak auth0-hosted-mcp into later tests.
+  afterEach(() => {
+    setFrameworkConfig(TEST_CONFIG);
+  });
+
   it('returns auth0-docs remote MCP server config', async () => {
     const servers = await getMcpServers();
     expect(servers).toHaveProperty('auth0-docs');
@@ -171,7 +177,6 @@ describe('getMcpServers', () => {
     expect((servers['auth0-hosted-mcp'] as { headers?: Record<string, string> }).headers).toEqual({
       Authorization: 'Bearer minted-token',
     });
-    setFrameworkConfig(TEST_CONFIG);
   });
 
   it('skips an authed server when the token mint fails', async () => {
@@ -195,7 +200,6 @@ describe('getMcpServers', () => {
     });
     const servers = await getMcpServers();
     expect(servers).not.toHaveProperty('auth0-hosted-mcp');
-    setFrameworkConfig(TEST_CONFIG);
   });
 });
 

--- a/packages/eval/tests/runners/gemini-cli-agent.test.ts
+++ b/packages/eval/tests/runners/gemini-cli-agent.test.ts
@@ -575,7 +575,7 @@ describe('.gemini/settings.json', () => {
     expect(existsSync(join(tmpWorkspace, '.gemini', 'settings.json'))).toBe(true);
   });
 
-  it('mints a token and writes an Authorization header for authed servers', async () => {
+  it('mints a token and writes an env-var Authorization header for authed servers', async () => {
     mockSpawn.mockReturnValue(makeChild([resultEvent()]));
     mintMcpTokenMock.mockResolvedValueOnce('minted-token');
     mockGetFrameworkConfig.mockReturnValueOnce({
@@ -598,14 +598,64 @@ describe('.gemini/settings.json', () => {
 
     await runGeminiCliAgent(evalDef, tmpWorkspace, { tools: ['mcp'] });
 
+    // The header references an env var — the token is never written to disk;
+    // Gemini CLI expands `${MCP_BEARER_*}` from the subprocess env at load time.
     const settings = readSettings();
     expect(settings.mcpServers).toEqual({
       'auth0-hosted-mcp': {
         httpUrl: 'https://tenant.auth0.com/v1/mcp',
         timeout: 30000,
-        headers: { Authorization: 'Bearer minted-token' },
+        headers: { Authorization: 'Bearer ${MCP_BEARER_AUTH0_HOSTED_MCP}' },
       },
     });
+    // The raw token must not leak into the settings file.
+    const raw = readFileSync(join(tmpWorkspace, '.gemini', 'settings.json'), 'utf-8');
+    expect(raw).not.toContain('minted-token');
+
+    // The token is injected into the subprocess env under the referenced name.
+    const spawnEnv = (mockSpawn.mock.calls[0] as [string, string[], { env: Record<string, string> }])[2].env;
+    expect(spawnEnv.MCP_BEARER_AUTH0_HOSTED_MCP).toBe('minted-token');
+  });
+
+  it('registers authed and unauthed servers together, only the authed one carrying a header', async () => {
+    // Mirrors the production eval.config.js: auth0-docs (unauthed) and
+    // auth0-hosted-mcp (authed) side by side. Both must land in the config,
+    // but only the authed server gets an Authorization header.
+    mockSpawn.mockReturnValue(makeChild([resultEvent()]));
+    mintMcpTokenMock.mockClear();
+    mintMcpTokenMock.mockResolvedValueOnce('minted-token');
+    mockGetFrameworkConfig.mockReturnValueOnce({
+      proxy: { baseUrl: 'https://llm.example.com/v1' },
+      mcp: {
+        servers: {
+          'auth0-docs': { type: 'http', url: 'https://auth0.com/docs/mcp' },
+          'auth0-hosted-mcp': {
+            type: 'http',
+            url: 'https://tenant.auth0.com/v1/mcp',
+            auth: {
+              tokenUrl: 'https://tenant.auth0.com/oauth/token',
+              clientId: 'cid',
+              clientSecret: 'secret',
+              audience: 'https://tenant.auth0.com/api/v2/',
+            },
+          },
+        },
+      },
+    });
+
+    await runGeminiCliAgent(evalDef, tmpWorkspace, { tools: ['mcp'] });
+
+    const settings = readSettings();
+    expect(settings.mcpServers).toEqual({
+      'auth0-docs': { httpUrl: 'https://auth0.com/docs/mcp', timeout: 30000 },
+      'auth0-hosted-mcp': {
+        httpUrl: 'https://tenant.auth0.com/v1/mcp',
+        timeout: 30000,
+        headers: { Authorization: 'Bearer ${MCP_BEARER_AUTH0_HOSTED_MCP}' },
+      },
+    });
+    // The token is minted exactly once — the unauthed server never triggers a mint.
+    expect(mintMcpTokenMock).toHaveBeenCalledOnce();
   });
 
   it('skips an authed server when the token mint fails', async () => {

--- a/packages/eval/tests/runners/gemini-cli-agent.test.ts
+++ b/packages/eval/tests/runners/gemini-cli-agent.test.ts
@@ -20,9 +20,8 @@ import { join } from 'node:path';
 
 // ── Mock framework config ────────────────────────────────────────────────────
 
-vi.mock('@a0/eval-core', async () => ({
-  ...(await vi.importActual('@a0/eval-core')),
-  getFrameworkConfig: vi.fn().mockReturnValue({
+const mockGetFrameworkConfig = vi.hoisted(() =>
+  vi.fn().mockReturnValue({
     proxy: { baseUrl: 'https://llm.example.com/v1' },
     mcp: {
       servers: {
@@ -30,6 +29,13 @@ vi.mock('@a0/eval-core', async () => ({
       },
     },
   }),
+);
+const mintMcpTokenMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@a0/eval-core', async () => ({
+  ...(await vi.importActual('@a0/eval-core')),
+  getFrameworkConfig: mockGetFrameworkConfig,
+  mintMcpToken: mintMcpTokenMock,
 }));
 
 // ── Mock spawn ────────────────────────────────────────────────────────────────
@@ -567,6 +573,66 @@ describe('.gemini/settings.json', () => {
     await runGeminiCliAgent(evalDef, tmpWorkspace, { tools: ['skills'] });
 
     expect(existsSync(join(tmpWorkspace, '.gemini', 'settings.json'))).toBe(true);
+  });
+
+  it('mints a token and writes an Authorization header for authed servers', async () => {
+    mockSpawn.mockReturnValue(makeChild([resultEvent()]));
+    mintMcpTokenMock.mockResolvedValueOnce('minted-token');
+    mockGetFrameworkConfig.mockReturnValueOnce({
+      proxy: { baseUrl: 'https://llm.example.com/v1' },
+      mcp: {
+        servers: {
+          'auth0-hosted-mcp': {
+            type: 'http',
+            url: 'https://tenant.auth0.com/v1/mcp',
+            auth: {
+              tokenUrl: 'https://tenant.auth0.com/oauth/token',
+              clientId: 'cid',
+              clientSecret: 'secret',
+              audience: 'https://tenant.auth0.com/api/v2/',
+            },
+          },
+        },
+      },
+    });
+
+    await runGeminiCliAgent(evalDef, tmpWorkspace, { tools: ['mcp'] });
+
+    const settings = readSettings();
+    expect(settings.mcpServers).toEqual({
+      'auth0-hosted-mcp': {
+        httpUrl: 'https://tenant.auth0.com/v1/mcp',
+        timeout: 30000,
+        headers: { Authorization: 'Bearer minted-token' },
+      },
+    });
+  });
+
+  it('skips an authed server when the token mint fails', async () => {
+    mockSpawn.mockReturnValue(makeChild([resultEvent()]));
+    mintMcpTokenMock.mockResolvedValueOnce(undefined);
+    mockGetFrameworkConfig.mockReturnValueOnce({
+      proxy: { baseUrl: 'https://llm.example.com/v1' },
+      mcp: {
+        servers: {
+          'auth0-hosted-mcp': {
+            type: 'http',
+            url: 'https://tenant.auth0.com/v1/mcp',
+            auth: {
+              tokenUrl: 'https://tenant.auth0.com/oauth/token',
+              clientId: 'cid',
+              clientSecret: 'secret',
+              audience: 'https://tenant.auth0.com/api/v2/',
+            },
+          },
+        },
+      },
+    });
+
+    await runGeminiCliAgent(evalDef, tmpWorkspace, { tools: ['mcp'] });
+
+    const settings = readSettings();
+    expect(settings).not.toHaveProperty('mcpServers');
   });
 });
 


### PR DESCRIPTION
## Summary

Adds support for **protected HTTP MCP servers** — servers that require an `Authorization: Bearer` token rather than being publicly reachable (e.g. the Auth0 hosted MCP server, which authenticates with a Management API token).

This is the auth-plumbing layer only. The `calledTool`/`calledToolOneOf` trace-based grader primitives and the `hosted_mcp_list_applications` eval that build on top of it are intentionally left for a follow-up PR.

## What's included

- **`mintMcpToken`** — per-job client-credentials token mint for HTTP MCP servers (minted per job so a long matrix run never reuses an expired token).
- **`MCPHttpServerConfig.auth`** — new optional `auth` block (`tokenUrl` / `clientId` / `clientSecret` / `audience`) typed as `MCPOAuthConfig`.
- **All four runners forward the token**: `claude-code`, `copilot`, and `gemini-cli` set an `Authorization: Bearer` header on the MCP server config; `codex` writes a `bearer_token_env_var` reference into `config.toml` and injects the token into its process env (an inline `bearer_token` is rejected by Codex, so the secret stays out of the file).
- **Loud failure** — a failed token mint skips the server with a `logger.warn` rather than registering it unauthenticated.
- **`sandbox.passthroughEnv`** — forward named host env vars into the Docker sandbox (names only; values resolved from `process.env` at launch) so MCP credentials reach the container.
- **`docs/PROTECTED_MCP.md`** — setup guide (prerequisites, env vars, config, how minting/forwarding works, troubleshooting).

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (697 tests)
- [x] `npm run lint` passes
- [ ] Manual: run an eval with `--tools mcp` against a protected server with `MCP_TENANT_DOMAIN`/`MCP_CLIENT_ID`/`MCP_CLIENT_SECRET` set and confirm the token is minted and forwarded for each runner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for protected MCP servers with per-job OAuth token minting.
  * Docker sandbox jobs can now receive selected host environment variables.
  * Several runners now forward authenticated MCP access automatically.

* **Bug Fixes**
  * Authenticated MCP servers are skipped with a warning if token minting fails, instead of being registered without credentials.
  * Improved handling for missing or incomplete auth settings.

* **Documentation**
  * Added guidance for configuring protected MCP servers and troubleshooting common setup issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->