### PR TITLE
feat(eval): add angular MFA step-up eval

### DIFF
--- a/apps/auth0-evals/src/evals/mfa/angular/PROMPT.md
+++ b/apps/auth0-evals/src/evals/mfa/angular/PROMPT.md
@@ -4,6 +4,7 @@ name: Angular MFA Step-Up
 scaffold: src/evals/scaffolds/angular/auth0
 skills: auth0-mfa
 setup_command: npm install
+compile_command: npm run build
 ---
 
 ## Task

--- a/apps/auth0-evals/src/evals/mfa/angular/PROMPT.md
+++ b/apps/auth0-evals/src/evals/mfa/angular/PROMPT.md
@@ -1,0 +1,15 @@
+---
+id: angular_mfa
+name: Angular MFA Step-Up
+scaffold: src/evals/scaffolds/angular/auth0
+skills: auth0-mfa
+setup_command: npm install
+---
+
+## Task
+
+My Angular app has Auth0 login set up. I want to add a Transfer Funds feature where users must complete MFA before the transfer runs. If they haven't done MFA yet, prompt them for it.
+
+Domain: dev-barkbook.us.auth0.com
+Client ID: barkbook_client_abc123xyz
+Audience: https://api.barkbook.com

--- a/apps/auth0-evals/src/evals/mfa/angular/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/angular/graders.ts
@@ -1,4 +1,4 @@
-import { contains, notContains, judge, GraderLevel } from '@a0/eval-graders';
+import { contains, notContains, judge, compiles, GraderLevel } from '@a0/eval-graders';
 
 export function defineGraders() {
   return [
@@ -27,6 +27,7 @@ export function defineGraders() {
     ),
 
     // ── L4: Structural correctness ────────────────────────────────────────
+    compiles('Project compiles (build succeeds)', GraderLevel.L4),
     judge(
       'Does the code subscribe to idTokenClaims$ (or otherwise read the amr claim from the ' +
         'ID token) before executing the transfer action, and only proceed when "mfa" is present ' +

--- a/apps/auth0-evals/src/evals/mfa/angular/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/angular/graders.ts
@@ -1,0 +1,56 @@
+import { contains, notContains, judge, GraderLevel } from '@a0/eval-graders';
+
+export function defineGraders() {
+  return [
+    // ── L1: Required MFA step-up symbols present ───────────────────────────
+    contains('acr_values', 'Step-up request uses acr_values parameter', GraderLevel.L1),
+    contains('amr', 'AMR claim checked to detect prior MFA completion', GraderLevel.L1),
+    contains('idTokenClaims$', 'ID token claims inspected via idTokenClaims$ observable', GraderLevel.L1),
+    contains(
+      'schemas.openid.net/pape/policies/2007/06/multi-factor',
+      'Uses correct multi-factor acr_values policy URI',
+      GraderLevel.L1,
+    ),
+
+    // ── L2: Hallucination / wrong approach ────────────────────────────────
+    notContains('speakeasy', 'No server-side TOTP library (speakeasy) used in client', GraderLevel.L2),
+    notContains('otplib', 'No server-side TOTP library (otplib) used in client', GraderLevel.L2),
+    notContains('@auth0/guardian', 'No fake Guardian client SDK referenced', GraderLevel.L2),
+    notContains('mfa/challenge', 'Does not call raw MFA challenge endpoint (wrong approach for SPAs)', GraderLevel.L2),
+
+    // ── L3: Security ──────────────────────────────────────────────────────
+    judge(
+      'Does the code avoid manually storing Auth0 tokens (access tokens, ID tokens, refresh tokens) ' +
+        'in localStorage or sessionStorage? Storing application state such as a pending transfer ' +
+        'object in sessionStorage is acceptable — only token storage is a violation.',
+      GraderLevel.L3,
+    ),
+
+    // ── L4: Structural correctness ────────────────────────────────────────
+    judge(
+      'Does the code subscribe to idTokenClaims$ (or otherwise read the amr claim from the ' +
+        'ID token) before executing the transfer action, and only proceed when "mfa" is present ' +
+        'in the amr array?',
+      GraderLevel.L4,
+    ),
+
+    // ── L5: Current API patterns ──────────────────────────────────────────
+    judge(
+      'Does the code pass acr_values inside an authorizationParams object rather than ' +
+        'as a top-level property on loginWithRedirect?',
+      GraderLevel.L5,
+    ),
+    judge(
+      'Does the code include max_age: 0 inside authorizationParams when requesting MFA ' +
+        'step-up, to force re-authentication rather than reusing a cached session?',
+      GraderLevel.L5,
+    ),
+
+    // ── Holistic judge (no level — always runs) ───────────────────────────
+    judge(
+      'Does the solution correctly implement MFA step-up authentication in an Angular app — ' +
+        'checking the amr claim via idTokenClaims$, requesting step-up via acr_values when ' +
+        'MFA is not present, and gating the Transfer Funds action behind MFA verification?',
+    ),
+  ];
+}

--- a/apps/auth0-evals/src/evals/scaffolds/angular/auth0/angular.json
+++ b/apps/auth0-evals/src/evals/scaffolds/angular/auth0/angular.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "newProjectRoot": "projects",
+  "projects": {
+    "barkbook": {
+      "projectType": "application",
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular/build:application",
+          "options": {
+            "outputPath": "dist/barkbook",
+            "index": "index.html",
+            "browser": "src/main.ts",
+            "tsConfig": "tsconfig.app.json"
+          }
+        },
+        "serve": {
+          "builder": "@angular/build:dev-server",
+          "configurations": {
+            "development": {
+              "buildTarget": "barkbook:build"
+            }
+          },
+          "defaultConfiguration": "development"
+        }
+      }
+    }
+  },
+  "cli": {
+    "analytics": false
+  }
+}

