### PR TITLE
fix(graders): honor caseSensitive in the matches grader

### DIFF
--- a/packages/eval-core/src/graders/executors/matches.ts
+++ b/packages/eval-core/src/graders/executors/matches.ts
@@ -15,7 +15,10 @@ export const matchesExecutor: GraderExecutor = {
     let passed: boolean;
     let detail: string;
     try {
-      passed = new RegExp(pattern, 'im').test(ctx.combinedText);
+      // Case-insensitive by default; honor caseSensitive to match the other
+      // text-search executors (contains/notContains). Always multiline.
+      const flags = def.caseSensitive === true ? 'm' : 'im';
+      passed = new RegExp(pattern, flags).test(ctx.combinedText);
       detail = `/${pattern}/ ${passed ? 'matched' : 'NOT matched'}`;
     } catch (e) {
       passed = false;

--- a/packages/eval-core/tests/graders/executors.test.ts
+++ b/packages/eval-core/tests/graders/executors.test.ts
@@ -264,6 +264,20 @@ describe('matchesExecutor', () => {
     expect(result.passed).toBe(true);
   });
 
+  it('honors caseSensitive: true (does not match differing case)', async () => {
+    const ctx = makeCtx({ 'app.ts': 'AUTH0PROVIDER' });
+    const def = makeDef({ kind: 'matches', pattern: 'auth0provider', caseSensitive: true });
+    const result = await matchesExecutor.execute(def, ctx);
+    expect(result.passed).toBe(false);
+  });
+
+  it('caseSensitive: true still matches exact case', async () => {
+    const ctx = makeCtx({ 'app.ts': 'Auth0Provider' });
+    const def = makeDef({ kind: 'matches', pattern: 'Auth0Provider', caseSensitive: true });
+    const result = await matchesExecutor.execute(def, ctx);
+    expect(result.passed).toBe(true);
+  });
+
   it('handles invalid regex gracefully', async () => {
     const ctx = makeCtx({ 'app.ts': 'some content' });
     const def = makeDef({ kind: 'matches', pattern: '[invalid(' });

--- a/packages/eval-graders/src/primitives.ts
+++ b/packages/eval-graders/src/primitives.ts
@@ -38,12 +38,20 @@ export function notContains(
   };
 }
 
-export function matches(pattern: string, description?: string, level?: GraderLevel): GraderDef {
+export function matches(
+  pattern: string,
+  description?: string,
+  level?: GraderLevel,
+  options: GraderOptions = {},
+): GraderDef {
   return {
     kind: 'matches',
     pattern,
     name: description ?? `matches /${pattern}/`,
     level,
+    // Default (undefined) keeps the regex case-insensitive; pass
+    // caseSensitive: true to require an exact-case match.
+    caseSensitive: options.caseSensitive,
   };
 }
 

--- a/packages/eval-graders/tests/primitives.test.ts
+++ b/packages/eval-graders/tests/primitives.test.ts
@@ -131,9 +131,14 @@ describe('matches', () => {
     expect(def.level).toBe(GraderLevel.L4);
   });
 
-  it('does not set caseSensitive (not applicable)', () => {
+  it('leaves caseSensitive undefined by default (case-insensitive regex)', () => {
     const def = matches('pattern');
     expect(def.caseSensitive).toBeUndefined();
+  });
+
+  it('passes through caseSensitive when provided', () => {
+    const def = matches('pattern', undefined, undefined, { caseSensitive: true });
+    expect(def.caseSensitive).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

The `matches` grader always compiled its regex with the `im` flags, so it was hardcoded case-insensitive and ignored any `caseSensitive` option — inconsistent with the other text-search executors (`contains`/`notContains`). This meant a grader couldn't require an exact-case match.

This threads a `caseSensitive` option through the `matches` primitive and honors it in the executor: case-insensitive by default (`im`), case-sensitive (`m`) when `caseSensitive: true`. Multiline is always on.

## Changes

- `packages/eval-core/src/graders/executors/matches.ts` — pick regex flags based on `def.caseSensitive` (`m` vs `im`).
- `packages/eval-graders/src/primitives.ts` — add an `options: GraderOptions` param to `matches()` and pass through `caseSensitive`.
- Tests in both packages covering the case-sensitive match/no-match paths and default (undefined) behavior.

## Test plan

- [x] `npm run build`
- [x] `eval-core` executors tests (50 pass)
- [x] `eval-graders` primitives tests