### PR TITLE
test(core): cover detectRetry in classify.ts

### DIFF
--- a/packages/eval-core/tests/traces.test.ts
+++ b/packages/eval-core/tests/traces.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { classifyActionType, classifyErrorCategory, primaryArg } from '../src/runners/classify.js';
+import { classifyActionType, classifyErrorCategory, detectRetry, primaryArg } from '../src/runners/classify.js';
 import {
   formatStep,
   serialiseTrace,
@@ -173,6 +173,42 @@ describe('primaryArg', () => {
     expect(primaryArg('unknown_tool', { foo: 'bar' }).length).toBeLessThanOrEqual(80);
     expect(primaryArg('read_file', {})).toBe('');
     expect(primaryArg('run_command', {})).toBe('');
+  });
+});
+
+// ── detectRetry tests ────────────────────────────────────────────────────────
+
+describe('detectRetry', () => {
+  it('returns true when a prior call with the same name and primary arg errored', () => {
+    const prior = [makeToolCall({ name: 'read_file', args: { path: 'a.ts' }, causedError: true })];
+    expect(detectRetry(prior, 'read_file', { path: 'a.ts' })).toBe(true);
+  });
+
+  it('returns false when the prior call with the same primary arg succeeded', () => {
+    const prior = [makeToolCall({ name: 'read_file', args: { path: 'a.ts' }, causedError: false })];
+    expect(detectRetry(prior, 'read_file', { path: 'a.ts' })).toBe(false);
+  });
+
+  it('returns false when the primary arg differs from any prior call', () => {
+    const prior = [makeToolCall({ name: 'read_file', args: { path: 'a.ts' }, causedError: true })];
+    expect(detectRetry(prior, 'read_file', { path: 'b.ts' })).toBe(false);
+  });
+
+  it('returns false when the tool name differs', () => {
+    const prior = [makeToolCall({ name: 'read_file', args: { path: 'a.ts' }, causedError: true })];
+    expect(detectRetry(prior, 'write_file', { path: 'a.ts' })).toBe(false);
+  });
+
+  it('uses the most recent matching call (findLast) — success after error is not a retry', () => {
+    const prior = [
+      makeToolCall({ name: 'read_file', args: { path: 'a.ts' }, causedError: true }),
+      makeToolCall({ name: 'read_file', args: { path: 'a.ts' }, causedError: false }),
+    ];
+    expect(detectRetry(prior, 'read_file', { path: 'a.ts' })).toBe(false);
+  });
+
+  it('returns false with no prior calls', () => {
+    expect(detectRetry([], 'read_file', { path: 'a.ts' })).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Adds unit-test coverage for the previously untested `detectRetry` helper in `packages/eval-core/src/runners/classify.ts`. `detectRetry` decides whether a tool call is a retry of a prior errored call with the same name and primary arg — a signal that feeds the Efficiency waste count.

## Changes

- `packages/eval-core/tests/traces.test.ts` — new `describe('detectRetry')` block covering:
  - prior same name + primary arg errored → `true`
  - prior same primary arg succeeded → `false`
  - differing primary arg → `false`
  - differing tool name → `false`
  - `findLast` semantics: a success after an error is not a retry
  - no prior calls → `false`

## Test plan

- [x] `eval-core` traces tests (47 pass)