### PR TITLE
fix(reporter): validate and contextualize errors in loadScores

### DIFF
--- a/packages/eval-reporter/src/report/processors.ts
+++ b/packages/eval-reporter/src/report/processors.ts
@@ -17,8 +17,17 @@ export function resultVariant(r: Record<string, unknown>): string {
 export function loadScores(paths: string[]): Record<string, unknown>[] {
   const results: Record<string, unknown>[] = [];
   for (const p of paths) {
-    const data = JSON.parse(readFileSync(p, 'utf-8')) as Record<string, unknown>[];
-    results.push(...data);
+    let data: unknown;
+    try {
+      data = JSON.parse(readFileSync(p, 'utf-8'));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`Failed to parse scores file ${p}: ${message}`);
+    }
+    if (!Array.isArray(data)) {
+      throw new Error(`Scores file ${p} must contain a JSON array, got ${typeof data}`);
+    }
+    results.push(...(data as Record<string, unknown>[]));
   }
   return results;
 }

--- a/packages/eval-reporter/tests/processors.test.ts
+++ b/packages/eval-reporter/tests/processors.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Unit tests for src/report/processors.ts — loadScores error handling.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { loadScores } from '../src/report/processors.js';
+import { makeTmpDir } from './tmp.js';
+
+const tmpDir = makeTmpDir('processors_test_');
+
+describe('loadScores', () => {
+  it('loads and concatenates arrays from multiple files', () => {
+    const dir = tmpDir();
+    const a = join(dir, 'a.json');
+    const b = join(dir, 'b.json');
+    writeFileSync(a, JSON.stringify([{ eval_id: 'x' }]));
+    writeFileSync(b, JSON.stringify([{ eval_id: 'y' }, { eval_id: 'z' }]));
+
+    const results = loadScores([a, b]);
+    expect(results).toHaveLength(3);
+    expect(results.map((r) => r.eval_id)).toEqual(['x', 'y', 'z']);
+  });
+
+  it('throws with the file path when a file contains invalid JSON', () => {
+    const dir = tmpDir();
+    const bad = join(dir, 'bad.json');
+    writeFileSync(bad, '{ not valid json');
+
+    expect(() => loadScores([bad])).toThrow(new RegExp(`Failed to parse scores file .*bad\\.json`));
+  });
+
+  it('throws with the file path when the JSON is not an array', () => {
+    const dir = tmpDir();
+    const obj = join(dir, 'obj.json');
+    writeFileSync(obj, JSON.stringify({ eval_id: 'x' }));
+
+    expect(() => loadScores([obj])).toThrow(new RegExp(`Scores file .*obj\\.json must contain a JSON array`));
+  });
+});


### PR DESCRIPTION
## Summary

`loadScores` parsed each scores file with a bare `JSON.parse(...)` and spread the result directly into the results array. A malformed file produced an opaque `SyntaxError` with no indication of *which* file was bad, and a valid-JSON-but-non-array file (e.g. an object) would spread into garbage instead of failing clearly.

This wraps parsing in a try/catch that reports the offending file path, and validates that the parsed value is an array before spreading.

## Changes

- `packages/eval-reporter/src/report/processors.ts`:
  - Catch `JSON.parse` failures and rethrow as `Failed to parse scores file <path>: <message>`.
  - Throw `Scores file <path> must contain a JSON array, got <type>` when the parsed value isn't an array.
- `packages/eval-reporter/tests/processors.test.ts` — tests for the happy path (concatenating arrays across files), invalid JSON, and non-array JSON.

## Test plan

- [x] `eval-reporter` processors tests (3 pass)