### PR TITLE
feat: adopt claude-opus-5 as judge and known model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ Use `notContainsInSource` (not `notContains`) when a value like a client ID is a
 | `notContains(needle)`                            | Substring must NOT appear in any non-excluded workspace file                                                                                                                                                                                   |
 | `notContainsInSource(needle)`                    | Substring must NOT appear in source files (allowed in config)                                                                                                                                                                                  |
 | `matches(pattern)`                               | Regex match in any non-excluded workspace file                                                                                                                                                                                                 |
-| `judge(question, framework?)`                    | LLM-as-judge yes/no question — uses `claude-opus-4-8`                                                                                                                                                                                          |
+| `judge(question, framework?)`                    | LLM-as-judge yes/no question — uses `claude-opus-5`                                                                                                                                                                                          |
 | `ranCommand(command, args, description, level)`  | Agent ran a shell command containing `command` (and all `args`) — event-based, level required (L4 or L5)                                                                                                                                       |
 | `ranCommandOneOf(commands, description, level)`  | Agent ran at least one command from the list — event-based, level required (L4 or L5)                                                                                                                                                          |
 | `wroteFile(path, description, level, expected?)` | Agent wrote a file whose path contains the substring. With optional `expected` (string or string array), the combined content of all writes to that path must also contain every `expected` substring — event-based, level required (L4 or L5) |
@@ -340,7 +340,7 @@ By default (LiteLLM proxy) the `modelIds` map is empty — the proxy serves mode
 Set `CLAUDE_CODE_USE_BEDROCK_PROXY=1` to route through the Bedrock proxy instead (`/anthropic` endpoint). The config then populates `modelIds` to map supported short aliases to full Bedrock model IDs:
 
 - `claude-sonnet-5` → `global.anthropic.claude-sonnet-5`
-- `claude-opus-4-8` → `global.anthropic.claude-opus-4-8`
+- `claude-opus-5` → `global.anthropic.claude-opus-5`
 - `claude-opus-4-5` → `global.anthropic.claude-opus-4-5-20251101-v1:0`
 - `claude-haiku-4-5` → `global.anthropic.claude-haiku-4-5-20251001-v1:0`
 
