### PR TITLE
fix(cost): warn on unknown models and name the default pricing

### DIFF
--- a/packages/eval-core/src/config/costs.ts
+++ b/packages/eval-core/src/config/costs.ts
@@ -1,3 +1,5 @@
+import { logger } from '../utils/logger.js';
+
 export const COST_TABLE: Record<string, [number, number]> = {
   'gpt-5.4': [2.5, 15.0],
   'gpt-5.4-mini': [0.75, 4.5],
@@ -12,7 +14,21 @@ export const COST_TABLE: Record<string, [number, number]> = {
   'gemini-3.5-flash': [1.5, 9.0],
 };
 
+/** [input, output] USD per million tokens applied to models absent from COST_TABLE. */
+export const DEFAULT_PRICING: [number, number] = [1.0, 5.0];
+
+// Models already warned about, so the fallback-pricing notice fires once per model.
+const warnedUnknownModels = new Set<string>();
+
 export function estimateCost(model: string, inputTokens: number, outputTokens: number): number {
-  const [inPrice, outPrice] = COST_TABLE[model] ?? [1.0, 5.0];
+  const pricing = COST_TABLE[model];
+  if (!pricing && !warnedUnknownModels.has(model)) {
+    warnedUnknownModels.add(model);
+    logger.warn(
+      `[cost] No pricing for model '${model}'; using default $${DEFAULT_PRICING[0]}/$${DEFAULT_PRICING[1]} per 1M tokens. ` +
+        `Add it to COST_TABLE for accurate cost estimates.`,
+    );
+  }
+  const [inPrice, outPrice] = pricing ?? DEFAULT_PRICING;
   return (inputTokens * inPrice + outputTokens * outPrice) / 1_000_000;
 }

--- a/packages/eval-core/tests/costs.test.ts
+++ b/packages/eval-core/tests/costs.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Tests for src/config/costs.ts — estimateCost pricing and unknown-model warning.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { estimateCost, COST_TABLE, DEFAULT_PRICING } from '../src/config/costs.js';
+import { setLogger } from '../src/utils/logger.js';
+import type { Logger } from '../src/utils/logger.js';
+
+const warnings: string[] = [];
+const captureLogger: Logger = {
+  info: () => {},
+  warn: (...args) => warnings.push(args.map(String).join(' ')),
+  error: () => {},
+};
+
+beforeEach(() => {
+  warnings.length = 0;
+  setLogger(captureLogger);
+});
+
+describe('estimateCost', () => {
+  it('computes cost from the model pricing in COST_TABLE', () => {
+    const [inPrice, outPrice] = COST_TABLE['gpt-5.4']!;
+    const cost = estimateCost('gpt-5.4', 1_000_000, 1_000_000);
+    expect(cost).toBeCloseTo(inPrice + outPrice, 6);
+  });
+
+  it('returns 0 for zero tokens', () => {
+    expect(estimateCost('gpt-5.4', 0, 0)).toBe(0);
+  });
+
+  it('applies DEFAULT_PRICING and warns once for an unknown model', () => {
+    const model = 'totally-made-up-model-xyz';
+    const cost = estimateCost(model, 1_000_000, 1_000_000);
+    expect(cost).toBeCloseTo(DEFAULT_PRICING[0] + DEFAULT_PRICING[1], 6);
+    expect(warnings.some((w) => w.includes(model))).toBe(true);
+
+    // A second call for the same model must not warn again.
+    warnings.length = 0;
+    estimateCost(model, 10, 10);
+    expect(warnings).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

`estimateCost` silently fell back to a hardcoded `[1.0, 5.0]` price for any model missing from `COST_TABLE`, so an unrecognized model produced a plausible-but-wrong cost estimate with no signal that the default was used. This makes the fallback explicit and observable.

## Changes

- `packages/eval-core/src/config/costs.ts`:
  - Extract the fallback into a named, exported `DEFAULT_PRICING` constant.
  - Log a one-time `warn` per unknown model (tracked via a `Set`) naming the model and the default pricing, so it's clear an estimate is approximate.
- `packages/eval-core/tests/costs.test.ts` — tests for known-model pricing, zero tokens, and the unknown-model path (applies `DEFAULT_PRICING` and warns exactly once per model).

## Test plan

- [x] `eval-core` costs tests (3 pass)