### PR TITLE
fix(swift): accept webAuth(clientId:domain:) in async/await grader

### DIFF
--- a/apps/auth0-evals/src/evals/quickstarts/swift/graders.ts
+++ b/apps/auth0-evals/src/evals/quickstarts/swift/graders.ts
@@ -36,11 +36,14 @@ export function defineGraders() {
     ),
 
     // ── L5: Version-specific API correctness ──────────────────────────────────
-    // Allow chained builder calls (e.g. `.scope(...)`, `.useEphemeralSession()`)
-    // and newlines between webAuth() and .start() — the idiomatic fluent form
-    // `Auth0.webAuth().scope("...").start()` is correct async/await usage.
+    // Accept both `webAuth()` (reads Auth0.plist) and the explicit-credentials
+    // form `webAuth(clientId:domain:)` — both are valid public factories. Allow
+    // chained builder calls (e.g. `.scope(...)`, `.useEphemeralSession()`) and
+    // newlines between the factory and `.start()`. The empty `.start()` is what
+    // distinguishes async/await usage from the completion-handler form
+    // (`.start { result in ... }`), which this L5 grader is meant to reject.
     matches(
-      String.raw`webAuth\(\)(?:\s*\.\w+\([^)]*\))*\s*\.start\(\)`,
+      String.raw`webAuth\([^)]*\)(?:\s*\.\w+\([^)]*\))*\s*\.start\(\)`,
       'Uses async/await webAuth().start() syntax (not completion handlers)',
       GraderLevel.L5,
     ),


### PR DESCRIPTION
## Summary

The Swift quickstart L5 async/await grader regex required `webAuth()` with **empty** parens:

```
webAuth\(\)(?:\s*\.\w+\([^)]*\))*\s*\.start\(\)
```

So the explicit-credentials factory `webAuth(clientId:domain:)` never matched, and valid solutions failed the grader. Both forms are valid public Auth0.swift factories (verified against SDK source + README):

- `public func webAuth(session:bundle:) -> WebAuth` — reads from `Auth0.plist`
- `public func webAuth(clientId:domain:session:) -> WebAuth` — explicit credentials


This grader for hardcoding credentials should fail however webauth structural l5 grader should pass

## Change

Widen the factory parens to `webAuth\([^)]*\)` so arguments are accepted, while keeping `.start()` **empty** — the empty call is what distinguishes async/await usage from the completion-handler form (`.start { result in ... }`) that this L5 grader is designed to reject.

## Eval signal

From `swift_quickstart` / `agent-mcp-skills` in eval run **29835398213**, 5 of 8 models failed this grader despite writing correct async/await code:

| Model | Grade | async grader |
| --- | --- | --- |
| claude-opus-4-8 | A (94.5) | FAIL — `NOT matched` |
| gpt-5.6-sol | A (92.9) | FAIL |
| gpt-5.6-luna / terra, gemini-3.5-flash | B | FAIL |
| claude-sonnet-5 | A (97.2) | PASS (used `webAuth()`) |
| gemini-3.1-pro-preview | A (98.2) | PASS (used `webAuth()`) |

Opus scored an **A (94.5) with correct code but still failed the version grader** purely because it used the `webAuth(clientId:domain:)` form — a false negative this change fixes.

## Test plan

Validated the new regex against positive and negative cases:

- [x] `webAuth().start()` -> match
- [x] `Auth0.webAuth(clientId: "...", domain: "...").start()` -> match
- [x] `Auth0.webAuth(clientId: "...", domain: "...").useHTTPS().start()` -> match
- [x] `webAuth().scope("openid").start()` -> match
- [x] multi-line `webAuth(clientId:domain:)\n.start()` -> match
- [x] `webAuth().start { result in }` -> **no match** (completion handler still rejected)
- [x] `webAuth(clientId:domain:).start { result in }` -> **no match**
- [x] `npm run build` + `npm run lint` pass

## Context

Part of the eval flywheel. The grader should *accept* any valid API form; the companion skill fix (auth0/agent-skills#155) separately stops the skill from *teaching* the hardcoded-credentials variant that made lower-tier models trip the L3 security graders.
