### PR TITLE
feat(eval): add spa-js DPoP token binding eval

### DIFF
--- a/apps/auth0-evals/src/evals/dpop/spa-js/PROMPT.md
+++ b/apps/auth0-evals/src/evals/dpop/spa-js/PROMPT.md
@@ -1,0 +1,16 @@
+---
+id: spa_js_dpop
+name: SPA JS DPoP Token Binding
+scaffold: src/evals/scaffolds/spa-js/auth0
+skills: auth0-dpop
+setup_command: npm install
+compile_command: npm run build
+---
+
+## Task
+
+My vanilla JavaScript SPA uses @auth0/auth0-spa-js for authentication. I want to add DPoP token binding so my API calls are protected against token replay attacks.
+
+Domain: dev-barkbook.us.auth0.com
+Client ID: barkbook_client_abc123xyz
+Audience: https://api.barkbook.com

--- a/apps/auth0-evals/src/evals/dpop/spa-js/graders.ts
+++ b/apps/auth0-evals/src/evals/dpop/spa-js/graders.ts
@@ -6,6 +6,7 @@ export function defineGraders() {
     contains('@auth0/auth0-spa-js', 'Uses @auth0/auth0-spa-js SDK', GraderLevel.L1),
     contains('useDpop', 'Enables useDpop option on Auth0 client', GraderLevel.L1),
     contains('createFetcher', 'Uses createFetcher to get a DPoP-aware fetcher', GraderLevel.L1),
+    contains('UseDpopNonceError', 'UseDpopNonceError imported and referenced', GraderLevel.L1),
 
     // ── L2: Hallucination / wrong SDK ─────────────────────────────────
     notContains('@auth0/auth0-react', 'No React SDK in vanilla JS app', GraderLevel.L2),
@@ -25,6 +26,13 @@ export function defineGraders() {
         'The fetcher (however the variable is named) automatically sends Authorization: DPoP <token> ' +
         'plus a DPoP proof header. A manual fetch using only getTokenSilently() with ' +
         'Authorization: Bearer would lack the DPoP proof and be rejected by the server.',
+      GraderLevel.L4,
+    ),
+    judge(
+      'Does the code catch UseDpopNonceError and retry the API request at least once? ' +
+        'When a DPoP nonce is rotated by the server the SDK throws UseDpopNonceError; ' +
+        'the correct pattern is to catch it and immediately retry the same request — ' +
+        'the SDK will have stored the new nonce automatically.',
       GraderLevel.L4,
     ),
 

--- a/apps/auth0-evals/src/evals/dpop/spa-js/graders.ts
+++ b/apps/auth0-evals/src/evals/dpop/spa-js/graders.ts
@@ -1,0 +1,50 @@
+import { contains, notContains, matches, judge, compiles, GraderLevel } from '@a0/eval-graders';
+
+export function defineGraders() {
+  return [
+    // ── L1: Positive presence ──────────────────────────────────────────
+    contains('@auth0/auth0-spa-js', 'Uses @auth0/auth0-spa-js SDK', GraderLevel.L1),
+    contains('useDpop', 'Enables useDpop option on Auth0 client', GraderLevel.L1),
+    contains('createFetcher', 'Uses createFetcher to get a DPoP-aware fetcher', GraderLevel.L1),
+
+    // ── L2: Hallucination / wrong SDK ─────────────────────────────────
+    notContains('@auth0/auth0-react', 'No React SDK in vanilla JS app', GraderLevel.L2),
+    notContains('client_secret', 'No client_secret in SPA (public client)', GraderLevel.L2),
+    notContains('crypto.subtle', 'No manual DPoP key generation — SDK manages the key pair internally', GraderLevel.L2),
+
+    // ── L3: Security checks ───────────────────────────────────────────
+    notContains('localStorage.setItem', 'No tokens manually stored in localStorage', GraderLevel.L3),
+    notContains('sessionStorage.setItem', 'No tokens manually stored in sessionStorage', GraderLevel.L3),
+
+    // ── L4: Structural / behavioral correctness ───────────────────────
+    compiles('Project compiles with DPoP configuration', GraderLevel.L4),
+    matches(String.raw`useDpop\s*:\s*true`, 'useDpop: true set on Auth0 client', GraderLevel.L4),
+    matches(String.raw`createFetcher\s*\(`, 'createFetcher called on Auth0 client', GraderLevel.L4),
+    judge(
+      'Does the code use the fetcher returned by auth0Client.createFetcher() to make the API request? ' +
+        'The fetcher (however the variable is named) automatically sends Authorization: DPoP <token> ' +
+        'plus a DPoP proof header. A manual fetch using only getTokenSilently() with ' +
+        'Authorization: Bearer would lack the DPoP proof and be rejected by the server.',
+      GraderLevel.L4,
+    ),
+
+    // ── L5: Version-specific API correctness ──────────────────────────
+    contains(
+      'authorizationParams',
+      'Uses authorizationParams (current v2 API, not deprecated top-level options)',
+      GraderLevel.L5,
+    ),
+    judge(
+      'Does the solution use the SDK-provided DPoP fetcher (auth0Client.createFetcher()) ' +
+        'rather than manually constructing DPoP proofs using WebCrypto, jose, or any third-party library?',
+      GraderLevel.L5,
+    ),
+
+    // ── Holistic judge ────────────────────────────────────────────────
+    judge(
+      'Does the solution correctly add DPoP token binding to the vanilla JavaScript SPA using @auth0/auth0-spa-js, ' +
+        'with useDpop: true on the Auth0 client and auth0Client.createFetcher() used to obtain a DPoP-aware fetcher ' +
+        'that automatically sends Authorization: DPoP and the DPoP proof header on API calls?',
+    ),
+  ];
+}

--- a/apps/auth0-evals/src/evals/scaffolds/spa-js/auth0/index.html
+++ b/apps/auth0-evals/src/evals/scaffolds/spa-js/auth0/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>My App</title>
+  </head>
+  <body>
+    <h1>My App</h1>
+
+    <div id="login-section">
+      <button id="login-btn">Log In</button>
+    </div>
+
+    <div id="profile-section" style="display: none">
+      <p id="user-name"></p>
+      <p id="user-email"></p>
+      <button id="logout-btn">Log Out</button>
+      <button id="call-api-btn">Call API</button>
+    </div>
+
+    <script type="module" src="/src/app.js"></script>
+  </body>
+</html>

--- a/apps/auth0-evals/src/evals/scaffolds/spa-js/auth0/package.json
+++ b/apps/auth0-evals/src/evals/scaffolds/spa-js/auth0/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "spa-js-app",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@auth0/auth0-spa-js": "^2.0.0"
+  },
+  "devDependencies": {
+    "vite": "^6.0.0"
+  }
+}

