### PR TITLE
chore(packages): restrict published files to build output

### DIFF
--- a/packages/evals-core/package.json
+++ b/packages/evals-core/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": ["dist"],
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/packages/evals-graders/package.json
+++ b/packages/evals-graders/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": ["dist"],
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/packages/evals-reporter/package.json
+++ b/packages/evals-reporter/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": ["dist", "src/templates"],
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -7,6 +7,7 @@
   "bin": {
     "a0-eval": "./dist/cli/bin.js"
   },
+  "files": ["dist"],
   "exports": {
     ".": {
       "import": "./dist/index.js",


### PR DESCRIPTION
## What

Add a `files` allowlist to all four `@a0/*` packages so npm-published tarballs ship only what consumers need. Today no package has a `files` field or `.npmignore`, so `npm pack` bundles `src/`, `tests/`, and dev tooling configs (`tsconfig.json`, `eslint.config.mjs`, `vitest.config.ts`, and `evals-core`'s `scripts/`) alongside `dist/`.

| Package | Now ships |
| --- | --- |
| `@a0/evals` | `dist` (+ `README.md`, added by npm automatically) |
| `@a0/evals-core` | `dist` |
| `@a0/evals-graders` | `dist` |
| `@a0/evals-reporter` | `dist` + `src/templates` |

## Why `evals-reporter` is different

Its nunjucks templates (`report.html.j2`, `report.css`) live in `src/templates/`, are **not** copied into `dist/` by `tsc`, and are loaded at runtime via `report.ts`'s `dist/../src/templates` fallback. A plain `files: ["dist"]` would install and import fine but throw the moment a report is rendered — so `src/templates` stays in its allowlist.

`evals-core` has a similar shape (two prompt `.md` files) but they're inlined into `dist` at build time by `generate-prompts.mjs`, so `dist` alone is safe there.

## Verification

Packed all four, installed them into a fresh copy of `apps/auth0-evals` **outside the workspace** (no symlinks), then:

- `npm install` — all four resolve locally
- `npm run build` — compiles against the installed packages
- `a0-eval --help` / `a0-eval run --help` — CLI bin + import graph load
- `a0-eval report` — rendered a full 28 KB HTML report, proving the reporter's templates resolve from the installed tarball

No source/behavior changes — `files` fields only. Pre-existing `docker.test.ts` failures in this environment (Docker unavailable) are unrelated and reproduce on clean `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package publishing configuration to include only required build output.
  * Preserved necessary reporter templates in the published package.
  * Reduced unnecessary files in distributed packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->