### PR TITLE
fix(judge): exclude .txt files from the LLM judge corpus

### DIFF
--- a/packages/evals-core/src/graders/executors/llm-judge.ts
+++ b/packages/evals-core/src/graders/executors/llm-judge.ts
@@ -16,12 +16,18 @@ import { logger } from '../../utils/logger.js';
  * are dropped so credential values never reach the judge LLM — security graders verify
  * secret absence in source deterministically via `notContainsInSource`, and "wired into
  * .env" is an event-based (`wroteFile`) concern, so the judge never needs `.env` content.
+ *
+ * `.md` / `.txt` files are dropped because agents routinely emit large standalone docs
+ * (integration guides, summaries, checklists) that are not source code. They inflate the
+ * corpus — sometimes past `maxCodeChars`, which fails the judge outright — while adding no
+ * signal the judge needs.
  */
 const JUDGE_EXCLUDED_PATTERNS = [
   /^tsconfig(\.\w+)?\.json$/,
   /^angular\.json$/,
   /^tsconfig\.tsbuildinfo$/,
   /\.md$/i,
+  /\.txt$/i,
   /^\.env(\..*)?$/,
 ];
 

--- a/packages/evals-core/tests/graders/executors.test.ts
+++ b/packages/evals-core/tests/graders/executors.test.ts
@@ -349,6 +349,12 @@ describe('isJudgeExcluded', () => {
     expect(isJudgeExcluded('docs/SETUP.md')).toBe(true);
     expect(isJudgeExcluded('CHANGELOG.MD')).toBe(true);
   });
+
+  it('excludes text files (agent-emitted docs, summaries, checklists)', () => {
+    expect(isJudgeExcluded('IMPLEMENTATION_SUMMARY.txt')).toBe(true);
+    expect(isJudgeExcluded('docs/VERIFICATION_CHECKLIST.txt')).toBe(true);
+    expect(isJudgeExcluded('NOTES.TXT')).toBe(true);
+  });
 });
 
 // ── compile ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Exclude `.txt` files from the corpus sent to the LLM judge, matching the existing `.md` exclusion.

Agents routinely emit large standalone `.txt` docs (implementation summaries, verification checklists) alongside the real source. These aren't code, add no signal the judge needs, and inflate the judged corpus — sometimes past `judge.maxCodeChars`, which errors the judge grader out and scores it as a hard fail.

## Concrete failure this fixes

In the `vue_quickstart` run, the judged corpus was **44,931 chars** — over the 32,768 limit. Both LLM-judge graders errored with `Code corpus exceeds limit` and the run flipped to `status=failure` despite **18/20** deterministic graders passing. The overflow was driven by agent-generated docs — a ~13KB `IMPLEMENTATION_SUMMARY.txt` and a `VERIFICATION_CHECKLIST.txt`. Stripping `.txt` (as `.md` already is) drops the corpus under the limit so the judge actually runs.

This is happening with only Haiku 4.5 model

## Change

- Add `/\.txt$/i` to `JUDGE_EXCLUDED_PATTERNS` in `llm-judge.ts`, with a comment explaining the rationale.
- Add a unit test covering `.txt` exclusion.

## Safety

The judge filter (`isJudgeExcluded`) is applied **only** inside the LLM-judge executor. Deterministic `contains`/`notContains` graders read the full file set (`collectFiles`), so they are unaffected by this change.

## Test

`npx turbo run test --filter=@a0/evals-core` — 486 passed (25 files), including the new `.txt` exclusion test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved evaluation accuracy by excluding `.txt` files from LLM-judge inputs, alongside other non-relevant project files.
  * Added support for excluding uppercase `.TXT` files and common text-based summary or notes files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->