### PR TITLE
feat(models): make --model all config-driven; drop Opus 4.5/4.6/4.7 from app's --model all

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -366,17 +366,17 @@ When MCP tools are enabled (`--tools mcp`), MCP server tool definitions are appe
 
 ### Known working models
 
-Used when `--model all` is passed:
+`--model all` expands to this app's `models.known` in `eval.config.js` (falling back to the framework's `KNOWN_WORKING_MODELS` constant only if the app leaves `models.known` empty):
 
 - `gpt-5.4` (default when no `--model` flag)
 - `gpt-5.4-mini`
 - `claude-sonnet-4-6`
-- `claude-opus-4-6`
-- `claude-opus-4-7`
 - `claude-opus-4-8`
 - `claude-haiku-4-5`
 - `gemini-3.1-pro-preview`
 - `gemini-3.5-flash`
+
+Opus 4.5, 4.6, and 4.7 are still supported by the framework (present in the cost table, effort-capable set, and Bedrock alias map) and can be run explicitly via `--model claude-opus-4-6`; they are intentionally omitted from `--model all` here so batch runs use only Opus 4.8 among the Opus variants.
 
 ### Judge model
 
@@ -433,7 +433,7 @@ npm run report
 | Flag                         | Values                                          | Default              | Notes                                                    |
 | ---------------------------- | ----------------------------------------------- | -------------------- | -------------------------------------------------------- |
 | `--eval <id>`                | Any registered eval ID                          | all evals            | Repeatable                                               |
-| `--model <model>`            | Any model string                                | `gpt-5.4`            | Repeatable; `all` expands to known working models        |
+| `--model <model>`            | Any model string                                | `gpt-5.4`            | Repeatable; `all` expands to the config's `models.known` |
 | `--mode <mode>`              | `baseline`, `agent`, `all`                      | `baseline`           | `all` expands to both                                    |
 | `--tools <tools>`            | `skills`, `mcp`, or comma-separated             | none                 | Only applies to agent mode                               |
 | `--agent-type <type>`        | `claude-code`, `copilot`, `gemini-cli`, `codex` | auto-routed by model | Overrides auto-routing                                   |

