### PR TITLE
fix(evals): wire up missing compiles() grader for flask/express/fastapi/fastify-api

### DIFF
--- a/apps/auth0-evals/src/evals/quickstarts/express/graders.ts
+++ b/apps/auth0-evals/src/evals/quickstarts/express/graders.ts
@@ -1,4 +1,13 @@
-import { contains, notContains, notContainsInSource, matches, judge, wroteFile, GraderLevel } from '@a0/evals-graders';
+import {
+  contains,
+  notContains,
+  notContainsInSource,
+  matches,
+  judge,
+  wroteFile,
+  compiles,
+  GraderLevel,
+} from '@a0/evals-graders';
 
 export function defineGraders() {
   return [
@@ -50,6 +59,7 @@ export function defineGraders() {
       'barkbook_client_abc123xyz',
       'barkbook_secret_def456uvw',
     ]),
+    compiles('Project compiles (node --check succeeds)', GraderLevel.L4),
     matches(String.raw`app\.use\s*\(\s*auth\s*\(`, 'auth middleware registered with app.use', GraderLevel.L4),
     contains('requiresAuth', 'Uses requiresAuth() to protect the /profile route', GraderLevel.L4),
     contains('req.oidc.accessToken', 'Accesses access token via req.oidc.accessToken', GraderLevel.L4),

--- a/apps/auth0-evals/src/evals/quickstarts/fastapi/graders.ts
+++ b/apps/auth0-evals/src/evals/quickstarts/fastapi/graders.ts
@@ -1,4 +1,13 @@
-import { contains, notContains, notContainsInSource, matches, judge, wroteFile, GraderLevel } from '@a0/evals-graders';
+import {
+  contains,
+  notContains,
+  notContainsInSource,
+  matches,
+  judge,
+  wroteFile,
+  compiles,
+  GraderLevel,
+} from '@a0/evals-graders';
 
 export function defineGraders() {
   return [
@@ -32,6 +41,7 @@ export function defineGraders() {
       'dev-barkbook.us.auth0.com',
       'api.barkbook.com',
     ]),
+    compiles('Project compiles (py_compile succeeds)', GraderLevel.L4),
     matches(String.raw`Auth0FastAPI\s*\(`, 'Auth0FastAPI instance is created', GraderLevel.L4),
     matches(
       String.raw`Depends\s*\(\s*\w+\.require_auth\s*\(`,

--- a/apps/auth0-evals/src/evals/quickstarts/fastify-api/graders.ts
+++ b/apps/auth0-evals/src/evals/quickstarts/fastify-api/graders.ts
@@ -1,4 +1,13 @@
-import { contains, notContains, notContainsInSource, matches, judge, wroteFile, GraderLevel } from '@a0/evals-graders';
+import {
+  contains,
+  notContains,
+  notContainsInSource,
+  matches,
+  judge,
+  wroteFile,
+  compiles,
+  GraderLevel,
+} from '@a0/evals-graders';
 
 export function defineGraders() {
   return [
@@ -36,6 +45,7 @@ export function defineGraders() {
       'dev-barkbook.us.auth0.com',
       'api.barkbook.com',
     ]),
+    compiles('Project compiles (node --check succeeds)', GraderLevel.L4),
     matches(
       String.raw`fastify\.register\s*\(\s*fastifyAuth0Api`,
       'Auth0 API plugin registered with fastify.register()',

--- a/apps/auth0-evals/src/evals/quickstarts/flask/graders.ts
+++ b/apps/auth0-evals/src/evals/quickstarts/flask/graders.ts
@@ -1,4 +1,13 @@
-import { contains, notContains, notContainsInSource, matches, judge, wroteFile, GraderLevel } from '@a0/evals-graders';
+import {
+  contains,
+  notContains,
+  notContainsInSource,
+  matches,
+  judge,
+  wroteFile,
+  compiles,
+  GraderLevel,
+} from '@a0/evals-graders';
 
 export function defineGraders() {
   return [
@@ -41,6 +50,7 @@ export function defineGraders() {
       'barkbook_client_abc123xyz',
       'barkbook_secret_def456uvw',
     ]),
+    compiles('Project compiles (py_compile succeeds)', GraderLevel.L4),
     contains('/callback', 'Implements /callback route', GraderLevel.L4),
     contains('/login', 'Implements /login route', GraderLevel.L4),
     contains('/logout', 'Implements /logout route', GraderLevel.L4),

--- a/packages/evals-core/src/workspace/workspace.ts
+++ b/packages/evals-core/src/workspace/workspace.ts
@@ -197,9 +197,11 @@ export function runCompileCommand(
 
   // When a setupCommand is provided, we ensure to run it before verifying compilation.
   // This is done because there is no guarantee that an agent did not add a dependency
-  // without running the installation command.
+  // without running the installation command. Split it the same way as the compile
+  // command itself so &&-chained setup commands (e.g. `python3 -m venv .venv && pip install ...`)
+  // run as separate sub-commands instead of one unsplit argv.
   if (options?.setupCommand) {
-    subCommands.unshift(options.setupCommand);
+    subCommands.unshift(...options.setupCommand.split('&&').map((s) => s.trim()));
   }
 
   let combinedOutput = '';

--- a/packages/evals-core/tests/workspace-commands.test.ts
+++ b/packages/evals-core/tests/workspace-commands.test.ts
@@ -200,4 +200,18 @@ describe('runCompileCommand', () => {
     expect(res.ok).toBe(true);
     expect(res.output).toContain('hello-compile');
   });
+
+  it('splits a &&-chained setupCommand into separate sub-commands', () => {
+    const dir = tmpDir();
+    const res = runCompileCommand(dir, 'true', {
+      setupCommand: 'echo setup-first && echo setup-second',
+    });
+    // If setupCommand were run unsplit (as one argv), '&&' and 'echo' would be
+    // passed as literal arguments to the first `echo`, producing a single line
+    // containing '&&' instead of two separate echoed lines.
+    expect(res.output).not.toContain('&&');
+    expect(res.output).toContain('setup-first');
+    expect(res.output).toContain('setup-second');
+    expect(res.ok).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- Four evals declared `compile_command` in `PROMPT.md` frontmatter but never wired up the corresponding `compiles()` grader in `graders.ts`, so the compile check silently never ran: `quickstarts/flask`, `quickstarts/express`, `quickstarts/fastapi`, `quickstarts/fastify-api`.
- Added `compiles(description, GraderLevel.L4)` to each, alongside the existing L4 structural checks, matching the pattern already used by `react`, `vue`, `angular`, `nuxt`, `nextjs`, `spa-js`, `dpop/spa-js`, and `mfa/*`.
- Verified no other evals with `compile_command` are missing the grader.

## Test plan
- [x] `npm run build` passes across the monorepo
- [x] `npm run lint` passes
- [x] `npm run format` — no changes needed
- [x] `npm test` — 714 + 485 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added compilation checks to the Express, FastAPI, Fastify, and Flask quickstart evaluations.
  * Projects are now validated for syntax errors using the appropriate runtime or compiler before other checks run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->