### PR TITLE
feat(models): migrate model registry to latest models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ Use `notContainsInSource` (not `notContains`) when a value like a client ID is a
 | `notContains(needle)`                            | Substring must NOT appear in any non-excluded workspace file                                                                                                                                                                                   |
 | `notContainsInSource(needle)`                    | Substring must NOT appear in source files (allowed in config)                                                                                                                                                                                  |
 | `matches(pattern)`                               | Regex match in any non-excluded workspace file                                                                                                                                                                                                 |
-| `judge(question, framework?)`                    | LLM-as-judge yes/no question — uses `claude-opus-4-7`                                                                                                                                                                                          |
+| `judge(question, framework?)`                    | LLM-as-judge yes/no question — uses `claude-opus-4-8`                                                                                                                                                                                          |
 | `ranCommand(command, args, description, level)`  | Agent ran a shell command containing `command` (and all `args`) — event-based, level required (L4 or L5)                                                                                                                                       |
 | `ranCommandOneOf(commands, description, level)`  | Agent ran at least one command from the list — event-based, level required (L4 or L5)                                                                                                                                                          |
 | `wroteFile(path, description, level, expected?)` | Agent wrote a file whose path contains the substring. With optional `expected` (string or string array), the combined content of all writes to that path must also contain every `expected` substring — event-based, level required (L4 or L5) |
@@ -339,9 +339,7 @@ By default (LiteLLM proxy) the `modelIds` map is empty — the proxy serves mode
 
 Set `CLAUDE_CODE_USE_BEDROCK_PROXY=1` to route through the Bedrock proxy instead (`/anthropic` endpoint). The config then populates `modelIds` to map supported short aliases to full Bedrock model IDs:
 
-- `claude-sonnet-4-6` → `global.anthropic.claude-sonnet-4-6`
-- `claude-opus-4-6` → `global.anthropic.claude-opus-4-6-v1`
-- `claude-opus-4-7` → `global.anthropic.claude-opus-4-7`
+- `claude-sonnet-5` → `global.anthropic.claude-sonnet-5`
 - `claude-opus-4-8` → `global.anthropic.claude-opus-4-8`
 - `claude-opus-4-5` → `global.anthropic.claude-opus-4-5-20251101-v1:0`
 - `claude-haiku-4-5` → `global.anthropic.claude-haiku-4-5-20251001-v1:0`
@@ -350,7 +348,7 @@ Set `CLAUDE_CODE_USE_BEDROCK_PROXY=1` to route through the Bedrock proxy instead
 
 Uses `@github/copilot-sdk` to drive the bundled Copilot runtime over JSON-RPC. Inference is routed through the configured LLM proxy via an OpenAI-compatible BYOK provider (`provider: { type: 'openai', wireApi: 'responses', baseUrl, apiKey }`) — **not** GitHub's Copilot backend. The Responses API is required because Copilot emits freeform/custom tool calls (e.g. `apply_patch`) that the chat-completions API rejects — the same reason the Codex runner uses `wire_api = "responses"`. This mirrors the Codex runner: the proxy base URL resolves from `agents.copilot.proxy.baseUrl` (falling back to the top-level `proxy.baseUrl`) and is normalized to end in `/v1`; the API key comes from the `LLM_API_KEY` env var. Set `COPILOT_PROXY_BASE_URL` to override the proxy for this runner only.
 
-The runner is GPT-only: `gpt-*` / `o*` models pass through, anything else (e.g. `claude-*`, `gemini-*`, or the `copilot` sentinel) falls back to the default GPT model (`gpt-5.4`).
+The runner is GPT-only: `gpt-*` / `o*` models pass through, anything else (e.g. `claude-*`, `gemini-*`, or the `copilot` sentinel) falls back to the default GPT model (`gpt-5.6-sol`).
 
 ---
 
