### PR TITLE
feat(evals): add scaffold and compile check to express_api_quickstart

### DIFF
--- a/apps/auth0-evals/src/evals/quickstarts/express-api/PROMPT.md
+++ b/apps/auth0-evals/src/evals/quickstarts/express-api/PROMPT.md
@@ -2,6 +2,8 @@
 id: express_api_quickstart
 name: Express API Quickstart
 skills: auth0
+setup_command: npm install
+compile_command: node --check server.js
 ---
 
 ## Task

--- a/apps/auth0-evals/src/evals/quickstarts/express-api/graders.ts
+++ b/apps/auth0-evals/src/evals/quickstarts/express-api/graders.ts
@@ -1,4 +1,13 @@
-import { contains, notContains, notContainsInSource, matches, judge, wroteFile, GraderLevel } from '@a0/evals-graders';
+import {
+  contains,
+  notContains,
+  notContainsInSource,
+  matches,
+  judge,
+  wroteFile,
+  compiles,
+  GraderLevel,
+} from '@a0/evals-graders';
 
 export function defineGraders() {
   return [
@@ -34,6 +43,7 @@ export function defineGraders() {
       'api.barkbook.com',
     ]),
 
+    compiles('Project compiles (node --check succeeds)', GraderLevel.L4),
     matches(
       String.raw`requiredScopes\s*\(\s*.*read:messages`,
       'GET /api/messages protected with read:messages scope',

--- a/apps/auth0-evals/src/evals/quickstarts/express-api/scaffold/package.json
+++ b/apps/auth0-evals/src/evals/quickstarts/express-api/scaffold/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "barkbook-api",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^5.0.0"
+  }
+}

--- a/apps/auth0-evals/src/evals/quickstarts/express-api/scaffold/server.js
+++ b/apps/auth0-evals/src/evals/quickstarts/express-api/scaffold/server.js
@@ -3,8 +3,6 @@ const express = require('express');
 const app = express();
 app.use(express.json());
 
-// TODO: protect these routes with Auth0
-
 app.get('/api/messages', (req, res) => {
   res.json({ messages: ['hello'] });
 });

--- a/apps/auth0-evals/src/evals/quickstarts/express-api/scaffold/server.js
+++ b/apps/auth0-evals/src/evals/quickstarts/express-api/scaffold/server.js
@@ -1,0 +1,21 @@
+const express = require('express');
+
+const app = express();
+app.use(express.json());
+
+// TODO: protect these routes with Auth0
+
+app.get('/api/messages', (req, res) => {
+  res.json({ messages: ['hello'] });
+});
+
+app.post('/api/messages', (req, res) => {
+  res.status(201).json({ message: req.body.message });
+});
+
+app.get('/api/profile', (req, res) => {
+  res.json({});
+});
+
+const port = process.env.PORT || 3001;
+app.listen(port, () => console.log(`Listening on http://localhost:${port}`));


### PR DESCRIPTION
## Summary
- `express_api_quickstart` had no `scaffold/` directory and no `compile_command`/`setup_command`, unlike the other JS-based quickstarts (`express`, `fastify-api`) — so agent output was never checked for compile correctness for this eval.
- Added a minimal Express API `scaffold/` (`package.json` + `server.js` with unprotected placeholder routes matching the task's required routes) so the agent has a realistic starting point, consistent with the `express` eval.
- Added `setup_command: npm install` and `compile_command: node --check server.js` to `PROMPT.md` frontmatter, matching the pattern used by `express`/`fastify-api`.
- Wired up `compiles('Project compiles (node --check succeeds)', GraderLevel.L4)` in `graders.ts`.

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm run format` — no changes needed
- [x] `npm test` — 486 + 714 tests pass
- [x] Verified `node --check server.js` passes against the new scaffold, and `npm install` succeeds in the scaffold directory