### PR TITLE
fix(compile): auto-run npm install before compile_command

### DIFF
--- a/packages/eval-core/src/workspace/workspace.ts
+++ b/packages/eval-core/src/workspace/workspace.ts
@@ -99,6 +99,8 @@ export interface RunSetupCommandOptions {
 export interface RunCompileCommandOptions {
   /** Timeout in ms for the compile command. Defaults to {@link DEFAULT_FRAMEWORK_CONFIG}.workspace.compileCommandTimeoutMs. */
   timeoutMs?: number;
+  /** When provided, this command is prepended to the compile command sequence (e.g. the eval's setup_command to ensure deps are installed). */
+  setupCommand?: string;
 }
 
 /**
@@ -191,10 +193,8 @@ export function runCompileCommand(
     return { ...base, output: `compile command has an empty segment: ${command}` };
   }
 
-  // Auto-install dependencies before building so new packages the agent added
-  // to package.json are available even if the agent never ran npm install itself.
-  if (existsSync(join(workspace, 'package.json'))) {
-    subCommands.unshift('npm install');
+  if (options?.setupCommand) {
+    subCommands.unshift(options.setupCommand);
   }
 
   let combinedOutput = '';

--- a/packages/eval-core/src/workspace/workspace.ts
+++ b/packages/eval-core/src/workspace/workspace.ts
@@ -193,6 +193,9 @@ export function runCompileCommand(
     return { ...base, output: `compile command has an empty segment: ${command}` };
   }
 
+  // When a setupCommand is provided, we ensure to run it before verifying compilation.
+  // This is done because there is no guarantee that an agent did not add a dependency
+  // without running the installation command.
   if (options?.setupCommand) {
     subCommands.unshift(options.setupCommand);
   }

--- a/packages/eval-core/src/workspace/workspace.ts
+++ b/packages/eval-core/src/workspace/workspace.ts
@@ -191,6 +191,12 @@ export function runCompileCommand(
     return { ...base, output: `compile command has an empty segment: ${command}` };
   }
 
+  // Auto-install dependencies before building so new packages the agent added
+  // to package.json are available even if the agent never ran npm install itself.
+  if (existsSync(join(workspace, 'package.json'))) {
+    subCommands.unshift('npm install');
+  }
+
   let combinedOutput = '';
   for (const subCommand of subCommands) {
     logger.info(`  [Compile] Running: ${subCommand}`);

--- a/packages/eval-core/tests/workspace-commands.test.ts
+++ b/packages/eval-core/tests/workspace-commands.test.ts
@@ -186,23 +186,18 @@ describe('runCompileCommand', () => {
     expect(res.ok).toBe(false);
   });
 
-  it('prepends npm install when package.json exists', () => {
+  it('prepends setupCommand when provided', () => {
     const dir = tmpDir();
-    writeFileSync(join(dir, 'package.json'), '{"name":"test"}');
-    // Use a command that creates a sentinel file — if npm install ran first the
-    // subcommand sequence will be: npm install && touch built.txt
-    const res = runCompileCommand(dir, 'touch built.txt');
+    const sentinel = join(dir, 'setup_ran.txt');
+    const res = runCompileCommand(dir, 'true', { setupCommand: `touch ${sentinel}` });
     expect(res.ok).toBe(true);
-    expect(existsSync(join(dir, 'built.txt'))).toBe(true);
+    expect(existsSync(sentinel)).toBe(true);
   });
 
-  it('does not prepend npm install when package.json is absent', () => {
+  it('does not prepend any command when setupCommand is absent', () => {
     const dir = tmpDir();
-    // Capture output to confirm npm install was NOT injected — use a command
-    // that echoes its own name so we can check the log
-    const res = runCompileCommand(dir, 'true');
+    const res = runCompileCommand(dir, 'echo hello-compile');
     expect(res.ok).toBe(true);
-    // output should not mention npm install
-    expect(res.output).not.toContain('npm install');
+    expect(res.output).toContain('hello-compile');
   });
 });

--- a/packages/eval-core/tests/workspace-commands.test.ts
+++ b/packages/eval-core/tests/workspace-commands.test.ts
@@ -185,4 +185,24 @@ describe('runCompileCommand', () => {
     const res = runCompileCommand(dir, '');
     expect(res.ok).toBe(false);
   });
+
+  it('prepends npm install when package.json exists', () => {
+    const dir = tmpDir();
+    writeFileSync(join(dir, 'package.json'), '{"name":"test"}');
+    // Use a command that creates a sentinel file — if npm install ran first the
+    // subcommand sequence will be: npm install && touch built.txt
+    const res = runCompileCommand(dir, 'touch built.txt');
+    expect(res.ok).toBe(true);
+    expect(existsSync(join(dir, 'built.txt'))).toBe(true);
+  });
+
+  it('does not prepend npm install when package.json is absent', () => {
+    const dir = tmpDir();
+    // Capture output to confirm npm install was NOT injected — use a command
+    // that echoes its own name so we can check the log
+    const res = runCompileCommand(dir, 'true');
+    expect(res.ok).toBe(true);
+    // output should not mention npm install
+    expect(res.output).not.toContain('npm install');
+  });
 });

--- a/packages/eval/src/cli/run.ts
+++ b/packages/eval/src/cli/run.ts
@@ -163,7 +163,9 @@ async function runAgentJob(
     const { record, resolvedModel } = await runner.run({ evalDef: preparedEval, workspace, model, tools, apiKey });
 
     const compileResult =
-      evalDef.compileCommand !== undefined ? runCompileCommand(workspace, evalDef.compileCommand) : undefined;
+      evalDef.compileCommand !== undefined
+        ? runCompileCommand(workspace, evalDef.compileCommand, { setupCommand: evalDef.setupCommand })
+        : undefined;
 
     let graderResults: Awaited<ReturnType<typeof runGraders>> = [];
     if (evalDef.graders.length > 0) {

--- a/packages/eval/src/cli/sandbox-runner.ts
+++ b/packages/eval/src/cli/sandbox-runner.ts
@@ -110,7 +110,9 @@ async function main(): Promise<void> {
     const { record, resolvedModel } = await runner.run({ evalDef: preparedEval, workspace, model, tools, apiKey });
 
     const compileResult =
-      evalDef.compileCommand !== undefined ? runCompileCommand(workspace, evalDef.compileCommand) : undefined;
+      evalDef.compileCommand !== undefined
+        ? runCompileCommand(workspace, evalDef.compileCommand, { setupCommand: evalDef.setupCommand })
+        : undefined;
 
     let graderResults: Awaited<ReturnType<typeof runGraders>> = [];
     if (evalDef.graders.length > 0) {


### PR DESCRIPTION
## Summary

- `runCompileCommand` now prepends `npm install` before the eval's `compile_command` whenever a `package.json` exists in the workspace
- Fixes builds failing with "module not found" when the agent added new dependencies to `package.json` but never ran `npm install` itself
- Two new tests: one verifying auto-install is prepended with a `package.json` present, one verifying it's skipped when absent

## Test plan

- [ ] `npm run build && npm test` passes
- [ ] Run an eval where the agent adds a new dep to `package.json` without running `npm install` — `compiles` grader should now pass