@@ -368,26 +366,27 @@ When MCP tools are enabled (`--tools mcp`), MCP server tool definitions are appe
 
 `--model all` expands to this app's `models.known` in `eval.config.js` (falling back to the framework's `KNOWN_WORKING_MODELS` constant only if the app leaves `models.known` empty):
 
-- `gpt-5.4` (default when no `--model` flag)
-- `gpt-5.4-mini`
-- `claude-sonnet-4-6`
+- `gpt-5.6-sol` (default when no `--model` flag)
+- `gpt-5.6-luna`
+- `gpt-5.6-terra`
+- `claude-sonnet-5`
 - `claude-opus-4-8`
 - `claude-haiku-4-5`
 - `gemini-3.1-pro-preview`
 - `gemini-3.5-flash`
 
-Opus 4.5, 4.6, and 4.7 are still supported by the framework (present in the cost table, effort-capable set, and Bedrock alias map) and can be run explicitly via `--model claude-opus-4-6`; they are intentionally omitted from `--model all` here so batch runs use only Opus 4.8 among the Opus variants.
+Opus 4.5 is still supported by the framework (present in the effort-capable set and Bedrock alias map) and can be run explicitly via `--model claude-opus-4-5`; it is intentionally omitted from `--model all` here so batch runs use only Opus 4.8 among the Opus variants. Opus 4.6 and 4.7 have been removed from the registry (deprecated).
 
 ### Judge model
 
-All LLM-as-judge graders use `claude-sonnet-4-5` via the configured LLM proxy (`proxy.baseUrl` in `eval.config.js`).
+All LLM-as-judge graders use `claude-opus-4-8` via the configured LLM proxy (`proxy.baseUrl` in `eval.config.js`).
 
 ### Settings
 
 | Setting              | Value                                            |
 | -------------------- | ------------------------------------------------ |
 | Base URL             | Configured in `eval.config.js` (`proxy.baseUrl`) |
-| Judge model          | `claude-sonnet-4-5`                              |
+| Judge model          | `claude-opus-4-8`                                |
 | Judge max tokens     | 1024                                             |
 | Judge max code chars | 32,768                                           |
 | Max agent turns      | 75                                               |
@@ -433,7 +432,7 @@ npm run report
 | Flag                         | Values                                          | Default              | Notes                                                    |
 | ---------------------------- | ----------------------------------------------- | -------------------- | -------------------------------------------------------- |
 | `--eval <id>`                | Any registered eval ID                          | all evals            | Repeatable                                               |
-| `--model <model>`            | Any model string                                | `gpt-5.4`            | Repeatable; `all` expands to the config's `models.known` |
+| `--model <model>`            | Any model string                                | `gpt-5.6-sol`        | Repeatable; `all` expands to the config's `models.known` |
 | `--mode <mode>`              | `baseline`, `agent`, `all`                      | `baseline`           | `all` expands to both                                    |
 | `--tools <tools>`            | `skills`, `mcp`, or comma-separated             | none                 | Only applies to agent mode                               |
 | `--agent-type <type>`        | `claude-code`, `copilot`, `gemini-cli`, `codex` | auto-routed by model | Overrides auto-routing                                   |

