### PR TITLE
fix(codex): measure real tool-call duration from item.started

### DIFF
--- a/packages/eval/src/runners/codex/agent.ts
+++ b/packages/eval/src/runners/codex/agent.ts
@@ -125,6 +125,12 @@ interface RunCtx {
   timedOut: boolean;
   /** Absolute workspace root — used to read back content of patched files. */
   workspace: string;
+  /**
+   * Start timestamp (seconds) per item id, captured on `item.started` so the
+   * ToolCallRecord reflects the real active duration (started → completed)
+   * rather than a ~0s window measured entirely within `item.completed`.
+   */
+  itemStartTimes: Map<string, number>;
 }
 
 /** Builds a ToolCallRecord and appends it to record.toolCalls. */
@@ -212,8 +218,7 @@ function handleItem(item: ThreadItem, record: RunRecord, ctx: RunCtx, now: numbe
       const isError = item.status === 'failed';
       for (const change of item.changes) {
         const rawName = change.kind === 'delete' ? 'delete_file' : 'write_file';
-        const content =
-          !isError && change.kind !== 'delete' ? readWorkspaceFile(ctx.workspace, change.path) : '';
+        const content = !isError && change.kind !== 'delete' ? readWorkspaceFile(ctx.workspace, change.path) : '';
         ctx.turnToolCount++;
         ctx.toolCallsInTurn++;
         pushToolCall(record, rawName, { path: change.path, content }, '', isError, now);
@@ -284,9 +289,20 @@ function handleEvent(
       ctx.turnToolCount = 0;
       break;
 
-    case 'item.completed':
-      handleItem(ev.item, record, ctx, Date.now() / 1000);
+    case 'item.started':
+      // Record when the item began so item.completed can compute a real
+      // active duration. Only tool-call items carry an id we care about.
+      if (ev.item.id) ctx.itemStartTimes.set(ev.item.id, Date.now() / 1000);
       break;
+
+    case 'item.completed': {
+      // Prefer the start time captured on item.started; fall back to now for
+      // items whose start we never saw (keeps duration non-negative).
+      const startTime = (ev.item.id && ctx.itemStartTimes.get(ev.item.id)) || Date.now() / 1000;
+      if (ev.item.id) ctx.itemStartTimes.delete(ev.item.id);
+      handleItem(ev.item, record, ctx, startTime);
+      break;
+    }
 
     case 'turn.completed': {
       ctx.turnNum++;
@@ -472,6 +488,7 @@ export async function runCodexAgent(
     toolCallsInTurn: 0,
     timedOut: false,
     workspace,
+    itemStartTimes: new Map(),
   };
 
   // The SDK spawns the `codex` binary with this env, so it reads

--- a/packages/eval/tests/runners/codex-agent.test.ts
+++ b/packages/eval/tests/runners/codex-agent.test.ts
@@ -515,6 +515,73 @@ describe('turn metrics', () => {
   });
 });
 
+// ── tool-call timing ──────────────────────────────────────────────────────────
+
+describe('tool-call timing', () => {
+  it('records active duration from item.started, not from item.completed', async () => {
+    // Advance Date.now() by 1s per read. With the fix, the timed_1 tool call's
+    // startTime is captured at its item.started event, so intervening reads
+    // (other items completing between started and completed) make its duration
+    // several seconds. The old code read startTime inside item.completed, giving
+    // a ~1-tick duration regardless — so Setup Speed was meaningless for Codex.
+    let clock = 1_000_000; // ms
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => {
+      const v = clock;
+      clock += 1_000; // advance 1s per read
+      return v;
+    });
+
+    queueTurns([
+      // timed_1 starts here...
+      { type: 'item.started', item: { type: 'command_execution', id: 'timed_1', command: 'npm install' } },
+      // ...several other items complete before timed_1 does (advancing the clock).
+      {
+        type: 'item.completed',
+        item: { type: 'command_execution', id: 'other_a', command: 'ls', aggregated_output: '', exit_code: 0 },
+      },
+      {
+        type: 'item.completed',
+        item: { type: 'command_execution', id: 'other_b', command: 'pwd', aggregated_output: '', exit_code: 0 },
+      },
+      // ...and only now does timed_1 complete.
+      {
+        type: 'item.completed',
+        item: {
+          type: 'command_execution',
+          id: 'timed_1',
+          command: 'npm install',
+          aggregated_output: 'ok',
+          exit_code: 0,
+        },
+      },
+      turnCompleted(),
+    ]);
+
+    const record = await runCodexAgent(evalDef, workspace);
+    nowSpy.mockRestore();
+
+    const timed = record.toolCalls.find((tc) => tc.args.command === 'npm install')!;
+    // Fixed: startTime is from item.started, several reads before completion → ≥ 2s.
+    // Buggy: startTime read inside item.completed → ~1s.
+    expect(timed.endTime - timed.startTime).toBeGreaterThanOrEqual(2);
+  });
+
+  it('falls back to a non-negative duration when item.started was not seen', async () => {
+    // No item.started for this id — startTime must not exceed endTime.
+    queueTurns([
+      {
+        type: 'item.completed',
+        item: { type: 'command_execution', id: 'no_start', command: 'ls', aggregated_output: '', exit_code: 0 },
+      },
+      turnCompleted(),
+    ]);
+
+    const record = await runCodexAgent(evalDef, workspace);
+    const tc = record.toolCalls[0];
+    expect(tc.endTime).toBeGreaterThanOrEqual(tc.startTime);
+  });
+});
+
 // ── finalSummary ──────────────────────────────────────────────────────────────
 
 describe('finalSummary', () => {


### PR DESCRIPTION
## Summary

The Codex runner stamped a tool call's `startTime` inside the `item.completed` handler, immediately before computing `endTime` — so every tool call had a ~0s duration regardless of how long it actually ran. This made the **Setup Speed** dimension meaningless for Codex (active tool time was always ~0).

This captures the start timestamp on `item.started` (keyed by item id) and uses it as the `ToolCallRecord.startTime` when the matching `item.completed` arrives, so the recorded duration reflects the real active window. If an `item.started` was never seen for an id, it falls back to `now` (keeping the duration non-negative).

## Changes

- `packages/eval/src/runners/codex/agent.ts`:
  - Add `itemStartTimes: Map<string, number>` to the run context.
  - Handle `item.started` — record the start timestamp per item id.
  - `item.completed` — look up the captured start time (fallback to now), delete the entry, and pass it as the tool call's `startTime`.
- `packages/eval/tests/runners/codex-agent.test.ts` — tests asserting the duration reflects the started→completed window (other items completing in between advance the clock) and that a missing `item.started` yields a non-negative duration.

## Test plan

- [x] `eval` codex-agent tests (35 pass)