### PR TITLE
fix(reporter): preserve caught error as cause in loadScores

### DIFF
--- a/packages/eval-reporter/src/report/processors.ts
+++ b/packages/eval-reporter/src/report/processors.ts
@@ -22,7 +22,7 @@ export function loadScores(paths: string[]): Record<string, unknown>[] {
       data = JSON.parse(readFileSync(p, 'utf-8'));
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      throw new Error(`Failed to parse scores file ${p}: ${message}`);
+      throw new Error(`Failed to parse scores file ${p}: ${message}`, { cause: err });
     }
     if (!Array.isArray(data)) {
       throw new Error(`Scores file ${p} must contain a JSON array, got ${typeof data}`);

--- a/packages/eval-reporter/tests/processors.test.ts
+++ b/packages/eval-reporter/tests/processors.test.ts
@@ -31,6 +31,20 @@ describe('loadScores', () => {
     expect(() => loadScores([bad])).toThrow(new RegExp(`Failed to parse scores file .*bad\\.json`));
   });
 
+  it('preserves the underlying parse error as `cause`', () => {
+    const dir = tmpDir();
+    const bad = join(dir, 'bad.json');
+    writeFileSync(bad, '{ not valid json');
+
+    try {
+      loadScores([bad]);
+      expect.fail('expected loadScores to throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).cause).toBeInstanceOf(Error);
+    }
+  });
+
   it('throws with the file path when the JSON is not an array', () => {
     const dir = tmpDir();
     const obj = join(dir, 'obj.json');


### PR DESCRIPTION
## What

Fixes the `preserve-caught-error` lint error currently failing on `main` in `packages/eval-reporter/src/report/processors.ts`.

The `loadScores` catch block rethrows a new `Error` with a contextual message but dropped the original parse error. The `preserve-caught-error` rule (enabled via `eslint.configs.recommended`) flags this. The fix attaches the caught error via the `Error` `cause` option, retaining the underlying stack.

## Why

`npm run lint` fails on `main` today, blocking pre-commit hooks on any branch that merges in latest main.

## Testing

- Added a test asserting `err.cause` is preserved on parse failure.
- `npm run lint` passes across all 5 workspaces.
- `npm test` passes.