### PR TITLE
fix(fastify-api): give L4 judge ground-truth for request.user claims

### DIFF
--- a/apps/auth0-evals/src/evals/quickstarts/fastify-api/graders.ts
+++ b/apps/auth0-evals/src/evals/quickstarts/fastify-api/graders.ts
@@ -49,7 +49,9 @@ export function defineGraders() {
     contains('read:messages', 'read:messages scope checked on /api/messages route', GraderLevel.L4),
     judge(
       'Does the app correctly register the @auth0/auth0-fastify-api plugin, protect /api/messages with the read:messages scope, ' +
-        'and protect /api/private requiring any valid access token?',
+        'and protect /api/private requiring any valid access token? ' +
+        'Note: @auth0/auth0-fastify-api exposes the verified token claims on request.user ' +
+        '(e.g. request.user.sub) — this is the correct API for this plugin, not request.auth.',
       GraderLevel.L4,
     ),
 


### PR DESCRIPTION
## Problem

The `fastify_api_quickstart` L4 judge grader fails correct solutions:

> Does the app correctly register the @auth0/auth0-fastify-api plugin, protect /api/messages with the read:messages scope, and protect /api/private requiring any valid access token?

Observed verdict (model `claude-opus-4-8`):

> ...the correct method is used but ... using `request.user.sub` is incorrect for this plugin which uses `request.auth` for token claims. This would cause the handlers to fail at runtime.

This is a **judge false-negative**. The judge question ships no API ground-truth, so the judge model relied on its own memory and invented `request.auth`.

## Ground truth

`@auth0/auth0-fastify-api` assigns the verified token to **`request.user`** — in the plugin source, `request['user'] = token` and the FastifyRequest augmentation declares `user: Token` (`{ sub, aud, iss, scope? }`). So `request.user.sub` is correct and `request.auth` does not exist on this plugin.

## Fix

Pin that fact in the L4 judge question, so the judge evaluates against the real API instead of its own recollection. This mirrors what the existing **L5** version-correctness judge in the same file already states (`access token claims via request.user`). Scoped to just this one judge — no other grader changed.

```diff
 judge(
   'Does the app correctly register the @auth0/auth0-fastify-api plugin, protect /api/messages with the read:messages scope, ' +
-    'and protect /api/private requiring any valid access token?',
+    'and protect /api/private requiring any valid access token? ' +
+    'Note: @auth0/auth0-fastify-api exposes the verified token claims on request.user ' +
+    '(e.g. request.user.sub) — this is the correct API for this plugin, not request.auth.',
   GraderLevel.L4,
 ),
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance for validating protected Fastify API routes with access tokens.
  * Documented that verified token claims are available through `request.user`, including identifiers such as `request.user.sub`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->