### PR TITLE
docs: fix non-existent model in ADDING_EVALS run example

### DIFF
--- a/docs/ADDING_EVALS.md
+++ b/docs/ADDING_EVALS.md
@@ -337,7 +337,7 @@ No manual registration step is needed. The framework auto-discovers evals by sca
 npm run evals -- --eval my_new_eval --mode agent --tools skills
 
 # Run with a specific model
-npm run evals -- --eval my_new_eval --model claude-sonnet-4-6 --mode agent
+npm run evals -- --eval my_new_eval --model claude-sonnet-5 --mode agent
 
 # Keep the temporary workspace after the run for inspection
 npm run evals -- --eval my_new_eval --mode agent --keep-workspace


### PR DESCRIPTION
## Summary

The "Run with a specific model" example in `docs/ADDING_EVALS.md` used `--model claude-sonnet-4-6`, which is not in the model registry. A developer copy-pasting the command would hit an unknown-model error.

Changed it to `claude-sonnet-5`, the actual Sonnet model in `apps/auth0-evals/eval.config.js` (`models.known`) and `AGENTS.md`.

## Test plan

Docs-only change, no code paths affected.