--- a/apps/auth0-evals/src/evals/scaffolds/angular/auth0/index.html
+++ b/apps/auth0-evals/src/evals/scaffolds/angular/auth0/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Barkbook</title>
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <app-root></app-root>
+  </body>
+</html>

--- a/apps/auth0-evals/src/evals/scaffolds/angular/auth0/package.json
+++ b/apps/auth0-evals/src/evals/scaffolds/angular/auth0/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "barkbook",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "ng": "ng",
+    "build": "ng build"
+  },
+  "dependencies": {
+    "@angular/animations": "^21.0.0",
+    "@angular/common": "^21.0.0",
+    "@angular/compiler": "^21.0.0",
+    "@angular/core": "^21.0.0",
+    "@angular/forms": "^21.0.0",
+    "@angular/platform-browser": "^21.0.0",
+    "@angular/platform-browser-dynamic": "^21.0.0",
+    "@angular/router": "^21.0.0",
+    "@auth0/auth0-angular": "^2.9.0",
+    "rxjs": "~7.8.0",
+    "tslib": "^2.3.0",
+    "zone.js": "~0.16.0"
+  },
+  "devDependencies": {
+    "@angular/build": "^21.0.0",
+    "@angular/cli": "^21.0.0",
+    "@angular/compiler-cli": "^21.0.0",
+    "typescript": "~5.9.0"
+  }
+}

