### PR TITLE
fix(graders): insert untrusted code verbatim in judge prompt

### DIFF
--- a/packages/eval-core/src/graders/llm-judge.ts
+++ b/packages/eval-core/src/graders/llm-judge.ts
@@ -58,7 +58,10 @@ export async function llmJudge(opts: LlmJudgeOptions): Promise<LlmJudgeResult> {
     }
     logger.warn(`[judge] Code corpus exceeds limit (${code.length} > ${judgeMaxCodeChars} chars) — proceeding anyway`);
   }
-  const user = USER_TEMPLATE.replace('{question}', question).replace('{code}', code);
+  // Use function replacers so `question`/`code` are inserted verbatim. A string
+  // replacement would interpret `$&`, `` $` ``, `$'`, and `$1` specially, and
+  // since `code` is untrusted agent output this would silently corrupt the prompt.
+  const user = USER_TEMPLATE.replace('{question}', () => question).replace('{code}', () => code);
 
   // The judge hits the /chat/completions endpoint, which serves models under
   // their plain alias, so the model is sent as-is (no Bedrock ID mapping).

--- a/packages/eval-core/tests/graders/engine.test.ts
+++ b/packages/eval-core/tests/graders/engine.test.ts
@@ -723,6 +723,33 @@ describe('llmJudge - code corpus overflow', () => {
     });
     expect(passed).toBe(true);
   });
+
+  it('inserts untrusted code verbatim even when it contains $-substitution sequences', async () => {
+    // Regression: String.prototype.replace with a string pattern treats `$&`,
+    // `` $` ``, `$'`, and `$1` in the replacement specially. Since `code` is
+    // untrusted agent output, those sequences would silently corrupt the judge
+    // prompt (e.g. `$&` expands to the matched `{code}`).
+    let capturedBody: Record<string, unknown> | undefined;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (_url: string, opts: RequestInit) => {
+        capturedBody = JSON.parse(opts.body as string) as Record<string, unknown>;
+        return { ok: true, json: async () => ({ choices: [{ message: { content: 'yes' } }] }) };
+      }),
+    );
+    const trickyCode = 'const re = /a/; s.replace(re, "$& and $1 and $` and $\'");';
+    await llmJudge({
+      question: 'Is the $& handling correct?',
+      code: trickyCode,
+      apiKey: 'key',
+      model: 'model',
+      baseUrl: 'http://test',
+    });
+    const messages = capturedBody?.messages as { role: string; content: string }[];
+    const userMessage = messages.find((mm) => mm.role === 'user')!.content;
+    expect(userMessage).toContain(trickyCode);
+    expect(userMessage).toContain('Is the $& handling correct?');
+  });
 });
 
 // ── llmJudge — enforceMaxChars=false (non-enforcing path) ───────────────────


### PR DESCRIPTION
## Summary

The LLM judge built its user prompt with `String.prototype.replace('{code}', code)` using a **string** replacement. String replacements interpret `$&`, `` $` ``, `$'`, and `$1`..`$n` as special substitution patterns. Since `code` is untrusted agent output, any such sequence in the generated code would silently corrupt the judge prompt (e.g. `$&` expands to the matched `{code}` placeholder rather than being inserted literally).

This switches both `{question}` and `{code}` interpolations to **function replacers** (`() => value`), which insert the value verbatim with no pattern interpretation.

## Changes

- `packages/eval-core/src/graders/llm-judge.ts` — use function replacers so `question`/`code` are inserted verbatim.
- `packages/eval-core/tests/graders/engine.test.ts` — regression test asserting code containing `$&`, `$1`, `` $` ``, and `$'` reaches the judge prompt unmodified.

## Test plan

- [x] `npm test` (eval-core grader tests, including the new regression test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prompt construction to safely include user-provided question and code text without accidental text substitution.
  * Prevented special `$`-style sequences from being altered when generating judge prompts.

* **Tests**
  * Added a regression test to verify the full code snippet and question are preserved exactly in the request payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->