--- a/apps/auth0-evals/eval.config.js
+++ b/apps/auth0-evals/eval.config.js
@@ -91,7 +91,10 @@ export default {
   },
 
   models: {
-    known: ['gpt-5.4', 'gpt-5.4-mini', 'claude-sonnet-4-6', 'claude-opus-4-6', 'claude-opus-4-7', 'claude-opus-4-8', 'claude-haiku-4-5', 'gemini-3.1-pro-preview', 'gemini-3.5-flash'],
+    // `known` is the set `--model all` expands to. Opus 4.5/4.6/4.7 are intentionally
+    // excluded here so `--model all` runs only Opus 4.8 among the Opus variants; the
+    // framework and `modelIds` map below still support them for explicit `--model` runs.
+    known: ['gpt-5.4', 'gpt-5.4-mini', 'claude-sonnet-4-6', 'claude-opus-4-8', 'claude-haiku-4-5', 'gemini-3.1-pro-preview', 'gemini-3.5-flash'],
     default: 'gpt-5.4',
     // Maps short model aliases to the IDs the active proxy expects.
     // Bedrock proxy needs full `global.anthropic.*` IDs; LiteLLM proxy serves

--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -130,7 +130,7 @@ a0-eval [options]
 | Flag | Values | Default | Description |
 |------|--------|---------|-------------|
 | `--eval <id>` | Any eval ID | all evals | Eval to run (repeatable) |
-| `--model <model>` | Any model string | `gpt-5.4` | Model to use (repeatable; `all` expands to known working models) |
+| `--model <model>` | Any model string | `gpt-5.4` | Model to use (repeatable; `all` expands to the config's `models.known`, falling back to the built-in known-working list) |
 | `--mode <mode>` | `baseline`, `agent`, `all` | `baseline` | `all` runs both modes in parallel |
 | `--tools <tools>` | `skills`, `mcp`, or comma-separated | none | Agent-mode only |
 | `--agent-type <type>` | `claude-code`, `copilot`, `gemini-cli` | auto-routed | Override agent runner selection |

--- a/packages/eval/src/cli/config.ts
+++ b/packages/eval/src/cli/config.ts
@@ -61,6 +61,34 @@ export interface RunConfig {
 export interface ParseRunConfigOptions {
   /** List of known eval IDs for validation. When omitted, eval ID validation is skipped. */
   knownEvalIds?: string[];
+  /**
+   * Models that `--model all` expands to — typically the app's `models.known`
+   * from `eval.config.js`. When omitted or empty, the framework's
+   * `KNOWN_WORKING_MODELS` fallback is used instead.
+   */
+  knownModels?: string[];
+}
+
+/**
+ * Extracts the `--config <path>` value from a raw argv without a full parse.
+ *
+ * Needed because the framework config must be loaded *before* `parseRunConfig`
+ * runs (so `--model all` can expand to the app's `models.known`), but the
+ * config path itself lives in argv. Supports both `--config <path>` and
+ * `--config=<path>` forms. Returns `undefined` when the flag is absent.
+ */
+export function extractConfigPath(argv: string[]): string | undefined {
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === undefined) continue;
+    if (arg === '--config') {
+      return argv[i + 1];
+    }
+    if (arg.startsWith('--config=')) {
+      return arg.slice('--config='.length);
+    }
+  }
+  return undefined;
 }
 
 /**
@@ -108,7 +136,7 @@ export function parseRunConfig(argv: string[], options: ParseRunConfigOptions = 
   const opts = program.opts();
 
   const apiKey = validateApiKey();
-  const models = validateModels(opts.model as string[]);
+  const models = validateModels(opts.model as string[], options.knownModels);
   const modes = validateModes(opts.mode as string | undefined);
 
   const evalIds = options.knownEvalIds

--- a/packages/eval/src/cli/index.ts
+++ b/packages/eval/src/cli/index.ts
@@ -8,7 +8,7 @@ export {
   type Mode,
 } from './constants.js';
 
-export { parseRunConfig, type RunConfig } from './config.js';
+export { parseRunConfig, extractConfigPath, type RunConfig } from './config.js';
 
 export { spawnEval, mergeIntoOutput } from './subprocess-runner.js';
 

--- a/packages/eval/src/cli/run.ts
+++ b/packages/eval/src/cli/run.ts
@@ -49,7 +49,7 @@ import {
 } from '@a0/eval-core';
 import type { EvalConfig, EvalDefinition, JobResult, AgentType, Mode } from '@a0/eval-core';
 
-import { parseRunConfig } from './config.js';
+import { parseRunConfig, extractConfigPath } from './config.js';
 import { spawnEval, mergeIntoOutput } from './subprocess-runner.js';
 import { DEFAULT_AGENT_TYPE } from './constants.js';
 import { resolveOutputPath, mergeResults, loadResults, saveResults } from '../persistence/index.js';
@@ -341,7 +341,14 @@ export async function runCli(): Promise<void> {
   // Load .env from the cwd
   loadDotenv();
 
-  const config = parseRunConfig(process.argv);
+  // Load the framework configuration (eval.config.js) *before* parsing CLI args
+  // so `--model all` can expand to the app's `models.known`. The config path is
+  // extracted from argv directly since the full parse depends on the loaded config.
+  const configPath = extractConfigPath(process.argv);
+  const frameworkConfig = await loadConfig({ configPath });
+  setFrameworkConfig(frameworkConfig);
+
+  const config = parseRunConfig(process.argv, { knownModels: frameworkConfig.models.known });
   const {
     models,
     modes,
@@ -353,13 +360,8 @@ export async function runCli(): Promise<void> {
     braintrust,
     apiKey,
     agentType,
-    configPath,
     sandbox,
   } = config;
-
-  // Load the framework configuration (eval.config.js) — auto-discovered or via --config.
-  const frameworkConfig = await loadConfig({ configPath });
-  setFrameworkConfig(frameworkConfig);
 
   // Validate required runtime fields
   const missing: string[] = [];

--- a/packages/eval/src/cli/validators.ts
+++ b/packages/eval/src/cli/validators.ts
@@ -33,12 +33,17 @@ export function validateApiKey(): string {
 
 /**
  * Resolves and validates the model list.
- * `--model all` expands to all known models.
+ *
+ * `--model all` expands to `knownModels` — the app's configured `models.known`
+ * when provided (and non-empty), otherwise the framework's `KNOWN_WORKING_MODELS`
+ * fallback. This lets an app narrow the `all` set (e.g. drop deprecated models)
+ * via `eval.config.js` without changing framework code.
  */
-export function validateModels(rawModels: string[]): string[] {
+export function validateModels(rawModels: string[], knownModels?: string[]): string[] {
+  const allModels = knownModels && knownModels.length > 0 ? knownModels : KNOWN_WORKING_MODELS;
   if (rawModels.length > 0 && rawModels.includes('all')) {
-    logger.info(`Using all known working models: ${KNOWN_WORKING_MODELS.join(', ')}`);
-    return KNOWN_WORKING_MODELS;
+    logger.info(`Using all known working models: ${allModels.join(', ')}`);
+    return allModels;
   }
   if (rawModels.length > 0) {
     return rawModels;

--- a/packages/eval/src/index.ts
+++ b/packages/eval/src/index.ts
@@ -34,6 +34,7 @@ export {
   DEFAULT_AGENT_TYPE,
   parseToolsArg,
   parseRunConfig,
+  extractConfigPath,
   type RunConfig,
   spawnEval,
   mergeIntoOutput,

--- a/packages/eval/tests/cli-config.test.ts
+++ b/packages/eval/tests/cli-config.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   parseRunConfig,
+  extractConfigPath,
   ALL_MODES,
   DEFAULT_MODEL,
   DEFAULT_AGENT_TYPE,
@@ -147,6 +148,25 @@ describe('--model', () => {
   it('--model all takes precedence when mixed with explicit models', () => {
     const config = parse('--model', 'gpt-5.2', '--model', 'all');
     expect(config.models).toEqual(KNOWN_WORKING_MODELS);
+  });
+
+  it('--model all expands to the provided knownModels when given', () => {
+    const known = ['gpt-5.4', 'claude-opus-4-8'];
+    const config = parseRunConfig(argv('--model', 'all'), { knownEvalIds: KNOWN_EVAL_IDS, knownModels: known });
+    expect(config.models).toEqual(known);
+  });
+
+  it('--model all falls back to KNOWN_WORKING_MODELS when knownModels is empty', () => {
+    const config = parseRunConfig(argv('--model', 'all'), { knownEvalIds: KNOWN_EVAL_IDS, knownModels: [] });
+    expect(config.models).toEqual(KNOWN_WORKING_MODELS);
+  });
+
+  it('explicit --model still passes through even when not in knownModels', () => {
+    const config = parseRunConfig(argv('--model', 'claude-opus-4-6'), {
+      knownEvalIds: KNOWN_EVAL_IDS,
+      knownModels: ['gpt-5.4', 'claude-opus-4-8'],
+    });
+    expect(config.models).toEqual(['claude-opus-4-6']);
   });
 });
 
@@ -305,5 +325,21 @@ describe('--agent-type', () => {
   it('prints the invalid agent type in the error message', () => {
     expect(() => parse('--agent-type', 'my-custom-agent')).toThrow();
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('my-custom-agent'));
+  });
+});
+
+// ── extractConfigPath ─────────────────────────────────────────────────────────
+
+describe('extractConfigPath', () => {
+  it('returns undefined when --config is absent', () => {
+    expect(extractConfigPath(argv('--model', 'all'))).toBeUndefined();
+  });
+
+  it('extracts the value from the space-separated form', () => {
+    expect(extractConfigPath(argv('--config', 'my.config.js', '--mode', 'agent'))).toBe('my.config.js');
+  });
+
+  it('extracts the value from the --config=<path> form', () => {
+    expect(extractConfigPath(argv('--config=/abs/path/eval.config.js'))).toBe('/abs/path/eval.config.js');
   });
 });


### PR DESCRIPTION
## What

Keeps full framework support for all Opus models, but scopes the auth0-evals app so `--model all` no longer runs Opus 4.5, 4.6, or 4.7 — only Opus 4.8 among the Opus variants.

## How

Previously `--model all` expanded to the framework's hardcoded `KNOWN_WORKING_MODELS` constant, ignoring the app's `eval.config.js`. Now:

- **`--model all` expands to the config's `models.known`** (falling back to `KNOWN_WORKING_MODELS` only when the app leaves it empty). An app can now narrow the batch-run set without touching framework code.
- **`apps/auth0-evals/eval.config.js`** drops Opus 4.5/4.6/4.7 from `models.known`. The framework still fully supports them (cost table, effort-capable set, Bedrock `modelIds` map all unchanged), so `--model claude-opus-4-6` still works for explicit runs.
- **Load-order fix:** the framework config must load *before* `--model all` expands, but the config path lives in argv. Added `extractConfigPath(argv)` to read `--config` up front (supports `--config <path>` and `--config=<path>`), then load the config before `parseRunConfig`.

## Changes

- `packages/eval/src/cli/validators.ts` — `validateModels(rawModels, knownModels?)` expands `all` to `knownModels` when provided
- `packages/eval/src/cli/config.ts` — new `extractConfigPath()`; `parseRunConfig` accepts `knownModels`
- `packages/eval/src/cli/run.ts` — load framework config before parsing; pass `models.known` through
- `packages/eval/src/cli/index.ts`, `src/index.ts` — export `extractConfigPath`
- `apps/auth0-evals/eval.config.js` — `models.known` drops 4.5/4.6/4.7 (with a comment explaining why)
- `AGENTS.md`, `packages/eval/README.md` — document config-driven `--model all`

## Tests

- New `cli-config.test.ts` cases: `--model all` uses `knownModels`; falls back when empty; explicit `--model` passes through even when not in `knownModels`; `extractConfigPath` for both flag forms
- `tsc --noEmit` clean; ESLint clean; **all 700 eval tests pass**
- `eval-core` is unchanged from `main`