### PR TITLE
fix(evals): centralize .env creation guidance for all agent runs

### DIFF
--- a/apps/auth0-evals/src/evals/quickstarts/angular/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/angular/PROMPT.md
@@ -15,5 +15,3 @@ Client ID: playground_client_abc123xyz
 Set up Auth0 using provideAuth0, implement login and logout, display the authenticated user's name and profile picture, and protect a /profile route so only logged-in users can access it.
 
 Also get an Access Token to call an external API with audience https://api.playground.com and include a function that makes an authenticated API request using that token.
-
-Do not prompt for permissions to create any .env or .env.local files.

--- a/apps/auth0-evals/src/evals/quickstarts/express/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/express/PROMPT.md
@@ -18,5 +18,3 @@ Audience: https://api.barkbook.com
 I also need to call an external API — get an access token and include a route that makes an authenticated request using that token.
 
 Create a protected /profile route that requires login and shows the user's profile.
-
-Do not prompt for permissions to create any .env or .env.local files.

--- a/apps/auth0-evals/src/evals/quickstarts/fastapi/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/fastapi/PROMPT.md
@@ -16,6 +16,4 @@ I need two protected routes:
 1. /api/messages — requires a valid token with the `read:messages` scope, returns the user's `sub` claim
 2. /api/private — requires any valid token, returns the user's `sub` claim
 
-Do not prompt for permissions to create any .env files.
-
 A virtual environment is already set up at `.venv`. Use `.venv/bin/pip` to install packages and update `requirements.txt` with any new dependencies.

--- a/apps/auth0-evals/src/evals/quickstarts/fastify-api/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/fastify-api/PROMPT.md
@@ -15,5 +15,3 @@ Audience: https://api.barkbook.com
 I need two protected routes:
 1. /api/messages — requires a valid token with the `read:messages` scope, returns the user's `sub` claim
 2. /api/private — requires any valid token, returns the user's `sub` claim
-
-Do not prompt for permissions to create any .env files.

--- a/apps/auth0-evals/src/evals/quickstarts/flask/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/flask/PROMPT.md
@@ -19,6 +19,4 @@ I also need to call an external API — get an access token and include a route 
 
 Create a protected /profile route that requires login and shows the user's profile.
 
-Do not prompt for permissions to create any .env files.
-
 A virtual environment is already set up at `.venv`. Use `.venv/bin/pip` to install packages and update `requirements.txt` with any new dependencies.

--- a/apps/auth0-evals/src/evals/quickstarts/nextjs/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/nextjs/PROMPT.md
@@ -17,5 +17,3 @@ The /dashboard page should be behind a login — if the user is not authenticate
 
 Also get an Access Token to call an external API with audience https://api.playground.com and include a function that makes an authenticated API request using that token.
 
-Do not prompt for permissions to create any .env or .env.local files.
-

--- a/apps/auth0-evals/src/evals/quickstarts/nuxt/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/nuxt/PROMPT.md
@@ -16,5 +16,3 @@ Client Secret: playground_secret_def456uvw
 Set up the Auth0 module in nuxt.config.ts, implement login and logout, display the authenticated user's name and profile picture, and protect a /profile route so only logged-in users can access it.
 
 Also get an Access Token to call an external API with audience https://api.playground.com and include a function that makes an authenticated API request using that token.
-
-Do not prompt for permissions to create any .env or .env.local files.

--- a/apps/auth0-evals/src/evals/quickstarts/vue/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/vue/PROMPT.md
@@ -15,5 +15,3 @@ Client ID: playground_client_abc123xyz
 Set up the Auth0 plugin, implement login and logout, display the authenticated user's name and profile picture, and protect a /profile route so only logged-in users can access it.
 
 Also get an Access Token to call an external API with audience https://api.playground.com and include a function that makes an authenticated API request using that token.
-
-Do not prompt for permissions to create any .env or .env.local files.

--- a/packages/evals-core/src/workspace/workspace.ts
+++ b/packages/evals-core/src/workspace/workspace.ts
@@ -31,6 +31,8 @@ import { resolveInside } from './path-utils.js';
  * context file (see {@link AGENT_CONTEXT_FILENAMES}).
  */
 export const AGENT_GUIDANCE = `Do not create any documentation files (README.md, SETUP.md, QUICKSTART.md, IMPLEMENTATION_SUMMARY.md, or any other .md files). Do not create any .txt summary or verification files. Do not create standalone summary or status files of any kind (e.g. AUTH0_SETUP.ts, IMPLEMENTATION_COMPLETE.ts, QUICK_START.ts, FILES_CREATED.txt) — these are not application source code. Only create and modify source code files that are part of the application.
+
+If the task requires environment variables (e.g. .env or .env.local files), create those files directly — do not pause to ask for permission to create them.
 `;
 
 /**

--- a/packages/evals-core/tests/workspace.test.ts
+++ b/packages/evals-core/tests/workspace.test.ts
@@ -106,6 +106,11 @@ describe('writeAgentGuidance - runner-aware context file', () => {
     cleanupWorkspace(workspace);
   });
 
+  it('steers the agent to create .env files directly without pausing for permission', () => {
+    expect(AGENT_GUIDANCE).toContain('.env');
+    expect(AGENT_GUIDANCE).toContain('do not pause to ask for permission');
+  });
+
   it('appends to an existing context file, preserving its content', () => {
     const workspace = setupWorkspace({ 'CLAUDE.md': 'Scaffold guidance.\n' });
     writeAgentGuidance(workspace, 'claude-code');


### PR DESCRIPTION
## What

Moves the `.env` no-permission-prompt guidance out of the eight individual quickstart `PROMPT.md` files and into the central `AGENT_GUIDANCE` string, so it reaches **every agent run** automatically.

## Why

The line *"Do not prompt for permissions to create any .env files"* was intended only to stop the agent pausing for a permission (`ask_user`) prompt. It was duplicated across eight quickstart prompts (fastapi, flask, nuxt, angular, express, fastify-api, nextjs, vue), and any future eval needing a `.env` would have to copy it again.

`writeAgentGuidance()` already injects `AGENT_GUIDANCE` into whichever context file the active runner reads (`CLAUDE.md` / `GEMINI.md` / `AGENTS.md` / `.github/copilot-instructions.md`) on every agent job — the same mechanism the existing "no documentation files" steering uses. Putting the `.env` intent there makes it DRY and applies it to all runners and all current/future evals.

## Change

- Add to `AGENT_GUIDANCE` (`packages/evals-core/src/workspace/workspace.ts`):

  > If the task requires environment variables (e.g. .env or .env.local files), create those files directly — do not pause to ask for permission to create them.

- Remove the now-redundant per-prompt lines from the eight quickstart `PROMPT.md` files.
- Add a test asserting the guidance carries the `.env` no-permission steering.

The credential-in-source concern (agents hardcoding secrets instead of using `.env`) is intentionally **not** covered here — that belongs to the skill, and is enforced independently by the L3 `notContainsInSource` grader.

## Notes

No frontmatter schema change, so no `docs/ADDING_EVALS.md` update required.