@@ -372,23 +372,23 @@ Authenticated HTTP MCP servers are configured with an `auth` block (`tokenUrl`, 
 - `gpt-5.6-luna`
 - `gpt-5.6-terra`
 - `claude-sonnet-5`
-- `claude-opus-4-8`
+- `claude-opus-5`
 - `claude-haiku-4-5`
 - `gemini-3.1-pro-preview`
 - `gemini-3.5-flash`
 
-Opus 4.5 is still supported by the framework (present in the effort-capable set and Bedrock alias map) and can be run explicitly via `--model claude-opus-4-5`; it is intentionally omitted from `--model all` here so batch runs use only Opus 4.8 among the Opus variants. Opus 4.6 and 4.7 have been removed from the registry (deprecated).
+Opus 4.5 is still supported by the framework (present in the effort-capable set and Bedrock alias map) and can be run explicitly via `--model claude-opus-4-5`; it is intentionally omitted from `--model all` here so batch runs use only Opus 5 among the Opus variants. Opus 4.6, 4.7, and 4.8 have been removed from the registry (deprecated).
 
 ### Judge model
 
-All LLM-as-judge graders use `claude-opus-4-8` via the configured LLM proxy (`proxy.baseUrl` in `eval.config.js`).
+All LLM-as-judge graders use `claude-opus-5` via the configured LLM proxy (`proxy.baseUrl` in `eval.config.js`).
 
 ### Settings
 
 | Setting              | Value                                            |
 | -------------------- | ------------------------------------------------ |
 | Base URL             | Configured in `eval.config.js` (`proxy.baseUrl`) |
-| Judge model          | `claude-opus-4-8`                                |
+| Judge model          | `claude-opus-5`                                  |
 | Judge max tokens     | 1024                                             |
 | Judge max code chars | 32,768                                           |
 | Max agent turns      | 75                                               |

--- a/apps/auth0-evals/eval.config.js
+++ b/apps/auth0-evals/eval.config.js
@@ -80,7 +80,7 @@ export default {
   },
 
   judge: {
-    model: 'claude-opus-4-8',
+    model: 'claude-opus-5',
     maxTokens: 1024,
     maxCodeChars: 32_768,
   },
@@ -115,9 +115,9 @@ export default {
 
   models: {
     // `known` is the set `--model all` expands to. Opus 4.5 is intentionally excluded
-    // here so `--model all` runs only Opus 4.8 among the Opus variants; the framework
+    // here so `--model all` runs only Opus 5 among the Opus variants; the framework
     // and `modelIds` map below still support it for explicit `--model` runs.
-    known: ['gpt-5.6-sol', 'gpt-5.6-luna', 'gpt-5.6-terra', 'claude-sonnet-5', 'claude-opus-4-8', 'claude-haiku-4-5', 'gemini-3.1-pro-preview', 'gemini-3.5-flash'],
+    known: ['gpt-5.6-sol', 'gpt-5.6-luna', 'gpt-5.6-terra', 'claude-sonnet-5', 'claude-opus-5', 'claude-haiku-4-5', 'gemini-3.1-pro-preview', 'gemini-3.5-flash'],
     default: 'gpt-5.6-sol',
     // Maps short model aliases to the IDs the active proxy expects.
     // Bedrock proxy needs full `global.anthropic.*` IDs; LiteLLM proxy serves
@@ -125,7 +125,7 @@ export default {
     modelIds: useBedrock
       ? {
           'claude-sonnet-5': 'global.anthropic.claude-sonnet-5',
-          'claude-opus-4-8': 'global.anthropic.claude-opus-4-8',
+          'claude-opus-5': 'global.anthropic.claude-opus-5',
           'claude-opus-4-5': 'global.anthropic.claude-opus-4-5-20251101-v1:0',
           'claude-haiku-4-5': 'global.anthropic.claude-haiku-4-5-20251001-v1:0',
         }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -50,7 +50,7 @@ flowchart TB
         subgraph Grade["4 · Grade the code — @a0/evals-core"]
             direction TB
             Engine["Automated checks<br/>runGraders() · L1–L5"]
-            Judge["AI judge<br/>llmJudge() · claude-opus-4-8"]
+            Judge["AI judge<br/>llmJudge() · claude-opus-5"]
             Engine --> Judge
         end
 

--- a/packages/evals-core/src/config/costs.ts
+++ b/packages/evals-core/src/config/costs.ts
@@ -5,7 +5,7 @@ export const COST_TABLE: Record<string, [number, number]> = {
   'gpt-5.6-luna': [1.0, 6.0],
   'gpt-5.6-terra': [2.5, 15.0],
   'claude-sonnet-5': [2.0, 10.0],
-  'claude-opus-4-8': [5.0, 25.0],
+  'claude-opus-5': [5.0, 25.0],
   'claude-haiku-4-5': [1.0, 5.0],
   'gemini-3.1-pro-preview': [2.0, 12.0],
   'gemini-3.5-flash': [1.5, 9.0],

--- a/packages/evals-core/src/config/settings.ts
+++ b/packages/evals-core/src/config/settings.ts
@@ -7,8 +7,8 @@ export const MAX_TURNS = 75;
 export const BEDROCK_MODELS = ['claude-'];
 
 // Claude models that support output_config.effort to cap reasoning effort and reduce latency.
-// Supported here: Claude Sonnet 5, Opus 4.8, and Opus 4.5.
-export const CLAUDE_EFFORT_MODELS = new Set(['claude-sonnet-5', 'claude-opus-4-8', 'claude-opus-4-5']);
+// Supported here: Claude Sonnet 5, Opus 5, and Opus 4.5.
+export const CLAUDE_EFFORT_MODELS = new Set(['claude-sonnet-5', 'claude-opus-5', 'claude-opus-4-5']);
 
 // Model name prefixes that use the older functions/function_call API
 // instead of tools/tool_choice.

--- a/packages/evals-core/tests/graders/engine.test.ts
+++ b/packages/evals-core/tests/graders/engine.test.ts
@@ -484,10 +484,10 @@ describe('llmJudge', () => {
       question: 'question',
       code: 'code',
       apiKey: 'key',
-      model: 'claude-opus-4-8',
+      model: 'claude-opus-5',
       baseUrl: 'http://test',
     });
-    expect(capturedBody?.model).toBe('claude-opus-4-8');
+    expect(capturedBody?.model).toBe('claude-opus-5');
   });
 
   it('throws JudgeError when baseUrl is empty', async () => {

--- a/packages/evals-core/tests/model-detect.test.ts
+++ b/packages/evals-core/tests/model-detect.test.ts
@@ -3,7 +3,7 @@ import { isBedrockModel, isClaudeModel, isGeminiModel, isGptModel } from '../src
 
 describe('model detection', () => {
   it('isBedrockModel matches claude- prefix', () => {
-    expect(isBedrockModel('claude-opus-4-8')).toBe(true);
+    expect(isBedrockModel('claude-opus-5')).toBe(true);
     expect(isBedrockModel('gpt-5.6-sol')).toBe(false);
   });
 
@@ -14,11 +14,11 @@ describe('model detection', () => {
 
   it('isGeminiModel matches gemini- prefix', () => {
     expect(isGeminiModel('gemini-3.1-pro-preview')).toBe(true);
-    expect(isGeminiModel('claude-opus-4-8')).toBe(false);
+    expect(isGeminiModel('claude-opus-5')).toBe(false);
   });
 
   it('isGptModel matches gpt- prefix', () => {
     expect(isGptModel('gpt-5.6-sol')).toBe(true);
-    expect(isGptModel('claude-opus-4-8')).toBe(false);
+    expect(isGptModel('claude-opus-5')).toBe(false);
   });
 });

--- a/packages/evals/src/cli/constants.ts
+++ b/packages/evals/src/cli/constants.ts
@@ -14,7 +14,7 @@ export const KNOWN_WORKING_MODELS = [
   'gpt-5.6-luna',
   'gpt-5.6-terra',
   'claude-sonnet-5',
-  'claude-opus-4-8',
+  'claude-opus-5',
   'claude-haiku-4-5',
   'gemini-3.1-pro-preview',
   'gemini-3.5-flash',

--- a/packages/evals/tests/cli-config.test.ts
+++ b/packages/evals/tests/cli-config.test.ts
@@ -151,7 +151,7 @@ describe('--model', () => {
   });
 
   it('--model all expands to the provided knownModels when given', () => {
-    const known = ['gpt-5.4', 'claude-opus-4-8'];
+    const known = ['gpt-5.4', 'claude-opus-5'];
     const config = parseRunConfig(argv('--model', 'all'), { knownEvalIds: KNOWN_EVAL_IDS, knownModels: known });
     expect(config.models).toEqual(known);
   });
@@ -164,7 +164,7 @@ describe('--model', () => {
   it('explicit --model still passes through even when not in knownModels', () => {
     const config = parseRunConfig(argv('--model', 'claude-opus-4-6'), {
       knownEvalIds: KNOWN_EVAL_IDS,
-      knownModels: ['gpt-5.4', 'claude-opus-4-8'],
+      knownModels: ['gpt-5.4', 'claude-opus-5'],
     });
     expect(config.models).toEqual(['claude-opus-4-6']);
   });

--- a/packages/evals/tests/recommendations.test.ts
+++ b/packages/evals/tests/recommendations.test.ts
@@ -334,7 +334,7 @@ describe('generateRecommendations', () => {
     // endpoint. Recommendations hit the /chat/completions endpoint, which serves
     // models under their plain alias — so even when a Bedrock map is configured,
     // the alias must be sent unchanged (regression: applying the map here
-    // produced model="global.anthropic.claude-opus-4-8" → 400).
+    // produced model="global.anthropic.claude-opus-5" → 400).
     const { setFrameworkConfig } = await import('@a0/evals-core');
     const { TEST_CONFIG } = await import('./test-config.js');
     setFrameworkConfig({


### PR DESCRIPTION
Replaces the retired `claude-opus-4-8` alias with `claude-opus-5` throughout the framework — the LLM-as-judge model, the `--model all` known set, the cost table, the effort-capable model set, and the Bedrock alias map.