--- a/apps/auth0-evals/src/evals/scaffolds/angular/auth0/src/app/app.component.ts
+++ b/apps/auth0-evals/src/evals/scaffolds/angular/auth0/src/app/app.component.ts
@@ -1,0 +1,114 @@
+import { AsyncPipe } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { RouterOutlet, RouterLink } from '@angular/router';
+import { AuthService } from '@auth0/auth0-angular';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [AsyncPipe, RouterOutlet, RouterLink],
+  template: `
+    <nav class="shell-nav">
+      <div class="shell-links">
+        <a routerLink="/">Home</a>
+        <a routerLink="/profile">Profile</a>
+      </div>
+
+      <div class="shell-auth">
+        @if (user$ | async; as user) {
+          <div class="user-chip">
+            @if (user.picture; as picture) {
+              <img [src]="picture" [alt]="(user.name || 'User') + ' avatar'" />
+            }
+            <span>{{ user.name || user.nickname || user.email }}</span>
+          </div>
+        }
+
+        @if (isAuthenticated$ | async) {
+          <button type="button" (click)="logout()">Log out</button>
+        } @else {
+          <button type="button" (click)="login()">Log in</button>
+        }
+      </div>
+    </nav>
+
+    <router-outlet />
+  `,
+  styles: `
+    :host {
+      display: block;
+      font-family: Arial, sans-serif;
+      color: #172033;
+    }
+
+    .shell-nav {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      padding: 1rem 1.5rem;
+      border-bottom: 1px solid #d9e2f2;
+      background: #f7f9fc;
+    }
+
+    .shell-links,
+    .shell-auth {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .shell-links a {
+      color: #1142a6;
+      text-decoration: none;
+      font-weight: 600;
+    }
+
+    .user-chip {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.35rem 0.75rem;
+      border-radius: 999px;
+      background: #e9f0ff;
+    }
+
+    .user-chip img {
+      width: 2rem;
+      height: 2rem;
+      border-radius: 50%;
+      object-fit: cover;
+    }
+
+    button {
+      border: 0;
+      border-radius: 999px;
+      padding: 0.65rem 1rem;
+      background: #1142a6;
+      color: #fff;
+      font-weight: 600;
+      cursor: pointer;
+    }
+  `,
+})
+export class AppComponent {
+  private readonly auth = inject(AuthService);
+
+  protected readonly isAuthenticated$ = this.auth.isAuthenticated$;
+  protected readonly user$ = this.auth.user$;
+
+  protected login(): void {
+    void firstValueFrom(this.auth.loginWithRedirect());
+  }
+
+  protected logout(): void {
+    void firstValueFrom(
+      this.auth.logout({
+        logoutParams: {
+          returnTo: window.location.origin,
+        },
+      }),
+    );
+  }
+}

--- a/apps/auth0-evals/src/evals/scaffolds/angular/auth0/src/app/app.config.ts
+++ b/apps/auth0-evals/src/evals/scaffolds/angular/auth0/src/app/app.config.ts
@@ -1,0 +1,22 @@
+import { provideHttpClient } from '@angular/common/http';
+import { ApplicationConfig } from '@angular/core';
+import { provideRouter } from '@angular/router';
+import { provideAuth0 } from '@auth0/auth0-angular';
+
+import { routes } from './app.routes';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideRouter(routes),
+    provideHttpClient(),
+    provideAuth0({
+      domain: 'dev-barkbook.us.auth0.com',
+      clientId: 'barkbook_client_abc123xyz',
+      authorizationParams: {
+        redirect_uri: window.location.origin,
+        audience: 'https://api.barkbook.com',
+        scope: 'openid profile email',
+      },
+    }),
+  ],
+};

--- a/apps/auth0-evals/src/evals/scaffolds/angular/auth0/src/app/app.routes.ts
+++ b/apps/auth0-evals/src/evals/scaffolds/angular/auth0/src/app/app.routes.ts
@@ -1,0 +1,9 @@
+import { Routes } from '@angular/router';
+import { authGuardFn } from '@auth0/auth0-angular';
+import { HomeComponent } from './pages/home/home.component';
+import { ProfileComponent } from './pages/profile/profile.component';
+
+export const routes: Routes = [
+  { path: '', component: HomeComponent },
+  { path: 'profile', component: ProfileComponent, canActivate: [authGuardFn] },
+];

