### PR TITLE
chore(eval): use single auth0 skill across all evals

### DIFF
--- a/apps/auth0-evals/src/evals/dpop/spa-js/PROMPT.md
+++ b/apps/auth0-evals/src/evals/dpop/spa-js/PROMPT.md
@@ -2,7 +2,7 @@
 id: spa_js_dpop
 name: SPA JS DPoP Token Binding
 scaffold: src/evals/scaffolds/spa-js/auth0
-skills: auth0-dpop
+skills: auth0
 setup_command: npm install
 compile_command: npm run build
 ---

--- a/apps/auth0-evals/src/evals/mfa/angular/PROMPT.md
+++ b/apps/auth0-evals/src/evals/mfa/angular/PROMPT.md
@@ -2,7 +2,7 @@
 id: angular_mfa
 name: Angular MFA Step-Up
 scaffold: src/evals/scaffolds/angular/auth0
-skills: auth0-mfa
+skills: auth0
 setup_command: npm install
 compile_command: npm run build
 ---

--- a/apps/auth0-evals/src/evals/mfa/react/PROMPT.md
+++ b/apps/auth0-evals/src/evals/mfa/react/PROMPT.md
@@ -2,7 +2,7 @@
 id: react_mfa
 name: React MFA Step-Up
 scaffold: src/evals/scaffolds/react/auth0
-skills: auth0-mfa
+skills: auth0
 setup_command: npm install
 compile_command: npm run build
 ---

--- a/apps/auth0-evals/src/evals/mfa/vue/PROMPT.md
+++ b/apps/auth0-evals/src/evals/mfa/vue/PROMPT.md
@@ -2,7 +2,7 @@
 id: vue_mfa
 name: Vue MFA Step-Up
 scaffold: src/evals/scaffolds/vue/auth0
-skills: auth0-mfa
+skills: auth0
 setup_command: npm install
 compile_command: npm run build
 ---

--- a/apps/auth0-evals/src/evals/quickstarts/android/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/android/PROMPT.md
@@ -1,7 +1,7 @@
 ---
 id: android_quickstart
 name: Android Quickstart
-skills: auth0-android
+skills: auth0
 ---
 
 ## Task

--- a/apps/auth0-evals/src/evals/quickstarts/angular/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/angular/PROMPT.md
@@ -1,7 +1,7 @@
 ---
 id: angular_quickstart
 name: Angular Quickstart
-skills: auth0-angular
+skills: auth0
 setup_command: npm install
 compile_command: npm run build
 ---

--- a/apps/auth0-evals/src/evals/quickstarts/express-api/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/express-api/PROMPT.md
@@ -1,7 +1,7 @@
 ---
 id: express_api_quickstart
 name: Express API Quickstart
-skills: express-oauth2-jwt-bearer
+skills: auth0
 ---
 
 ## Task

--- a/apps/auth0-evals/src/evals/quickstarts/express/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/express/PROMPT.md
@@ -1,7 +1,7 @@
 ---
 id: express_quickstart
 name: Express Quickstart
-skills: auth0-express
+skills: auth0
 setup_command: npm install
 compile_command: node --check server.js
 ---

--- a/apps/auth0-evals/src/evals/quickstarts/fastapi/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/fastapi/PROMPT.md
@@ -1,7 +1,7 @@
 ---
 id: fastapi_quickstart
 name: FastAPI Quickstart
-skills: auth0-fastapi-api
+skills: auth0
 setup_command: python3 -m venv .venv && .venv/bin/pip install -r requirements.txt
 compile_command: .venv/bin/python -m py_compile main.py
 ---

--- a/apps/auth0-evals/src/evals/quickstarts/fastify-api/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/fastify-api/PROMPT.md
@@ -1,7 +1,7 @@
 ---
 id: fastify_api_quickstart
 name: Fastify API Quickstart
-skills: auth0-fastify-api
+skills: auth0
 setup_command: npm install
 compile_command: node --check server.js
 ---

--- a/apps/auth0-evals/src/evals/quickstarts/flask/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/flask/PROMPT.md
@@ -1,7 +1,7 @@
 ---
 id: flask_quickstart
 name: Flask Quickstart
-skills: auth0-flask
+skills: auth0
 setup_command: python3 -m venv .venv && .venv/bin/pip install -r requirements.txt
 compile_command: .venv/bin/python -m py_compile app.py
 ---

--- a/apps/auth0-evals/src/evals/quickstarts/nextjs/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/nextjs/PROMPT.md
@@ -1,7 +1,7 @@
 ---
 id: nextjs_quickstart
 name: Next.js App Router Quickstart
-skills: auth0-nextjs
+skills: auth0
 setup_command: npm install
 compile_command: npm run build
 ---

--- a/apps/auth0-evals/src/evals/quickstarts/nuxt/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/nuxt/PROMPT.md
@@ -1,7 +1,7 @@
 ---
 id: nuxt_quickstart
 name: Nuxt Quickstart
-skills: auth0-nuxt
+skills: auth0
 setup_command: npm install
 compile_command: npm run build
 ---

--- a/apps/auth0-evals/src/evals/quickstarts/react/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/react/PROMPT.md
@@ -2,7 +2,7 @@
 id: react_quickstart
 name: React Quickstart
 scaffold: src/evals/scaffolds/react/basic
-skills: auth0-react
+skills: auth0
 setup_command: npm install
 compile_command: npm run build
 ---

--- a/apps/auth0-evals/src/evals/quickstarts/spa-js/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/spa-js/PROMPT.md
@@ -1,7 +1,7 @@
 ---
 id: spa_js_quickstart
 name: SPA JS Quickstart
-skills: auth0-spa-js
+skills: auth0
 setup_command: npm install
 compile_command: npm run build
 ---

--- a/apps/auth0-evals/src/evals/quickstarts/swift/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/swift/PROMPT.md
@@ -1,7 +1,7 @@
 ---
 id: swift_quickstart
 name: Swift iOS Quickstart
-skills: auth0-swift
+skills: auth0
 ---
 
 ## Task

--- a/apps/auth0-evals/src/evals/quickstarts/vue/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/vue/PROMPT.md
@@ -1,7 +1,7 @@
 ---
 id: vue_quickstart
 name: Vue Quickstart
-skills: auth0-vue
+skills: auth0
 setup_command: npm install
 compile_command: npm run build
 ---


### PR DESCRIPTION
Changes the `skills:` frontmatter in all 17 eval `PROMPT.md` files from framework-specific skills (`auth0-react`, `auth0-angular`, `auth0-dpop`, `express-oauth2-jwt-bearer`, etc.) to a single `auth0` skill.

## Files changed
All 17 evals under `apps/auth0-evals/src/evals/` now reference `skills: auth0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Standardized evaluation and quickstart prompt metadata to use the unified `auth0` skill classification.
  - Updated coverage across DPoP, MFA, and Android, Angular, Express, FastAPI, Fastify, Flask, Next.js, Nuxt, React, SPA JavaScript, Swift, and Vue quickstarts.
  - Prompt instructions and content remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->