### PR TITLE
fix(graders): guard judge against unverifiable SDK-shape claims

### DIFF
--- a/packages/evals-core/src/graders/prompts/default.md
+++ b/packages/evals-core/src/graders/prompts/default.md
@@ -1,1 +1,5 @@
-You are a strict code reviewer. Provide 1-3 short sentences of reasoning, then on the FINAL line write your verdict as exactly 'yes' or 'no' (nothing else on that line).
+You are a strict code reviewer. Judge only what the question asks and what the code shows.
+
+Do NOT fail code over claims you cannot verify from the code in front of you. In particular, do not assert that an import path is wrong, that a package exposes a symbol under a different module name, or that a method signature is invalid unless the code itself contradicts the question — your memory of a package's module layout may be outdated or incorrect, and a package's public import surface often differs from its internal module name.
+
+Provide 1-3 short sentences of reasoning, then on the FINAL line write your verdict as exactly 'yes' or 'no' (nothing else on that line).


### PR DESCRIPTION
## What

Hardens the shared LLM-judge system prompt (`packages/evals-core/src/graders/prompts/default.md`) so the judge stops failing correct code over SDK-shape claims it cannot verify from the code in front of it.

## Why

The judge produced **false negatives** by asserting, from stale/incorrect model memory, that valid code was broken. Two confirmed cases from the latest matrix:

- **fastapi**: judge claimed `from fastapi_plugin import Auth0FastAPI` *"would cause an ImportError."* Verified against `auth0-fastapi-api==1.0.0b7`: `fastapi_plugin` is the **correct** public import; `auth0_fastapi_api` (what the judge said was right) does **not** exist. The agent's own runtime `import main` succeeded in the trace.
- **nuxt**: judge called `useAuth0`, `getSession`, and `{ accessToken }` destructuring *"invented."* Verified against `@auth0/auth0-nuxt@1.1.0`: all three are real (`useAuth0(event): Auth0Client`, `getSession(): Promise<SessionData | undefined>`, `getAccessToken(): Promise<TokenSet>` where `TokenSet.accessToken: string`).

These verdicts sank otherwise-correct runs (fastapi 84.2 was the only sub-85 run in the matrix, driven partly by these two judge failures).

## Change

Adds guidance to `default.md` instructing the judge to grade only what the code shows and not to assert an import path is wrong, that a package exposes a symbol under a different module name, or that a signature is invalid unless the code itself contradicts the question — because a package's public import surface often differs from its internal module name.

`default.md` is the source for `prompts.generated.ts` (gitignored, regenerated on build via `scripts/generate-prompts.mjs`).

## Verification

- `npm run build` ✓ (5/5 packages)
- `npm test` ✓ (all tasks; 484 tests in evals-core)
- `npm run lint` ✓ / `npm run format` ✓ (unchanged)

## Notes

Companion to `fix/quickstart-env-prompt-wording` (#125), which addresses the separate hardcoded-secret failures. Independent — either can merge first.