--- a/apps/auth0-evals/eval.config.js
+++ b/apps/auth0-evals/eval.config.js
@@ -91,19 +91,17 @@ export default {
   },
 
   models: {
-    // `known` is the set `--model all` expands to. Opus 4.5/4.6/4.7 are intentionally
-    // excluded here so `--model all` runs only Opus 4.8 among the Opus variants; the
-    // framework and `modelIds` map below still support them for explicit `--model` runs.
-    known: ['gpt-5.4', 'gpt-5.4-mini', 'claude-sonnet-4-6', 'claude-opus-4-8', 'claude-haiku-4-5', 'gemini-3.1-pro-preview', 'gemini-3.5-flash'],
-    default: 'gpt-5.4',
+    // `known` is the set `--model all` expands to. Opus 4.5 is intentionally excluded
+    // here so `--model all` runs only Opus 4.8 among the Opus variants; the framework
+    // and `modelIds` map below still support it for explicit `--model` runs.
+    known: ['gpt-5.6-sol', 'gpt-5.6-luna', 'gpt-5.6-terra', 'claude-sonnet-5', 'claude-opus-4-8', 'claude-haiku-4-5', 'gemini-3.1-pro-preview', 'gemini-3.5-flash'],
+    default: 'gpt-5.6-sol',
     // Maps short model aliases to the IDs the active proxy expects.
     // Bedrock proxy needs full `global.anthropic.*` IDs; LiteLLM proxy serves
     // models under the alias itself, so the map is empty and aliases pass through.
     modelIds: useBedrock
       ? {
-          'claude-sonnet-4-6': 'global.anthropic.claude-sonnet-4-6',
-          'claude-opus-4-6': 'global.anthropic.claude-opus-4-6-v1',
-          'claude-opus-4-7': 'global.anthropic.claude-opus-4-7',
+          'claude-sonnet-5': 'global.anthropic.claude-sonnet-5',
           'claude-opus-4-8': 'global.anthropic.claude-opus-4-8',
           'claude-opus-4-5': 'global.anthropic.claude-opus-4-5-20251101-v1:0',
           'claude-haiku-4-5': 'global.anthropic.claude-haiku-4-5-20251001-v1:0',

--- a/packages/eval-core/src/config/costs.ts
+++ b/packages/eval-core/src/config/costs.ts
@@ -1,13 +1,10 @@
 import { logger } from '../utils/logger.js';
 
 export const COST_TABLE: Record<string, [number, number]> = {
-  'gpt-5.4': [2.5, 15.0],
-  'gpt-5.4-mini': [0.75, 4.5],
-  'gpt-4.1': [2.0, 8.0],
-  'claude-sonnet-4-5': [3.0, 15.0],
-  'claude-sonnet-4-6': [3.0, 15.0],
-  'claude-opus-4-6': [5.0, 25.0],
-  'claude-opus-4-7': [5.0, 25.0],
+  'gpt-5.6-sol': [5.0, 30.0],
+  'gpt-5.6-luna': [1.0, 6.0],
+  'gpt-5.6-terra': [2.5, 15.0],
+  'claude-sonnet-5': [2.0, 10.0],
   'claude-opus-4-8': [5.0, 25.0],
   'claude-haiku-4-5': [1.0, 5.0],
   'gemini-3.1-pro-preview': [2.0, 12.0],

--- a/packages/eval-core/src/config/settings.ts
+++ b/packages/eval-core/src/config/settings.ts
@@ -7,14 +7,8 @@ export const MAX_TURNS = 75;
 export const BEDROCK_MODELS = ['claude-'];
 
 // Claude models that support output_config.effort to cap reasoning effort and reduce latency.
-// Supported here: Claude Opus 4.6, Sonnet 4.6, Opus 4.7, Opus 4.8, and Opus 4.5.
-export const CLAUDE_EFFORT_MODELS = new Set([
-  'claude-opus-4-6',
-  'claude-sonnet-4-6',
-  'claude-opus-4-7',
-  'claude-opus-4-8',
-  'claude-opus-4-5',
-]);
+// Supported here: Claude Sonnet 5, Opus 4.8, and Opus 4.5.
+export const CLAUDE_EFFORT_MODELS = new Set(['claude-sonnet-5', 'claude-opus-4-8', 'claude-opus-4-5']);
 
 // Model name prefixes that use the older functions/function_call API
 // instead of tools/tool_choice.

--- a/packages/eval-core/src/loader.ts
+++ b/packages/eval-core/src/loader.ts
@@ -133,11 +133,7 @@ async function loadGraders(gradersPath: string): Promise<GraderDef[]> {
  * Resolve the scaffold directory from the optional `scaffold` frontmatter field.
  * Falls back to the local scaffold/ subdirectory when the field is absent.
  */
-function resolveScaffoldFromMeta(
-  scaffoldMeta: string | undefined,
-  evalPath: string,
-  frameworkRoot: string,
-): string {
+function resolveScaffoldFromMeta(scaffoldMeta: string | undefined, evalPath: string, frameworkRoot: string): string {
   if (!scaffoldMeta) {
     return join(evalPath, 'scaffold');
   }
@@ -153,10 +149,7 @@ function resolveScaffoldFromMeta(
   }
 
   if (!existsSync(resolvedPath)) {
-    throw new EvalConfigError(
-      `scaffold path does not exist: ${resolvedPath}`,
-      join(evalPath, 'PROMPT.md'),
-    );
+    throw new EvalConfigError(`scaffold path does not exist: ${resolvedPath}`, join(evalPath, 'PROMPT.md'));
   }
 
   return resolvedPath;

--- a/packages/eval-core/tests/costs.test.ts
+++ b/packages/eval-core/tests/costs.test.ts
@@ -21,13 +21,13 @@ beforeEach(() => {
 
 describe('estimateCost', () => {
   it('computes cost from the model pricing in COST_TABLE', () => {
-    const [inPrice, outPrice] = COST_TABLE['gpt-5.4']!;
-    const cost = estimateCost('gpt-5.4', 1_000_000, 1_000_000);
+    const [inPrice, outPrice] = COST_TABLE['gpt-5.6-sol']!;
+    const cost = estimateCost('gpt-5.6-sol', 1_000_000, 1_000_000);
     expect(cost).toBeCloseTo(inPrice + outPrice, 6);
   });
 
   it('returns 0 for zero tokens', () => {
-    expect(estimateCost('gpt-5.4', 0, 0)).toBe(0);
+    expect(estimateCost('gpt-5.6-sol', 0, 0)).toBe(0);
   });
 
   it('applies DEFAULT_PRICING and warns once for an unknown model', () => {

--- a/packages/eval-core/tests/model-detect.test.ts
+++ b/packages/eval-core/tests/model-detect.test.ts
@@ -3,22 +3,22 @@ import { isBedrockModel, isClaudeModel, isGeminiModel, isGptModel } from '../src
 
 describe('model detection', () => {
   it('isBedrockModel matches claude- prefix', () => {
-    expect(isBedrockModel('claude-opus-4-7')).toBe(true);
-    expect(isBedrockModel('gpt-5.4')).toBe(false);
+    expect(isBedrockModel('claude-opus-4-8')).toBe(true);
+    expect(isBedrockModel('gpt-5.6-sol')).toBe(false);
   });
 
   it('isClaudeModel is an alias for isBedrockModel', () => {
-    expect(isClaudeModel('claude-sonnet-4-6')).toBe(true);
+    expect(isClaudeModel('claude-sonnet-5')).toBe(true);
     expect(isClaudeModel('gemini-3.1-pro-preview')).toBe(false);
   });
 
   it('isGeminiModel matches gemini- prefix', () => {
     expect(isGeminiModel('gemini-3.1-pro-preview')).toBe(true);
-    expect(isGeminiModel('claude-opus-4-7')).toBe(false);
+    expect(isGeminiModel('claude-opus-4-8')).toBe(false);
   });
 
   it('isGptModel matches gpt- prefix', () => {
-    expect(isGptModel('gpt-5.4')).toBe(true);
-    expect(isGptModel('claude-opus-4-7')).toBe(false);
+    expect(isGptModel('gpt-5.6-sol')).toBe(true);
+    expect(isGptModel('claude-opus-4-8')).toBe(false);
   });
 });

--- a/packages/eval/src/cli/constants.ts
+++ b/packages/eval/src/cli/constants.ts
@@ -10,11 +10,10 @@ export type { AgentType, Mode } from '@a0/eval-core';
 
 /** Models known to work reliably across all eval modes. Used when `--model all` is passed. */
 export const KNOWN_WORKING_MODELS = [
-  'gpt-5.4',
-  'gpt-5.4-mini',
-  'claude-sonnet-4-6',
-  'claude-opus-4-6',
-  'claude-opus-4-7',
+  'gpt-5.6-sol',
+  'gpt-5.6-luna',
+  'gpt-5.6-terra',
+  'claude-sonnet-5',
   'claude-opus-4-8',
   'claude-haiku-4-5',
   'gemini-3.1-pro-preview',
@@ -22,7 +21,7 @@ export const KNOWN_WORKING_MODELS = [
 ];
 
 /** Model used when no `--model` flag is provided. */
-export const DEFAULT_MODEL = 'gpt-5.4';
+export const DEFAULT_MODEL = 'gpt-5.6-sol';
 
 /** Tool names accepted by the `--tools` flag (case-insensitive). */
 export const KNOWN_TOOLS = ['skills', 'mcp'];

--- a/packages/eval/src/cli/run.ts
+++ b/packages/eval/src/cli/run.ts
@@ -7,7 +7,7 @@
  *
  * Options:
  *   --eval        Eval ID to run (default: all). Can be repeated.
- *   --model       Model(s) to run (default: gpt-5.4). Can be repeated.
+ *   --model       Model(s) to run (default: gpt-5.6-sol). Can be repeated.
  *                 Use 'all' to run all known working models.
  *   --mode        Execution mode: baseline | agent | all (default: baseline)
  *   --agent-type  Agent runner: claude-code | copilot | gemini-cli | codex

--- a/packages/eval/src/runners/claude-code/agent.ts
+++ b/packages/eval/src/runners/claude-code/agent.ts
@@ -73,7 +73,7 @@ export interface ClaudeCodeRunOptions {
    * Claude model identifier to pass via `model` option.
    * When omitted the SDK uses its own default model.
    * Use the Anthropic model ID format (e.g. `claude-sonnet-4-5-20251101`) or
-   * a proxy alias (e.g. `claude-sonnet-4-6`) when routing through the proxy.
+   * a proxy alias (e.g. `claude-sonnet-5`) when routing through the proxy.
    */
   model?: string;
 }
@@ -305,9 +305,7 @@ export function handleMessage(
 
     const usage = msg.usage;
     const turnInput =
-      (usage?.input_tokens ?? 0) +
-      (usage?.cache_read_input_tokens ?? 0) +
-      (usage?.cache_creation_input_tokens ?? 0);
+      (usage?.input_tokens ?? 0) + (usage?.cache_read_input_tokens ?? 0) + (usage?.cache_creation_input_tokens ?? 0);
     const turnOutput = usage?.output_tokens ?? 0;
     record.inputTokens += turnInput;
     record.outputTokens += turnOutput;

--- a/packages/eval/src/runners/codex/agent.ts
+++ b/packages/eval/src/runners/codex/agent.ts
@@ -48,7 +48,7 @@ const translator = new CodexTranslator();
 export const CODEX_MODEL_ID = 'codex';
 
 /** Default model for the Codex CLI runner. */
-export const CODEX_DEFAULT_MODEL = 'gpt-5.4';
+export const CODEX_DEFAULT_MODEL = 'gpt-5.6-sol';
 
 /**
  * Writes Codex config.toml to configure a custom proxy provider.

--- a/packages/eval/src/runners/copilot/agent.ts
+++ b/packages/eval/src/runners/copilot/agent.ts
@@ -38,7 +38,7 @@ const translator = new CopilotCliTranslator();
 export const COPILOT_MODEL_ID = 'copilot';
 
 /** Default GPT model used when no explicit model is requested. */
-export const COPILOT_DEFAULT_MODEL = 'gpt-5.4';
+export const COPILOT_DEFAULT_MODEL = 'gpt-5.6-sol';
 
 export interface CopilotRunOptions {
   /** Path to the `copilot` binary. Defaults to the bundled CLI from @github/copilot. */

--- a/packages/eval/src/runners/gemini-cli/runner.ts
+++ b/packages/eval/src/runners/gemini-cli/runner.ts
@@ -15,7 +15,7 @@ export class GeminiCliRunner implements AgentRunner {
 
   async run({ evalDef, workspace, model, tools }: RunParams): Promise<RunResult> {
     // Accept either the sentinel 'gemini-cli' or a real Gemini model ID
-    // (e.g. 'gemini-2.5-flash').  Anything else (e.g. the default 'gpt-5.4')
+    // (e.g. 'gemini-2.5-flash').  Anything else (e.g. the default 'gpt-5.6-sol')
     // is not a valid Gemini model — fall back to the default flash model so
     // running with --agent-type gemini-cli and no --model flag still works.
     const isGeminiModel = model === GEMINI_CLI_MODEL_ID || model.startsWith('gemini-');

--- a/packages/eval/tests/baseline.test.ts
+++ b/packages/eval/tests/baseline.test.ts
@@ -41,18 +41,23 @@ function makeAiResponse(text = 'Here is the code.', inputTokens = 100, outputTok
 
 describe('estimateCost', () => {
   it('uses correct input price for known model', () => {
-    const cost = estimateCost('gpt-5.4', 1_000_000, 0);
-    expect(cost).toBe(2.5);
+    const cost = estimateCost('gpt-5.6-sol', 1_000_000, 0);
+    expect(cost).toBe(5.0);
   });
 
   it('uses correct output price for known model', () => {
-    const cost = estimateCost('gpt-5.4', 0, 1_000_000);
-    expect(cost).toBe(15.0);
+    const cost = estimateCost('gpt-5.6-sol', 0, 1_000_000);
+    expect(cost).toBe(30.0);
   });
 
   it('sums input and output costs', () => {
-    const cost = estimateCost('gpt-5.4', 1_000_000, 1_000_000);
-    expect(cost).toBe(17.5);
+    const cost = estimateCost('gpt-5.6-sol', 1_000_000, 1_000_000);
+    expect(cost).toBe(35.0);
+  });
+
+  it('prices another known model from COST_TABLE', () => {
+    const cost = estimateCost('claude-sonnet-5', 1_000_000, 0);
+    expect(cost).toBe(2.0);
   });
 
   it('uses default price for unknown model', () => {
@@ -61,7 +66,7 @@ describe('estimateCost', () => {
   });
 
   it('returns zero cost for zero tokens', () => {
-    const cost = estimateCost('gpt-5.4', 0, 0);
+    const cost = estimateCost('gpt-5.6-sol', 0, 0);
     expect(cost).toBe(0.0);
   });
 });
@@ -77,29 +82,29 @@ describe('runBaseline', () => {
   it('returns a BaselineResult with eval_id and model', async () => {
     mockGenerateText.mockResolvedValue(makeAiResponse());
 
-    const result = await runBaseline('key', 'gpt-5.4', makeEvalDef());
+    const result = await runBaseline('key', 'gpt-5.6-sol', makeEvalDef());
     expect(result.evalId).toBe('react_quickstart');
-    expect(result.model).toBe('gpt-5.4');
+    expect(result.model).toBe('gpt-5.6-sol');
   });
 
   it('mode is baseline', async () => {
     mockGenerateText.mockResolvedValue(makeAiResponse());
 
-    const result = await runBaseline('key', 'gpt-5.4', makeEvalDef());
+    const result = await runBaseline('key', 'gpt-5.6-sol', makeEvalDef());
     expect(result.mode).toBe('baseline');
   });
 
   it('captures response text', async () => {
     mockGenerateText.mockResolvedValue(makeAiResponse('Auth0 code here'));
 
-    const result = await runBaseline('key', 'gpt-5.4', makeEvalDef());
+    const result = await runBaseline('key', 'gpt-5.6-sol', makeEvalDef());
     expect(result.responseText).toBe('Auth0 code here');
   });
 
   it('captures token counts', async () => {
     mockGenerateText.mockResolvedValue(makeAiResponse('ok', 500, 250));
 
-    const result = await runBaseline('key', 'gpt-5.4', makeEvalDef());
+    const result = await runBaseline('key', 'gpt-5.6-sol', makeEvalDef());
     expect(result.inputTokens).toBe(500);
     expect(result.outputTokens).toBe(250);
   });
@@ -107,7 +112,7 @@ describe('runBaseline', () => {
   it('defaults token counts to zero when usage fields are absent', async () => {
     mockGenerateText.mockResolvedValue({ text: 'ok', usage: { inputTokens: undefined, outputTokens: undefined } });
 
-    const result = await runBaseline('key', 'gpt-5.4', makeEvalDef());
+    const result = await runBaseline('key', 'gpt-5.6-sol', makeEvalDef());
     expect(result.inputTokens).toBe(0);
     expect(result.outputTokens).toBe(0);
   });
@@ -115,21 +120,21 @@ describe('runBaseline', () => {
   it('calculates cost from token counts', async () => {
     mockGenerateText.mockResolvedValue(makeAiResponse('ok', 1_000_000, 0));
 
-    const result = await runBaseline('key', 'gpt-5.4', makeEvalDef());
-    expect(result.costUsd).toBe(2.5);
+    const result = await runBaseline('key', 'gpt-5.6-sol', makeEvalDef());
+    expect(result.costUsd).toBe(5.0);
   });
 
   it('status is success on happy path', async () => {
     mockGenerateText.mockResolvedValue(makeAiResponse());
 
-    const result = await runBaseline('key', 'gpt-5.4', makeEvalDef());
+    const result = await runBaseline('key', 'gpt-5.6-sol', makeEvalDef());
     expect(result.status).toBe('success');
   });
 
   it('status is failure on error', async () => {
     mockGenerateText.mockRejectedValue(new Error('timeout'));
 
-    const result = await runBaseline('key', 'gpt-5.4', makeEvalDef());
+    const result = await runBaseline('key', 'gpt-5.6-sol', makeEvalDef());
     expect(result.status).toBe('failure');
     expect(result.error).toContain('timeout');
   });
@@ -137,7 +142,7 @@ describe('runBaseline', () => {
   it('records wall time', async () => {
     mockGenerateText.mockResolvedValue(makeAiResponse());
 
-    const result = await runBaseline('key', 'gpt-5.4', makeEvalDef());
+    const result = await runBaseline('key', 'gpt-5.6-sol', makeEvalDef());
     expect(typeof result.wallTime).toBe('number');
     expect(result.wallTime).toBeGreaterThanOrEqual(0);
   });
@@ -145,7 +150,7 @@ describe('runBaseline', () => {
   it('passes system prompt and user prompt to generateText', async () => {
     mockGenerateText.mockResolvedValue(makeAiResponse());
 
-    await runBaseline('key', 'gpt-5.4', makeEvalDef());
+    await runBaseline('key', 'gpt-5.6-sol', makeEvalDef());
     expect(mockGenerateText).toHaveBeenCalledWith(
       expect.objectContaining({
         system: 'You are a React developer.',
@@ -157,7 +162,7 @@ describe('runBaseline', () => {
   it('omits system when baselineSystemPrompt is undefined', async () => {
     mockGenerateText.mockResolvedValue(makeAiResponse());
 
-    await runBaseline('key', 'gpt-5.4', { id: 'x', userPrompt: 'hello', baselineSystemPrompt: undefined });
+    await runBaseline('key', 'gpt-5.6-sol', { id: 'x', userPrompt: 'hello', baselineSystemPrompt: undefined });
     expect(mockGenerateText).toHaveBeenCalledWith(expect.objectContaining({ system: undefined, prompt: 'hello' }));
   });
 });

--- a/packages/eval/tests/runners/claude-code-agent.test.ts
+++ b/packages/eval/tests/runners/claude-code-agent.test.ts
@@ -297,7 +297,12 @@ describe('handleMessage — assistant', () => {
     const record = makeRecord();
     record.inputTokens = 0;
     handleMessage(
-      makeAssistantMsg({ input_tokens: 6, output_tokens: 3, cache_read_input_tokens: 4800, cache_creation_input_tokens: 200 }),
+      makeAssistantMsg({
+        input_tokens: 6,
+        output_tokens: 3,
+        cache_read_input_tokens: 4800,
+        cache_creation_input_tokens: 200,
+      }),
       record,
       makePending(),
       0,
@@ -602,7 +607,12 @@ describe('handleMessage — result', () => {
     const record = makeRecord();
     record.inputTokens = 999;
     handleMessage(
-      makeResultMsg({ input_tokens: 100, output_tokens: 50, cache_read_input_tokens: 4000, cache_creation_input_tokens: 500 }),
+      makeResultMsg({
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 4000,
+        cache_creation_input_tokens: 500,
+      }),
       record,
       makePending(),
       0,

--- a/packages/eval/tests/runners/copilot-agent.test.ts
+++ b/packages/eval/tests/runners/copilot-agent.test.ts
@@ -117,8 +117,8 @@ describe('COPILOT_MODEL_ID', () => {
 });
 
 describe('COPILOT_DEFAULT_MODEL', () => {
-  it('is gpt-5.4', () => {
-    expect(COPILOT_DEFAULT_MODEL).toBe('gpt-5.4');
+  it('is gpt-5.6-sol', () => {
+    expect(COPILOT_DEFAULT_MODEL).toBe('gpt-5.6-sol');
   });
 });
 


### PR DESCRIPTION
## Summary

Migrates the eval model registry to the latest models available for our API key, updated in lockstep across every touch point so `--model all`, cost estimation, and Bedrock alias resolution stay consistent.

**Model transitions:**
- **OpenAI:** `gpt-5.4` → `gpt-5.6-sol` (new default), `gpt-5.4-mini` → `gpt-5.6-luna`, added `gpt-5.6-terra`
- **Anthropic:** `claude-sonnet-4-6` → `claude-sonnet-5`; removed deprecated **Opus 4.6 / 4.7** from the registry and cost map (Opus 4.5 retained in the Bedrock alias map for explicit `--model` runs)
- **Unchanged:** Haiku 4.5, Gemini 3.1 Pro, Gemini 3.5 Flash

**Touch points:** `constants.ts` (KNOWN_WORKING_MODELS + DEFAULT_MODEL), `costs.ts` (COST_TABLE), `settings.ts` (CLAUDE_EFFORT_MODELS), `eval.config.js` (known list + Bedrock `modelIds`), codex/copilot runner defaults, and `AGENTS.md`.

**Pricing** validated against [models.litellm.ai](https://models.litellm.ai/) (per-MTok): sol 5/30, luna 1/6, terra 2.5/15, sonnet-5 2/10, opus-4-8 5/25, haiku-4-5 1/5, gemini-pro 2/12, gemini-flash 1.5/9.

Also aligned AGENTS.md's judge-model docs to the actually-configured value (`claude-opus-4-8`), since they referenced the now-removed Opus 4.7 / Sonnet 4.5.

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 701/701 pass
- [x] `npm run lint` — clean
- [x] `npm run format` — applied
- [x] Grep sweep: no stale model strings remain in source/config/docs
- [ ] Live single-eval smoke run (`--dangerously-skip-sandbox`) — requires proxy + API key; not run locally