--- a/apps/auth0-evals/src/evals/scaffolds/spa-js/auth0/src/app.js
+++ b/apps/auth0-evals/src/evals/scaffolds/spa-js/auth0/src/app.js
@@ -1,0 +1,80 @@
+import { createAuth0Client } from '@auth0/auth0-spa-js';
+
+const domain = 'dev-barkbook.us.auth0.com';
+const clientId = 'barkbook_client_abc123xyz';
+const audience = 'https://api.barkbook.com';
+
+let auth0Client = null;
+
+async function initAuth0() {
+  auth0Client = await createAuth0Client({
+    domain,
+    clientId,
+    authorizationParams: {
+      audience,
+    },
+  });
+
+  const query = window.location.search;
+  if (query.includes('code=') && query.includes('state=')) {
+    await auth0Client.handleRedirectCallback();
+    window.history.replaceState({}, document.title, window.location.pathname);
+  }
+
+  await updateUI();
+}
+
+async function updateUI() {
+  const isAuthenticated = await auth0Client.isAuthenticated();
+
+  const loginSection = document.getElementById('login-section');
+  const profileSection = document.getElementById('profile-section');
+
+  if (isAuthenticated) {
+    const user = await auth0Client.getUser();
+    document.getElementById('user-name').textContent = `Name: ${user.name}`;
+    document.getElementById('user-email').textContent = `Email: ${user.email}`;
+    loginSection.style.display = 'none';
+    profileSection.style.display = 'block';
+  } else {
+    loginSection.style.display = 'block';
+    profileSection.style.display = 'none';
+  }
+}
+
+async function fetchApiData() {
+  const accessToken = await auth0Client.getTokenSilently({
+    authorizationParams: { audience },
+  });
+
+  const response = await fetch('https://api.barkbook.com/data', {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  if (!response.ok) {
+    throw new Error(`API request failed: ${response.status} ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+document.getElementById('login-btn').addEventListener('click', async () => {
+  await auth0Client.loginWithRedirect({
+    authorizationParams: { redirect_uri: window.location.origin },
+  });
+});
+
+document.getElementById('logout-btn').addEventListener('click', () => {
+  auth0Client.logout({ logoutParams: { returnTo: window.location.origin } });
+});
+
+document.getElementById('call-api-btn').addEventListener('click', async () => {
+  try {
+    const data = await fetchApiData();
+    console.log('API response:', data);
+  } catch (err) {
+    console.error('API call failed:', err);
+  }
+});
+
+initAuth0();

--- a/apps/auth0-evals/src/evals/scaffolds/spa-js/auth0/vite.config.js
+++ b/apps/auth0-evals/src/evals/scaffolds/spa-js/auth0/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    target: 'esnext',
+  },
+});


### PR DESCRIPTION
## Summary

- Adds a new `dpop/spa-js` eval that measures how well agents add DPoP token binding to a vanilla JS SPA using `@auth0/auth0-spa-js`
- Adds `scaffolds/spa-js/auth0` — a working Auth0 SPA scaffold (generated from the `spa_js_quickstart` eval) that agents build on top of
- Graders cover `useDpop: true` config, `createFetcher`/`fetchWithAuth` usage, no manual crypto, and correct `Authorization: DPoP` header behaviour

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes
- [x] `npm run evals -- --eval spa_js_dpop --mode baseline` runs and scores graders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new SPA evaluation setup for Auth0 with a basic login, profile, and API-calling experience.
  * Included support for DPoP token binding checks in the evaluation flow.
  * Added project setup and build configuration for running the SPA locally.

* **Bug Fixes**
  * Improved handling of authentication redirects and cleaned up the URL after login.
  * Added safer API request handling with error reporting for failed responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->