### PR TITLE
fix(cli): honor models.default when --model is omitted

### DIFF
--- a/packages/evals/src/cli/config.ts
+++ b/packages/evals/src/cli/config.ts
@@ -67,6 +67,12 @@ export interface ParseRunConfigOptions {
    * `KNOWN_WORKING_MODELS` fallback is used instead.
    */
   knownModels?: string[];
+  /**
+   * Model used when `--model` is omitted entirely — typically the app's
+   * `models.default` from `eval.config.js`. When omitted or empty, the
+   * framework's `DEFAULT_MODEL` constant is used instead.
+   */
+  defaultModel?: string;
 }
 
 /**
@@ -107,7 +113,7 @@ export function parseRunConfig(argv: string[], options: ParseRunConfigOptions = 
     .option('--eval <id>', 'Eval ID(s) to run (default: all)', (v, prev: string[]) => [...prev, v], [] as string[])
     .option(
       '--model <model>',
-      `Model(s) to run (default: ${DEFAULT_MODEL})`,
+      `Model(s) to run (default: ${options.defaultModel && options.defaultModel.length > 0 ? options.defaultModel : DEFAULT_MODEL})`,
       (v, prev: string[]) => [...prev, v],
       [] as string[],
     )
@@ -136,7 +142,7 @@ export function parseRunConfig(argv: string[], options: ParseRunConfigOptions = 
   const opts = program.opts();
 
   const apiKey = validateApiKey();
-  const models = validateModels(opts.model as string[], options.knownModels);
+  const models = validateModels(opts.model as string[], options.knownModels, options.defaultModel);
   const modes = validateModes(opts.mode as string | undefined);
 
   const evalIds = options.knownEvalIds

--- a/packages/evals/src/cli/run.ts
+++ b/packages/evals/src/cli/run.ts
@@ -349,7 +349,10 @@ export async function runCli(): Promise<void> {
   const frameworkConfig = await loadConfig({ configPath });
   setFrameworkConfig(frameworkConfig);
 
-  const config = parseRunConfig(process.argv, { knownModels: frameworkConfig.models.known });
+  const config = parseRunConfig(process.argv, {
+    knownModels: frameworkConfig.models.known,
+    defaultModel: frameworkConfig.models.default,
+  });
   const {
     models,
     modes,

--- a/packages/evals/src/cli/validators.ts
+++ b/packages/evals/src/cli/validators.ts
@@ -38,8 +38,12 @@ export function validateApiKey(): string {
  * when provided (and non-empty), otherwise the framework's `KNOWN_WORKING_MODELS`
  * fallback. This lets an app narrow the `all` set (e.g. drop deprecated models)
  * via `eval.config.js` without changing framework code.
+ *
+ * When `--model` is omitted entirely, falls back to `defaultModel` — the app's
+ * configured `models.default` — when provided (and non-empty), otherwise the
+ * framework's `DEFAULT_MODEL` constant.
  */
-export function validateModels(rawModels: string[], knownModels?: string[]): string[] {
+export function validateModels(rawModels: string[], knownModels?: string[], defaultModel?: string): string[] {
   const allModels = knownModels && knownModels.length > 0 ? knownModels : KNOWN_WORKING_MODELS;
   if (rawModels.length > 0 && rawModels.includes('all')) {
     logger.info(`Using all known working models: ${allModels.join(', ')}`);
@@ -48,7 +52,7 @@ export function validateModels(rawModels: string[], knownModels?: string[]): str
   if (rawModels.length > 0) {
     return rawModels;
   }
-  return [DEFAULT_MODEL];
+  return [defaultModel && defaultModel.length > 0 ? defaultModel : DEFAULT_MODEL];
 }
 
 /**

--- a/packages/evals/tests/cli-config.test.ts
+++ b/packages/evals/tests/cli-config.test.ts
@@ -168,6 +168,24 @@ describe('--model', () => {
     });
     expect(config.models).toEqual(['claude-opus-4-6']);
   });
+
+  it('falls back to the provided defaultModel when --model is omitted', () => {
+    const config = parseRunConfig(argv(), { knownEvalIds: KNOWN_EVAL_IDS, defaultModel: 'claude-opus-4-8' });
+    expect(config.models).toEqual(['claude-opus-4-8']);
+  });
+
+  it('falls back to DEFAULT_MODEL when defaultModel is empty', () => {
+    const config = parseRunConfig(argv(), { knownEvalIds: KNOWN_EVAL_IDS, defaultModel: '' });
+    expect(config.models).toEqual([DEFAULT_MODEL]);
+  });
+
+  it('defaultModel has no effect when --model is explicitly passed', () => {
+    const config = parseRunConfig(argv('--model', 'gpt-5.2'), {
+      knownEvalIds: KNOWN_EVAL_IDS,
+      defaultModel: 'claude-opus-4-8',
+    });
+    expect(config.models).toEqual(['gpt-5.2']);
+  });
 });
 
 // ── Mode selection ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `frameworkConfig.models.default` was validated as required in `run.ts` (the CLI exits if it's missing from `eval.config.js`) but its value was never actually consulted — omitting `--model` always fell back to the framework's hardcoded `DEFAULT_MODEL` constant (`gpt-5.6-sol`), making the required config field effectively write-only.
- Threads `frameworkConfig.models.default` through `parseRunConfig` → `validateModels`, so a consumer's configured default model is used when `--model` is omitted. Falls back to the framework's `DEFAULT_MODEL` only when `models.default` is empty/unset.
- Also updates the `--model` help text to reflect the resolved default.

## Test plan

- [x] Added tests in `packages/evals/tests/cli-config.test.ts`: falls back to `defaultModel` when `--model` is omitted, falls back to `DEFAULT_MODEL` when `defaultModel` is empty, explicit `--model` still overrides `defaultModel`.
- [x] `npm run build` passes
- [x] `npm test` passes (717/717)
- [x] `npm run lint` / `npm run format` clean on changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a default model for CLI evaluation runs.
  * CLI help now displays the configured default model when applicable.
  * Explicit model selections continue to take precedence over the default.

* **Bug Fixes**
  * Empty default model values now correctly fall back to the framework’s standard model.
  * Model expansion and validation now consistently honor configured defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->