--- a/apps/auth0-evals/src/evals/scaffolds/angular/auth0/src/app/pages/home/home.component.ts
+++ b/apps/auth0-evals/src/evals/scaffolds/angular/auth0/src/app/pages/home/home.component.ts
@@ -1,0 +1,140 @@
+import { AsyncPipe } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { AuthService } from '@auth0/auth0-angular';
+import { ExternalApiService } from '../../services/external-api.service';
+
+@Component({
+  selector: 'app-home',
+  standalone: true,
+  imports: [AsyncPipe],
+  template: `
+    <main class="page">
+      <h1>Barkbook</h1>
+      <p>Auth0 is configured with redirect login, route protection, and an API access token flow.</p>
+
+      <section class="panel">
+        <h2>Session</h2>
+        <p>
+          Status:
+          <strong>{{ (isAuthenticated$ | async) ? 'Authenticated' : 'Signed out' }}</strong>
+        </p>
+
+        @if (isAuthenticated$ | async) {
+          <div class="actions">
+            <button type="button" (click)="loadAccessToken()">Get Access Token</button>
+            <button type="button" (click)="callApi()">Call External API</button>
+          </div>
+        } @else {
+          <p>Log in to request an access token and call the external API.</p>
+        }
+      </section>
+
+      @if (accessToken) {
+        <section class="panel">
+          <h2>Access Token</h2>
+          <pre>{{ accessToken }}</pre>
+        </section>
+      }
+
+      @if (apiResponse) {
+        <section class="panel">
+          <h2>API Response</h2>
+          <pre>{{ apiResponse }}</pre>
+        </section>
+      }
+
+      @if (errorMessage) {
+        <section class="panel error">
+          <h2>Request Error</h2>
+          <pre>{{ errorMessage }}</pre>
+        </section>
+      }
+    </main>
+  `,
+  styles: `
+    .page {
+      max-width: 56rem;
+      margin: 0 auto;
+      padding: 2rem 1.5rem 3rem;
+      display: grid;
+      gap: 1rem;
+    }
+
+    .panel {
+      padding: 1.25rem;
+      border: 1px solid #d9e2f2;
+      border-radius: 1rem;
+      background: #fff;
+    }
+
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      margin-top: 1rem;
+    }
+
+    button {
+      border: 0;
+      border-radius: 999px;
+      padding: 0.65rem 1rem;
+      background: #1142a6;
+      color: #fff;
+      font-weight: 600;
+      cursor: pointer;
+    }
+
+    pre {
+      margin: 0;
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+    }
+
+    .error {
+      border-color: #f1b6b6;
+      background: #fff6f6;
+    }
+  `,
+})
+export class HomeComponent {
+  private readonly auth = inject(AuthService);
+  private readonly externalApi = inject(ExternalApiService);
+
+  protected readonly isAuthenticated$ = this.auth.isAuthenticated$;
+
+  protected accessToken = '';
+  protected apiResponse = '';
+  protected errorMessage = '';
+
+  protected async loadAccessToken(): Promise<void> {
+    this.errorMessage = '';
+
+    try {
+      this.accessToken = await firstValueFrom(this.externalApi.getAccessToken());
+    } catch (error) {
+      this.accessToken = '';
+      this.errorMessage = this.getErrorMessage(error);
+    }
+  }
+
+  protected async callApi(): Promise<void> {
+    this.errorMessage = '';
+
+    try {
+      const response = await firstValueFrom(this.externalApi.callExternalApi());
+      this.apiResponse = JSON.stringify(response, null, 2);
+    } catch (error) {
+      this.apiResponse = '';
+      this.errorMessage = this.getErrorMessage(error);
+    }
+  }
+
+  private getErrorMessage(error: unknown): string {
+    if (error instanceof Error) {
+      return error.message;
+    }
+
+    return 'The request failed.';
+  }
+}

--- a/apps/auth0-evals/src/evals/scaffolds/angular/auth0/src/app/pages/profile/profile.component.ts
+++ b/apps/auth0-evals/src/evals/scaffolds/angular/auth0/src/app/pages/profile/profile.component.ts
@@ -1,0 +1,61 @@
+import { AsyncPipe } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { AuthService } from '@auth0/auth0-angular';
+
+@Component({
+  selector: 'app-profile',
+  standalone: true,
+  imports: [AsyncPipe],
+  template: `
+    <main class="page">
+      <h1>Profile</h1>
+
+      @if (user$ | async; as user) {
+        <section class="card">
+          @if (user.picture; as picture) {
+            <img [src]="picture" [alt]="(user.name || 'User') + ' avatar'" />
+          }
+
+          <div>
+            <h2>{{ user.name || user.nickname || 'Authenticated User' }}</h2>
+            <p>{{ user.email || 'No email claim available' }}</p>
+          </div>
+        </section>
+      }
+    </main>
+  `,
+  styles: `
+    .page {
+      max-width: 48rem;
+      margin: 0 auto;
+      padding: 2rem 1.5rem 3rem;
+    }
+
+    .card {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      padding: 1.25rem;
+      border: 1px solid #d9e2f2;
+      border-radius: 1rem;
+      background: #fff;
+    }
+
+    img {
+      width: 4.5rem;
+      height: 4.5rem;
+      border-radius: 50%;
+      object-fit: cover;
+    }
+
+    h2,
+    p {
+      margin: 0;
+    }
+  `,
+})
+export class ProfileComponent {
+  private readonly auth = inject(AuthService);
+
+  protected readonly user$ = this.auth.user$;
+}

