### PR TITLE
fix(copilot): bump @github/copilot-sdk to 1.0.1 and route through LLM proxy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -336,6 +336,12 @@ Set `CLAUDE_CODE_USE_BEDROCK_PROXY=1` to route through the Bedrock proxy instead
 - `claude-opus-4-5` → `global.anthropic.claude-opus-4-5-20251101-v1:0`
 - `claude-haiku-4-5` → `global.anthropic.claude-haiku-4-5-20251001-v1:0`
 
+### Copilot SDK runner details
+
+Uses `@github/copilot-sdk` to drive the bundled Copilot runtime over JSON-RPC. Inference is routed through the configured LLM proxy via an OpenAI-compatible BYOK provider (`provider: { type: 'openai', wireApi: 'responses', baseUrl, apiKey }`) — **not** GitHub's Copilot backend. The Responses API is required because Copilot emits freeform/custom tool calls (e.g. `apply_patch`) that the chat-completions API rejects — the same reason the Codex runner uses `wire_api = "responses"`. This mirrors the Codex runner: the proxy base URL resolves from `agents.copilot.proxy.baseUrl` (falling back to the top-level `proxy.baseUrl`) and is normalized to end in `/v1`; the API key comes from the `LLM_API_KEY` env var. Set `COPILOT_PROXY_BASE_URL` to override the proxy for this runner only.
+
+The runner is GPT-only: `gpt-*` / `o*` models pass through, anything else (e.g. `claude-*`, `gemini-*`, or the `copilot` sentinel) falls back to the default GPT model (`gpt-5.4`).
+
 ---
 
 ## Agent tools

--- a/apps/auth0-evals/eval.config.js
+++ b/apps/auth0-evals/eval.config.js
@@ -11,6 +11,7 @@ const PROXY_BASE_URL = process.env.LLM_PROXY_BASE_URL ?? '';
 const CLAUDE_PROXY_BASE_URL = process.env.CLAUDE_PROXY_BASE_URL ?? PROXY_BASE_URL;
 const GEMINI_PROXY_BASE_URL = process.env.GEMINI_PROXY_BASE_URL ?? PROXY_BASE_URL;
 const CODEX_PROXY_BASE_URL = process.env.CODEX_PROXY_BASE_URL ?? PROXY_BASE_URL;
+const COPILOT_PROXY_BASE_URL = process.env.COPILOT_PROXY_BASE_URL ?? PROXY_BASE_URL;
 
 // When set, route Claude models through the Bedrock proxy, which needs full
 // `global.anthropic.*` model IDs instead of the short aliases.
@@ -35,6 +36,9 @@ export default {
     },
     'codex': {
       proxy: { baseUrl: CODEX_PROXY_BASE_URL },
+    },
+    'copilot': {
+      proxy: { baseUrl: COPILOT_PROXY_BASE_URL },
     },
   },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1118,24 +1118,30 @@
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.46",
-      "integrity": "sha512-e3gxCj8DLGesTAZQ5+jCCbCxe3lMyjKfs5eLgER/SID8Rcb7YpgBXoUvOn3eXxLSsJEmJ3GagHaaHDkf3Zm+Ng==",
+      "version": "1.0.63",
+      "integrity": "sha512-e8DRYiWJQc4kepVXsXjC8vpDU2FXS/TfR+Z6p/KAojfcwIUZzKMAfCV5D1lD25hV4CryVH1Z9t7mHqChickj0Q==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "detect-libc": "^2.1.2",
+        "os-theme": "^0.0.8"
+      },
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.46",
-        "@github/copilot-darwin-x64": "1.0.46",
-        "@github/copilot-linux-arm64": "1.0.46",
-        "@github/copilot-linux-x64": "1.0.46",
-        "@github/copilot-win32-arm64": "1.0.46",
-        "@github/copilot-win32-x64": "1.0.46"
+        "@github/copilot-darwin-arm64": "1.0.63",
+        "@github/copilot-darwin-x64": "1.0.63",
+        "@github/copilot-linux-arm64": "1.0.63",
+        "@github/copilot-linux-x64": "1.0.63",
+        "@github/copilot-linuxmusl-arm64": "1.0.63",
+        "@github/copilot-linuxmusl-x64": "1.0.63",
+        "@github/copilot-win32-arm64": "1.0.63",
+        "@github/copilot-win32-x64": "1.0.63"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.46",
-      "integrity": "sha512-zbhXuRguCdDgeIZKH+rjgBM/6CDMUmhLMck8w9XFDxUY2wrP7MSWXuX8yA4/1H3ySOTZMIH1G5DQpWh+npmR2Q==",
+      "version": "1.0.63",
+      "integrity": "sha512-z6CMBxNDlKvT6bvOpqhu4M2bhb0daEbVwSe9SN9WfDUJbt7bpoL7OKKas428iyPSWHoL2WXwxSsy/FjIwSLV6w==",
       "cpu": [
         "arm64"
       ],
