### PR TITLE
feat(mfa/react): add compile-time check to React MFA eval

### DIFF
--- a/apps/auth0-evals/src/evals/mfa/react/PROMPT.md
+++ b/apps/auth0-evals/src/evals/mfa/react/PROMPT.md
@@ -4,6 +4,7 @@ name: React MFA Step-Up
 scaffold: src/evals/scaffolds/react/auth0
 skills: auth0-mfa
 setup_command: npm install
+compile_command: npm run build
 ---
 
 ## Task

--- a/apps/auth0-evals/src/evals/mfa/react/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/react/graders.ts
@@ -1,4 +1,4 @@
-import { contains, notContains, judge, GraderLevel } from '@a0/eval-graders';
+import { contains, notContains, judge, compiles, GraderLevel } from '@a0/eval-graders';
 
 export function defineGraders() {
   return [
@@ -27,6 +27,7 @@ export function defineGraders() {
     ),
 
     // ── L4: Structural correctness ────────────────────────────────────────
+    compiles('Project compiles (build succeeds)', GraderLevel.L4),
     judge(
       'Does the code check the amr claim before executing the transfer action, and only ' +
         'proceed when "mfa" is present in the amr array?',


### PR DESCRIPTION
## Summary

- Adds `compile_command: npm run build` to `react_mfa` PROMPT.md frontmatter
- Adds a `compiles()` grader at L4 in `graders.ts`, mirroring `react_quickstart`
- Ensures generated MFA code is verified to build after each agent run

## Notes

`vite build` catches import/bundling errors but not type errors — same limitation as the quickstart eval, kept consistent intentionally.

## Test plan

- [ ] `npm run build` passes
- [ ] `npm test` passes with no new failures
- [ ] Linked to SDK-9695