### PR TITLE
fix(fastapi): give judges ground-truth for the fastapi_plugin import

### DIFF
--- a/apps/auth0-evals/src/evals/quickstarts/fastapi/graders.ts
+++ b/apps/auth0-evals/src/evals/quickstarts/fastapi/graders.ts
@@ -41,7 +41,9 @@ export function defineGraders() {
     contains('read:messages', 'read:messages scope checked on /api/messages route', GraderLevel.L4),
     judge(
       'Does the app correctly create an Auth0FastAPI instance, protect /api/messages with the read:messages scope, ' +
-        'and protect /api/private requiring any valid access token?',
+        'and protect /api/private requiring any valid access token? ' +
+        'Note: the auth0-fastapi-api distribution imports as the module `fastapi_plugin` ' +
+        '(i.e. `from fastapi_plugin import Auth0FastAPI` is correct — there is no `auth0_fastapi_api` module).',
       GraderLevel.L4,
     ),
 
@@ -50,7 +52,9 @@ export function defineGraders() {
       'Does the solution use current auth0-fastapi-api patterns? ' +
         'Specifically: does it use Auth0FastAPI with domain and audience parameters, ' +
         'use require_auth() as a FastAPI Depends dependency (not a decorator), ' +
-        'and read credentials from environment variables (not hardcoded)?',
+        'and read credentials from environment variables (not hardcoded)? ' +
+        'Note: the auth0-fastapi-api distribution imports as the module `fastapi_plugin` ' +
+        '(`from fastapi_plugin import Auth0FastAPI` is correct — there is no `auth0_fastapi_api` module).',
       GraderLevel.L5,
     ),
 
@@ -59,7 +63,9 @@ export function defineGraders() {
       'Does the solution correctly integrate Auth0 into a FastAPI API using auth0-fastapi-api? ' +
         'It should create an Auth0FastAPI instance configured with domain and audience from environment variables, ' +
         'protect the /api/messages route with read:messages scope check, ' +
-        'and protect the /api/private route requiring a valid access token.',
+        'and protect the /api/private route requiring a valid access token. ' +
+        'Note: the auth0-fastapi-api distribution imports as the module `fastapi_plugin` ' +
+        '(`from fastapi_plugin import Auth0FastAPI` is correct — there is no `auth0_fastapi_api` module).',
     ),
   ];
 }


### PR DESCRIPTION
## Problem

The `fastapi_quickstart` judges fail correct solutions **across all 8 models** in the matrix. Example verdict (`claude-opus-4-8`):

> ...creates an Auth0FastAPI instance... protects /api/messages with the "read:messages" scope... However, the import is from `fastapi_plugin` rather than the correct `auth0_fastapi_api` package (auth0-fastapi-api), so the code would fail to import.

This is a **judge false-negative**. Failing uniformly on every model is the signature of a judge-side problem, not agent output — and indeed every model produced the correct import.

## Ground truth

The `auth0-fastapi-api` distribution ships its code in the module **`fastapi_plugin`**:

- `pyproject.toml`: `packages = [{ include = "fastapi_plugin" }]`
- `fastapi_plugin/__init__.py`: `from .fast_api_client import Auth0FastAPI` / `__all__ = ["Auth0FastAPI", ...]`
- There is **no** `auth0_fastapi_api/` module directory.

So `from fastapi_plugin import Auth0FastAPI` is correct, and `from auth0_fastapi_api import Auth0FastAPI` (what the judge demanded) would itself raise `ModuleNotFoundError`. The judge conflated the pip **distribution name** (`auth0-fastapi-api`) with the **import module name** (`fastapi_plugin`).

## Fix

Pin the import-path fact into the three judge questions (L4, L5, holistic) so they evaluate against the real module, mirroring how the L5 judge already states version-correct patterns. No other grader changed; the skill and agent output were already correct.

```diff
   'and protect /api/private requiring any valid access token?',
+  'Note: the auth0-fastapi-api distribution imports as the module `fastapi_plugin` ' +
+  '(from fastapi_plugin import Auth0FastAPI is correct — there is no auth0_fastapi_api module).',
```