@@ -1149,8 +1155,8 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.46",
-      "integrity": "sha512-kSUcV6cARhM+b/BuNSQtazbORTetRjIWpO3SqWSmH+2UoeZP5A5x+ipr7mhshq+E+pcWPeQKMGbKGY3lrCSMFw==",
+      "version": "1.0.63",
+      "integrity": "sha512-YKd7cXZgAGxhudzrtWdWh2NS35p2G5bV22Gz3jhEyBTqmq45o4sD4OwO87+UpkvM+3nZpwsHaLd3a+ILYX6OXg==",
       "cpu": [
         "x64"
       ],
@@ -1164,8 +1170,8 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.46",
-      "integrity": "sha512-Tz3F0LuGFbOvvv0VKQJ4E5XYBsTdqTNMAwOhbkwX6TuKMX88uLJNKP5uPf6yuu1z3J3nt/5rfEd9CxVrZbnqLA==",
+      "version": "1.0.63",
+      "integrity": "sha512-A3DOeEfmsJH9j1N+QLc7WXmESBskbezmhDyhyAJcHkw0ngRbKctuWQf/evUHFMh/kgwy1Lr/+9jXJm3NZqr0MA==",
       "cpu": [
         "arm64"
       ],
@@ -1179,8 +1185,8 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.46",
-      "integrity": "sha512-s9JWe/YE78I7QEeXrvDGHB5x2XnnkegUJYVE9QR2DI/qLXviHMarM3akOUhed21uVqzoiLPacXKZcTcaDO8tOg==",
+      "version": "1.0.63",
+      "integrity": "sha512-OMKfZJRoDaJOV7vuWX/nFPNdLa9/H+nhajdE83v4YT9mKLXr86aWrkXE3pPoDYsKWvgQFHg4APA6oZPao0Fyow==",
       "cpu": [
         "x64"
       ],
@@ -1193,22 +1199,52 @@
         "copilot-linux-x64": "copilot"
       }
     },
