### PR TITLE
chore: group Anthropic dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,9 @@ updates:
         patterns:
           - "@openai/codex"
           - "@openai/codex-sdk"
+      # Keep the Claude Code CLI and Agent SDK in lockstep — they share a
+      # release cadence and are easier to test together than separately.
+      anthropic:
+        patterns:
+          - "@anthropic-ai/claude-code"
+          - "@anthropic-ai/claude-agent-sdk"


### PR DESCRIPTION
## Summary
- Add an `anthropic` group to `.github/dependabot.yml` so `@anthropic-ai/claude-code` and `@anthropic-ai/claude-agent-sdk` are bumped together in a single PR, mirroring the existing `openai-codex` group.

This replaces the separate PRs #43 (`claude-code`) and #37 (`claude-agent-sdk`) — grouping them makes the two easier to test as a unit since they share a release cadence.

## Test plan
- [ ] Dependabot picks up the new group on its next weekly run and opens a single combined PR for the two Anthropic packages
- [ ] Close #43 and #37 once the grouped PR supersedes them