### PR TITLE
fix(reporter): do not drop judge reasoning on a leading newline

### DIFF
--- a/packages/eval-reporter/src/report-filters.ts
+++ b/packages/eval-reporter/src/report-filters.ts
@@ -83,11 +83,10 @@ export function judgeHtml(detail: string): string {
     return '';
   }
 
-  const [firstLine, ...bodyLines] = detail.split('\n');
-
-  if (!firstLine) {
-    return '';
-  }
+  // split('\n') always yields at least one element; default guards the type.
+  // Note: no early return on an empty first line — a leading newline is real
+  // content. The `body.length > 0` check below handles the genuinely-empty case.
+  const [firstLine = '', ...bodyLines] = detail.split('\n');
 
   const modelMatch = /Judge \(([^)]+)\):\s*/.exec(firstLine);
   const model = modelMatch && modelMatch[1] ? modelMatch[1] : 'judge';

--- a/packages/eval-reporter/tests/report-filters.test.ts
+++ b/packages/eval-reporter/tests/report-filters.test.ts
@@ -148,4 +148,14 @@ describe('judgeHtml', () => {
     expect(html).not.toContain('onerror');
     expect(html).not.toContain('<img');
   });
+
+  it('renders reasoning when the detail begins with a blank line', () => {
+    // Regression: an empty first line made `!firstLine` true, discarding all
+    // reasoning even though the detail was non-empty.
+    const detail = '\nThe answer is correct.';
+    const html = judgeHtml(detail);
+    expect(html).not.toBe('');
+    expect(html).toContain('The answer is correct.');
+    expect(html).toContain('judge-reasoning-body');
+  });
 });


### PR DESCRIPTION
## Summary

`judgeHtml` split the judge detail on `\n` and early-returned `''` when the first line was empty (`!firstLine`). When a judge detail began with a blank line (a leading `\n`), the first line was empty, so all of the reasoning that followed was silently discarded and the report showed nothing.

This removes the faulty `!firstLine` early return. The genuinely-empty case is already covered by the top-level `if (!detail)` guard, and the empty-reasoning case is handled downstream by the `body.length > 0` check (which renders "No reasoning provided.").

## Changes

- `packages/eval-reporter/src/report-filters.ts` — drop the `!firstLine` early return; default the destructured `firstLine` to `''` for type safety.
- `packages/eval-reporter/tests/report-filters.test.ts` — regression test asserting reasoning is rendered when the detail begins with a blank line.

## Test plan

- [x] `eval-reporter` report-filters tests (34 pass)