+    "node_modules/@github/copilot-linuxmusl-arm64": {
+      "version": "1.0.63",
+      "integrity": "sha512-jcIo6B3uHgcOluNfUHp+6atShKKrXYBPLaRyF6aDT699lwI83gW9KTDuEvDs5FDg8qWsWFfOl+al2dkWDYD3CQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linuxmusl-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linuxmusl-x64": {
+      "version": "1.0.63",
+      "integrity": "sha512-BEdBbEF3fG7VqXzuaAY4JtmbdGSkpJFeb2ZQYaMpq7OP3aS7ssGe1cCX8ehZNegcMM/eb4GC6PXNXsvl3X/PAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linuxmusl-x64": "copilot"
+      }
+    },
     "node_modules/@github/copilot-sdk": {
-      "version": "0.3.0",
-      "integrity": "sha512-SUo35k56pzzgYgwmDPHcu7kZxPrzXbH66IWXaEf6pmb94DlA709F82HrrDeja087TL4djJ9OuvRFWWOKCosAsg==",
+      "version": "1.0.1",
+      "integrity": "sha512-w6AaS0WqqTE/3iyUrZznvgCLQhsUF7ZmEVCneacuHCfOzlH0r6ww9WUmyA0zgqmXO75V0IYrkIcnFke/qJkkDg==",
       "license": "MIT",
       "dependencies": {
-        "@github/copilot": "^1.0.36-0",
+        "@github/copilot": "^1.0.61",
         "vscode-jsonrpc": "^8.2.1",
         "zod": "^4.3.6"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.46",
-      "integrity": "sha512-auX8o8vG8A+rdSthvey1D8q3o6lNlNIfHFjoBU0Z9Fxid6Ghz2paaAn0/Uwz9Ev8W8cn/5C5kEPs3niMXSh4Jw==",
+      "version": "1.0.63",
+      "integrity": "sha512-7FqUwOmtoeBoOn4zkKQqRL+WGFwektVRSr5Po2FvPAbKxGXGyFXApZTmRLqVcHhMKDRzMb8KLST1LU1TMTY/wg==",
       "cpu": [
         "arm64"
       ],
@@ -1222,8 +1258,8 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.46",
-      "integrity": "sha512-iXo9TUqtSxqlBfC+SZSQMrctKJpWR19zr+8dk7hczE42gOVB0/A+NySJwCmY3UFAEY98lbLDjIC+NCbYFcpEHA==",
+      "version": "1.0.63",
+      "integrity": "sha512-RC/6y9KHdw/YRCrCEksF2RzbeblfBUNE7bkYZxygaQGYThuv1GeZL2YD2jVqxC2LxKzsUmWGvwEMxerfR6pmeQ==",
       "cpu": [
         "x64"
       ],
@@ -1234,6 +1270,32 @@
       ],
       "bin": {
         "copilot-win32-x64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot/node_modules/os-theme": {
+      "version": "0.0.8",
+      "integrity": "sha512-u1q3bLSv5uMHNIiPItkfDrHXu6ZFs2juwqxWREFM/uVBa+7Kkhy2v49LmJev2JcinGwqiEccElB/XsH9gwasuA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@os-theme/darwin-arm64": "0.0.8",
+        "@os-theme/linux-x64": "0.0.8",
+        "@os-theme/win32-x64": "0.0.8"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      }
+    },
+    "node_modules/@github/copilot/node_modules/typescript": {
+      "version": "5.9.3",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@github/keytar": {
@@ -1675,6 +1737,42 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/@os-theme/darwin-arm64": {
+      "version": "0.0.8",
+      "integrity": "sha512-gMsOs+8Ju396a5yyMWigkbA0dMTxD78U3HzG3mlpiAyn6hfd5dbyI4VGP+sfTB82KGgWLzIhWWTFX5UYY6iX0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@os-theme/linux-x64": {
+      "version": "0.0.8",
+      "integrity": "sha512-zvjmBUiSQPjM1RbhpsfCDYMJxW4eLlGmkFPnpteC/03X2lz6CjiX2hfbN2EWLxXjNnIje3Jqaen8IsqEnWrRBg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@os-theme/win32-x64": {
+      "version": "0.0.8",
+      "integrity": "sha512-N3yxKNbVl2IBa/ncDuq55QhwqwUjnYLJxDKMEmYeJbLIV950qZNojPw3scXA6PbfxPZfIiRa8iz1pzNg9XxP8w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@oxc-project/types": {
       "version": "0.129.0",
@@ -3049,7 +3147,6 @@
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -5801,8 +5898,8 @@
         "@a0/eval-reporter": "*",
         "@ai-sdk/openai": "^3.0.71",
         "@anthropic-ai/claude-agent-sdk": "^0.3.178",
-        "@anthropic-ai/claude-code": "^2.1.178",
-        "@github/copilot-sdk": "^0.3.0",
+        "@anthropic-ai/claude-code": "2.1.178",
+        "@github/copilot-sdk": "^1.0.1",
         "@google/gemini-cli": "^0.46.0",
         "@openai/codex": "^0.140.0",
         "@openai/codex-sdk": "^0.140.0",

--- a/packages/eval/package.json
+++ b/packages/eval/package.json
@@ -19,7 +19,7 @@
     "@ai-sdk/openai": "^3.0.71",
     "@anthropic-ai/claude-agent-sdk": "^0.3.178",
     "@anthropic-ai/claude-code": "2.1.178",
-    "@github/copilot-sdk": "^0.3.0",
+    "@github/copilot-sdk": "^1.0.1",
     "@google/gemini-cli": "^0.46.0",
     "@openai/codex": "^0.140.0",
     "@openai/codex-sdk": "^0.140.0",

--- a/packages/eval/src/runners/copilot/agent.ts
+++ b/packages/eval/src/runners/copilot/agent.ts
@@ -15,19 +15,21 @@
  */
 
 import { join } from 'node:path';
-import { CopilotClient, approveAll } from '@github/copilot-sdk';
-import type { MCPServerConfig } from '@github/copilot-sdk';
+import { CopilotClient, RuntimeConnection, approveAll } from '@github/copilot-sdk';
+import type { MCPServerConfig, ProviderConfig } from '@github/copilot-sdk';
 import type { EvalDefinition, RunRecord, ToolCallRecord, TurnMetric } from '@a0/eval-core';
 import {
   COPILOT_TASK_TIMEOUT_MS,
   MAX_TURNS,
   getFrameworkConfig,
+  getAgentProxyBaseUrl,
   estimateCost,
   logger,
   makeSessionId,
   filteredEnv,
 } from '@a0/eval-core';
 import { classifyActionType, classifyErrorCategory, detectRetry } from '@a0/eval-core';
+import { LLM_API_KEY_ENV } from '../../cli/constants.js';
 import { CopilotCliTranslator } from './translator.js';
 
 const translator = new CopilotCliTranslator();
@@ -112,9 +114,19 @@ export async function runCopilotAgent(
     copilotEnv.GH_TOKEN = process.env.GH_TOKEN;
   }
 
+  // Route inference through the configured LLM proxy via a BYOK provider, just
+  // like the codex runner. The proxy exposes an OpenAI-compatible API under /v1.
+  const proxyBaseUrl = getAgentProxyBaseUrl('copilot');
+  const normalizedBaseUrl = proxyBaseUrl.replace(/\/+$/, '');
+  const proxyApiUrl = normalizedBaseUrl.endsWith('/v1') ? normalizedBaseUrl : `${normalizedBaseUrl}/v1`;
+  const apiKey = process.env[LLM_API_KEY_ENV];
+  if (!apiKey) {
+    logger.warn(`[Copilot] ${LLM_API_KEY_ENV} not set — requests will fail.`);
+  }
+
   const client = new CopilotClient({
-    ...(copilotBin ? { cliPath: copilotBin } : {}),
-    cwd: workspace,
+    ...(copilotBin ? { connection: RuntimeConnection.forStdio({ path: copilotBin }) } : {}),
+    workingDirectory: workspace,
     // useLoggedInUser defaults to true — the Copilot CLI picks up auth from
     // the gh CLI's stored credentials (set via `gh auth login` in CI).
     env: { ...filteredEnv(), ...copilotEnv, ...env },
@@ -122,6 +134,7 @@ export async function runCopilotAgent(
 
   logger.info(`\n[Copilot] Starting task: ${evalDef.id}`);
   logger.info(`[Copilot] Workspace: ${workspace}`);
+  logger.info(`[Copilot] Proxy: ${proxyBaseUrl}`);
   if (model) {
     logger.info(`[Copilot] Model: ${model}`);
   }
@@ -132,6 +145,16 @@ export async function runCopilotAgent(
     model,
     workingDirectory: workspace,
     onPermissionRequest: approveAll,
+    // Route inference through the LLM proxy (OpenAI-compatible BYOK provider).
+    // Use the Responses API: Copilot emits freeform/custom tool calls (e.g.
+    // apply_patch) which the chat-completions API rejects.
+    provider: {
+      type: 'openai',
+      wireApi: 'responses',
+      baseUrl: proxyApiUrl,
+      apiKey,
+      modelId: model,
+    } satisfies ProviderConfig,
     // Suppress ask_user to prevent eval runs from blocking on interactive input.
     excludedTools: ['ask_user'],
     ...(tools.includes('mcp') ? { mcpServers: getMcpServers() } : {}),

--- a/packages/eval/tests/runners/copilot-agent.test.ts
+++ b/packages/eval/tests/runners/copilot-agent.test.ts
@@ -795,6 +795,56 @@ describe('runCopilotAgent — session configuration', () => {
   });
 });
 
+// ── Proxy / BYOK provider ─────────────────────────────────────────────────────
+
+describe('runCopilotAgent — proxy provider', () => {
+  let prevKey: string | undefined;
+
+  beforeEach(() => {
+    prevKey = process.env.LLM_API_KEY;
+  });
+
+  afterEach(() => {
+    if (prevKey === undefined) delete process.env.LLM_API_KEY;
+    else process.env.LLM_API_KEY = prevKey;
+  });
+
+  it('passes an OpenAI-compatible provider pointing at the proxy', async () => {
+    process.env.LLM_API_KEY = 'test-key';
+    fakeSession.setScenario(async () => {});
+    await runCopilotAgent(evalDef, workspace, { model: 'gpt-5.4' });
+    expect(mockCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: expect.objectContaining({
+          type: 'openai',
+          wireApi: 'responses',
+          baseUrl: expect.stringContaining('/v1'),
+          apiKey: 'test-key',
+          modelId: 'gpt-5.4',
+        }),
+      }),
+    );
+  });
+
+  it('does not double-append /v1 when the proxy base URL already ends in /v1', async () => {
+    // TEST_CONFIG.proxy.baseUrl is https://llm.example.com/v1
+    process.env.LLM_API_KEY = 'test-key';
+    fakeSession.setScenario(async () => {});
+    await runCopilotAgent(evalDef, workspace, { model: 'gpt-5.4' });
+    const config = mockCreateSession.mock.calls[0][0];
+    expect(config.provider.baseUrl).toBe('https://llm.example.com/v1');
+  });
+
+  it('still calls createSession when LLM_API_KEY is unset (warns, does not throw)', async () => {
+    delete process.env.LLM_API_KEY;
+    fakeSession.setScenario(async () => {});
+    await runCopilotAgent(evalDef, workspace, { model: 'gpt-5.4' });
+    expect(mockCreateSession).toHaveBeenCalled();
+    const config = mockCreateSession.mock.calls[0][0];
+    expect(config.provider.apiKey).toBeUndefined();
+  });
+});
+
 // ── CopilotCliRunner ──────────────────────────────────────────────────────────
 
 describe('CopilotCliRunner — model routing', () => {


### PR DESCRIPTION
## Summary

Supersedes #25 (the dependabot bump), which only changed the version number and **breaks the build** on its own. This PR bumps `@github/copilot-sdk` 0.3.0 → 1.0.1 *and* makes the Copilot runner work end-to-end.

- **SDK 1.0.1 API migration** — the major version has breaking changes: `cwd` → `workingDirectory`, and `cliPath` → `connection: RuntimeConnection.forStdio({ path })`.
- **Route the Copilot runner through the LLM proxy (BYOK)** — previously the runner authenticated via the logged-in `gh` user and talked to GitHub's Copilot backend, which only serves `auto` / `claude-haiku-4.5` / `gpt-5-mini` — so `gpt-5.4` failed with `session.create failed: Model "gpt-5.4" is not available`. It now uses an OpenAI-compatible BYOK `provider` block pointing at the configured proxy (`agents.copilot.proxy.baseUrl` → top-level `proxy.baseUrl`, normalized to `/v1`, key from `LLM_API_KEY`), mirroring the Codex runner.
- **Responses API** — uses `wireApi: 'responses'` because Copilot emits freeform/custom tool calls (`apply_patch`) that the chat-completions API rejects. This is the same reason the Codex runner uses `wire_api = "responses"`.

Scope is intentionally GPT-only — model routing in `runner.ts` is unchanged.

## Test plan

- [x] `npm run build` — passes
- [x] `npm test` — all 9 packages green (690 in `@a0/eval`, incl. 3 new provider tests)
- [x] `npm run lint` — clean
- [x] End-to-end: `npm run evals -- --eval react_quickstart --mode agent --agent-type copilot --dangerously-skip-sandbox` → **status=success, 6 turns, 12 tool calls, grade=A (96), \$0.2478** through the proxy (no "Model gpt-5.4 is not available", `apply_patch` accepted)

## Notes

Closes the dependabot PR #25 — the version bump is included here.