### PR TITLE
fix(runners): use makeSessionId for codex and gemini session ids

### DIFF
--- a/packages/eval/src/runners/codex/agent.ts
+++ b/packages/eval/src/runners/codex/agent.ts
@@ -36,6 +36,7 @@ import {
   logger,
   filteredEnv,
   readWorkspaceFile,
+  makeSessionId,
 } from '@a0/eval-core';
 import { classifyActionType, classifyErrorCategory, detectRetry } from '@a0/eval-core';
 import { LLM_API_KEY_ENV } from '../../cli/constants.js';
@@ -404,7 +405,7 @@ export async function runCodexAgent(
   const record: RunRecord = {
     taskName: evalDef.id,
     model,
-    sessionId: Math.random().toString(36).slice(2, 10),
+    sessionId: makeSessionId(),
     startTime: Date.now() / 1000,
     endTime: 0,
     toolCalls: [],

--- a/packages/eval/src/runners/gemini-cli/agent.ts
+++ b/packages/eval/src/runners/gemini-cli/agent.ts
@@ -28,6 +28,7 @@ import {
   estimateCost,
   logger,
   filteredEnv,
+  makeSessionId,
 } from '@a0/eval-core';
 import { classifyActionType, classifyErrorCategory, detectRetry } from '@a0/eval-core';
 import { LLM_API_KEY_ENV } from '../../cli/constants.js';
@@ -137,7 +138,7 @@ export async function runGeminiCliAgent(
   const record: RunRecord = {
     taskName: evalDef.id,
     model,
-    sessionId: Math.random().toString(36).slice(2, 10),
+    sessionId: makeSessionId(),
     startTime: Date.now() / 1000,
     endTime: 0,
     toolCalls: [],


### PR DESCRIPTION
## Summary

The `codex` and `gemini-cli` runners generated their trace `sessionId` inline with `Math.random().toString(36).slice(2, 10)`, while the `claude-code` and `copilot` runners use the shared `makeSessionId()` helper from `@a0/eval-core`. This switches the two outliers to `makeSessionId()` so all runners produce session ids consistently through one code path.

## Changes

- `packages/eval/src/runners/codex/agent.ts` — import and use `makeSessionId()`.
- `packages/eval/src/runners/gemini-cli/agent.ts` — import and use `makeSessionId()`.

## Test plan

- [x] `tsc --noEmit` on the eval package (no errors)