--- a/apps/auth0-evals/src/evals/scaffolds/angular/auth0/src/app/services/external-api.service.ts
+++ b/apps/auth0-evals/src/evals/scaffolds/angular/auth0/src/app/services/external-api.service.ts
@@ -1,0 +1,37 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { AuthService } from '@auth0/auth0-angular';
+import { switchMap } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ExternalApiService {
+  private readonly auth = inject(AuthService);
+  private readonly http = inject(HttpClient);
+
+  private readonly apiAudience = 'https://api.barkbook.com';
+  private readonly apiBaseUrl = 'https://api.barkbook.com';
+
+  getAccessToken() {
+    return this.auth.getAccessTokenSilently({
+      authorizationParams: {
+        audience: this.apiAudience,
+      },
+    });
+  }
+
+  callExternalApi(path = '/demo') {
+    const url = `${this.apiBaseUrl}${path.startsWith('/') ? path : `/${path}`}`;
+
+    return this.getAccessToken().pipe(
+      switchMap((token) =>
+        this.http.get<unknown>(url, {
+          headers: new HttpHeaders({
+            Authorization: `Bearer ${token}`,
+          }),
+        }),
+      ),
+    );
+  }
+}

--- a/apps/auth0-evals/src/evals/scaffolds/angular/auth0/src/main.ts
+++ b/apps/auth0-evals/src/evals/scaffolds/angular/auth0/src/main.ts
@@ -1,0 +1,5 @@
+import { bootstrapApplication } from '@angular/platform-browser';
+import { appConfig } from './app/app.config';
+import { AppComponent } from './app/app.component';
+
+bootstrapApplication(AppComponent, appConfig).catch((err) => console.error(err));

--- a/apps/auth0-evals/src/evals/scaffolds/angular/auth0/tsconfig.app.json
+++ b/apps/auth0-evals/src/evals/scaffolds/angular/auth0/tsconfig.app.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/app"
+  },
+  "files": ["src/main.ts"],
+  "include": ["src/**/*.d.ts"]
+}

--- a/apps/auth0-evals/src/evals/scaffolds/angular/auth0/tsconfig.json
+++ b/apps/auth0-evals/src/evals/scaffolds/angular/auth0/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "outDir": "./dist/out-tsc",
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "sourceMap": true,
+    "declaration": false,
+    "downlevelIteration": true,
+    "experimentalDecorators": true,
+    "moduleResolution": "bundler",
+    "importHelpers": true,
+    "target": "ES2022",
+    "module": "ES2022",
+    "lib": ["ES2022", "dom"],
+    "skipLibCheck": true
+  },
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/apps/auth0-evals/tsconfig.json
+++ b/apps/auth0-evals/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist", "src/**/scaffold"]
+  "exclude": ["node_modules", "dist", "src/**/scaffold", "src/evals/scaffolds"]
 }


### PR DESCRIPTION
## Summary

- Adds `angular_mfa` eval with `PROMPT.md` and `graders.ts` (L1–L5 graders + holistic judge)
- Adds a shared Angular scaffold at `src/evals/scaffolds/angular/auth0/` with `@auth0/auth0-angular` pre-configured
- Excludes the new `scaffolds/` directory from `tsconfig.json` compilation

## Test results

| Configuration | Grade | Correctness |
|---|---|---|
| `agent` (no skills) | B (80–81) | F (33%) — model uses error-reactive flow, omits `acr_values` |
| `agent+skills` | **A (97.7)** | **A (100%)** — all 11 graders pass |

The `auth0-mfa` skill steers the model from an error-reactive MFA flow to the proactive `acr_values` + policy URI step-up pattern.