### PR TITLE
fix(config): surface the underlying cause when config loading fails

### DIFF
--- a/packages/eval-core/src/config/loader.ts
+++ b/packages/eval-core/src/config/loader.ts
@@ -102,7 +102,7 @@ async function importConfigFile(filePath: string): Promise<Partial<FrameworkConf
   } catch (error) {
     if (error instanceof EvalConfigError) throw error;
     const message = error instanceof Error ? error.message : String(error);
-    throw new EvalConfigError(`Failed to load config`, filePath);
+    throw new EvalConfigError(`Failed to load config: ${message}`, filePath);
   }
 }
 

--- a/packages/eval-core/tests/config/loader.test.ts
+++ b/packages/eval-core/tests/config/loader.test.ts
@@ -99,6 +99,15 @@ describe('loadConfig', () => {
     );
   });
 
+  it('includes the underlying cause in the error message for a broken config', async () => {
+    // Regression: the loader used to discard the root cause and throw a bare
+    // "Failed to load config: <path>", making misconfigured configs hard to
+    // debug. The message must now surface the underlying parse/import error.
+    await expect(loadConfig({ configPath: join(FIXTURES_DIR, 'broken', 'eval.config.js') })).rejects.toThrow(
+      /Failed to load config: .*(parse|syntax|unexpected)/i,
+    );
+  });
+
   it('throws EvalConfigError when config has no default export', async () => {
     await expect(loadConfig({ configPath: join(FIXTURES_DIR, 'no-default', 'eval.config.js') })).rejects.toThrow(
       'must have a default export',


### PR DESCRIPTION
## Summary

When loading `eval.config.js` failed (parse/import error), the loader threw a bare `Failed to load config: <path>`, discarding the underlying error message. This made misconfigured configs hard to debug — you got the file path but no indication of *why* it failed.

This appends the underlying error message to the thrown `EvalConfigError`, so the root cause (parse error, syntax error, etc.) is surfaced to the user.

## Changes

- `packages/eval-core/src/config/loader.ts` — include `${message}` (the underlying error's message) in the `Failed to load config` error.
- `packages/eval-core/tests/config/loader.test.ts` — regression test asserting a broken config's error message surfaces the underlying parse/syntax/import cause.

## Test plan

- [x] `npm test` (eval-core config loader tests, including the new regression test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved config-loading errors to include the original failure message, making it easier to understand why a config file could not be loaded.
  * Added coverage for broken config files to ensure the more detailed error message is returned consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->