### PR TITLE
refactor(reporter): hoist grade badge map and test gradeCssClass

### DIFF
--- a/packages/eval-reporter/src/report-filters.ts
+++ b/packages/eval-reporter/src/report-filters.ts
@@ -34,14 +34,15 @@ export function rateCssClass(rate: number): string {
   return 'rate-poor';
 }
 
+const GRADE_TO_BADGE_CLASS: Record<string, string> = {
+  A: 'badge-a',
+  B: 'badge-b',
+  C: 'badge-c',
+  D: 'badge-df',
+  F: 'badge-df',
+};
+
 export function gradeCssClass(grade: string): string {
-  const GRADE_TO_BADGE_CLASS: Record<string, string> = {
-    A: 'badge-a',
-    B: 'badge-b',
-    C: 'badge-c',
-    D: 'badge-df',
-    F: 'badge-df',
-  };
   return GRADE_TO_BADGE_CLASS[grade] ?? '';
 }
 

--- a/packages/eval-reporter/tests/report-filters.test.ts
+++ b/packages/eval-reporter/tests/report-filters.test.ts
@@ -8,9 +8,27 @@ import {
   latencyCssClass,
   actionCssClass,
   sizeCssClass,
+  gradeCssClass,
   mdInline,
   judgeHtml,
 } from '../src/report-filters.js';
+
+// ── gradeCssClass ─────────────────────────────────────────────────────────────
+
+describe('gradeCssClass', () => {
+  it.each([
+    ['A', 'badge-a'],
+    ['B', 'badge-b'],
+    ['C', 'badge-c'],
+    ['D', 'badge-df'],
+    ['F', 'badge-df'],
+    // Unknown grade falls back to empty string
+    ['Z', ''],
+    ['', ''],
+  ] as [string, string][])('%j → %j', (grade, expected) => {
+    expect(gradeCssClass(grade)).toBe(expected);
+  });
+});
 
 // ── finishCssClass ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

`gradeCssClass` rebuilt its `GRADE_TO_BADGE_CLASS` lookup object on every call. This hoists the map to module scope (built once) — a pure refactor with no behavior change — and adds test coverage for the function, including the unknown-grade fallback to an empty string.

## Changes

- `packages/eval-reporter/src/report-filters.ts` — move `GRADE_TO_BADGE_CLASS` out of `gradeCssClass` to module scope.
- `packages/eval-reporter/tests/report-filters.test.ts` — table-driven tests for A/B/C/D/F mappings plus unknown/empty grade fallbacks.

## Test plan

- [x] `eval-reporter` report-filters tests (40 pass)