### PR TITLE
docs: fix inaccuracies in ADDING_EVALS.md

### DIFF
--- a/docs/ADDING_EVALS.md
+++ b/docs/ADDING_EVALS.md
@@ -35,29 +35,29 @@ compile_command: npm run build
 ---
 ```
 
-| Field | Required | Description |
-|---|---|---|
-| `id` | **yes** | Unique snake_case identifier, used with `--eval` on the CLI |
-| `name` | no | Human-readable display name. Defaults to `id` |
-| `category` | no | Defaults to the parent directory name (e.g. `quickstarts`) |
-| `skills` | no | Comma-separated skill names from [auth0/agent-skills](https://github.com/auth0/agent-skills). Injected into agent context when running with `--tools skills` |
-| `setup_command` | no | Command run before the agent starts (e.g. `npm install`). Split on whitespace and executed directly via `spawnSync` — no shell, no operators (`&&`, `\|`, etc.), no quoting. One command only. |
-| `compile_command` | no | Compile/build command (e.g. `npm run build`, `node --check server.js`, `.venv/bin/python -m py_compile main.py`). Used two ways: (1) an instruction pointing the agent at this command is appended to the agent's native context file (`CLAUDE.md` / `GEMINI.md` / `AGENTS.md` / `.github/copilot-instructions.md`) alongside the "no docs files" guidance, nudging the agent to verify the build; and (2) **the framework runs it against the workspace after the agent finishes and uses the result to drive any `compiles()` grader in `graders.ts`** — so an agent whose output compiles passes even if it never ran the build itself. Agent modes only — baseline ignores it. Omit for evals with no CLI compile step (e.g. mobile). If you add a `compiles()` grader, you MUST also declare `compile_command`, or the grader fails. |
+| Field             | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| ----------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`              | **yes**  | Unique snake_case identifier, used with `--eval` on the CLI                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `name`            | no       | Human-readable display name. Defaults to `id`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `category`        | no       | Defaults to the parent directory name (e.g. `quickstarts`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `skills`          | no       | Comma-separated skill names from [auth0/agent-skills](https://github.com/auth0/agent-skills). Injected into agent context when running with `--tools skills`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `setup_command`   | no       | Command run before the agent starts (e.g. `npm install`). Split on `&&` into sub-commands run in sequence; each sub-command is split on whitespace and executed directly via `spawnSync` — no shell, so no other operators (`\|`, `;`, `>`, etc.), no quoting, no glob expansion. `&&` is the only supported operator (e.g. `python3 -m venv .venv && .venv/bin/pip install -r requirements.txt`).                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `compile_command` | no       | Compile/build command (e.g. `npm run build`, `node --check server.js`, `.venv/bin/python -m py_compile main.py`). Used two ways: (1) an instruction pointing the agent at this command is appended to the agent's native context file (`CLAUDE.md` / `GEMINI.md` / `AGENTS.md` / `.github/copilot-instructions.md`) alongside the "no docs files" guidance, nudging the agent to verify the build; and (2) **the framework runs it against the workspace after the agent finishes and uses the result to drive any `compiles()` grader in `graders.ts`** — so an agent whose output compiles passes even if it never ran the build itself. Agent modes only — baseline ignores it. Omit for evals with no CLI compile step (e.g. mobile). If you add a `compiles()` grader, you MUST also declare `compile_command`, or the grader fails. |
 
 To test a skill before it is pushed to the remote repo, see [TESTING_SKILLS.md](TESTING_SKILLS.md).
 
 ### Sections
 
-| Section | Used in | Purpose |
-|---|---|---|
+| Section     | Used in    | Purpose                                                                           |
+| ----------- | ---------- | --------------------------------------------------------------------------------- |
 | `## System` | `baseline` | System prompt for the single-turn LLM call. If omitted, a default prompt is used. |
-| `## Task` | all modes | The user-facing request sent to the model |
+| `## Task`   | all modes  | The user-facing request sent to the model                                         |
 
 If no sections are present, the entire body (after frontmatter) is used as the task prompt in all modes.
 
 ### Example
 
-````markdown
+```markdown
 ---
 id: react_quickstart
 name: React Quickstart
@@ -67,13 +67,14 @@ compile_command: npm run build
 ---
 
 ## Task
+
 Add Auth0 authentication to a React application using the `@auth0/auth0-react` SDK.
 
 - Domain: `dev-barkbook.us.auth0.com`
 - Client ID: `barkbook_client_abc123xyz`
 
 The app should support login, logout, and display the authenticated user's name and email.
-````
+```
 
 ### Tips
 
@@ -89,21 +90,21 @@ Graders define the acceptance criteria. Export a single `defineGraders()` functi
 
 ### Grader Primitives
 
-| Primitive | Passes when… |
-|---|---|
-| `contains(needle, description?, level?, options?)` | Any workspace file contains the substring (case-sensitive by default) |
-| `notContains(needle, description?, level?, options?)` | No workspace file contains the substring (case-sensitive by default) |
-| `notContainsInSource(needle, description?, level?, options?)` | No **source** file contains the substring (skips `.env`, `.json`, `.plist`, config files) |
-| `matches(pattern, description?, level?)` | Any workspace file matches the regex pattern |
-| `judge(question, level?)` | An LLM judge answers "yes" given the full workspace contents |
-| `ranCommand(command, args, description, level)` | Agent ran a successful shell command containing `command` and all `args` substrings |
-| `ranCommandOneOf(commands, description, level)` | Agent ran at least one successful command from the list (substring match) |
-| `wroteFile(path, description, level, expected?)` | Agent wrote a file whose path contains the substring. With optional `expected` (string or string array), the combined content of all writes to that path must also contain every `expected` substring |
-| `compiles(description, level)` | Framework runs the eval's `compile_command` against the workspace after the agent finishes and passes/fails on its exit code. Requires `compile_command` in frontmatter, or the grader fails. |
-| `calledTool(toolName, description, level)` | Agent invoked an MCP tool whose name contains the substring (trace-based; L4/L5 only) |
-| `calledToolOneOf(toolNames, description, level)` | Agent invoked at least one of the named MCP tools (trace-based; L4/L5 only) |
+| Primitive                                                     | Passes when…                                                                                                                                                                                          |
+| ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `contains(needle, description?, level?, options?)`            | Any workspace file contains the substring (case-sensitive by default)                                                                                                                                 |
+| `notContains(needle, description?, level?, options?)`         | No workspace file contains the substring (case-sensitive by default)                                                                                                                                  |
+| `notContainsInSource(needle, description?, level?, options?)` | No **source** file contains the substring (skips config/non-source files: `.env*`, `.json`, `.plist`, `.xml`, `.yaml`, `.yml`, `.toml`, `.ini`, `.cfg`, `.conf`, `.md`)                               |
+| `matches(pattern, description?, level?, options?)`            | Any workspace file matches the regex pattern (case-**insensitive** by default)                                                                                                                        |
+| `judge(question, level?)`                                     | An LLM judge answers "yes" given the full workspace contents                                                                                                                                          |
+| `ranCommand(command, args, description, level)`               | Agent ran a successful shell command containing `command` and all `args` substrings                                                                                                                   |
+| `ranCommandOneOf(commands, description, level)`               | Agent ran at least one successful command from the list (substring match)                                                                                                                             |
+| `wroteFile(path, description, level, expected?)`              | Agent wrote a file whose path contains the substring. With optional `expected` (string or string array), the combined content of all writes to that path must also contain every `expected` substring |
+| `compiles(description, level)`                                | Framework runs the eval's `compile_command` against the workspace after the agent finishes and passes/fails on its exit code. Requires `compile_command` in frontmatter, or the grader fails.         |
+| `calledTool(toolName, description, level)`                    | Agent invoked an MCP tool whose name contains the substring (trace-based; L4/L5 only)                                                                                                                 |
+| `calledToolOneOf(toolNames, description, level)`              | Agent invoked at least one of the named MCP tools (trace-based; L4/L5 only)                                                                                                                           |
 
-The `options` parameter is an object with an optional `caseSensitive` field (defaults to `true`).
+The `options` parameter is an object with an optional `caseSensitive` field. It defaults to `true` for `contains`, `notContains`, and `notContainsInSource`, but to `false` (case-insensitive) for `matches`.
 
 The event-based primitives (`ranCommand`, `ranCommandOneOf`, `wroteFile`) inspect the agent's tool-call trace rather than workspace file contents. They only produce meaningful results in agent mode — in baseline mode (no tool calls), they gracefully fail. The `level` parameter is **required** and must be `GraderLevel.L4` or `GraderLevel.L5` (the type system enforces this). Use L4 for behavioral checks like verifying the agent explicitly installed dependencies. To grade compilation, prefer `compiles()` over `ranCommand(...build...)`: `ranCommand` only checks whether the agent ran a build in its trace, whereas `compiles()` runs the eval's `compile_command` itself after the agent finishes, so output that compiles passes even if the agent never ran the build.
 
@@ -132,6 +133,7 @@ import { GraderLevel } from '@a0/evals-graders';
 **Primitives to use:** `contains`
 
 **Examples:**
+
 ```typescript
 contains('@auth0/auth0-react', 'Uses @auth0/auth0-react SDK', GraderLevel.L1),
 contains('Auth0Provider', 'Wraps app with Auth0Provider', GraderLevel.L1),
@@ -151,6 +153,7 @@ contains('webAuth()', 'Uses webAuth() for login', GraderLevel.L1),
 **Primitives to use:** `notContains`
 
 **Examples:**
+
 ```typescript
 notContains('@auth0/react', 'No hallucinated @auth0/react package (correct: @auth0/auth0-react)', GraderLevel.L2),
 notContains('@auth0/nextjs-auth0', 'Does not use server SDK in a SPA', GraderLevel.L2),
@@ -170,6 +173,7 @@ notContains('completionHandler', 'Does not use deprecated completion handler pat
 **Primitives to use:** `notContains`, `notContainsInSource`
 
 **Examples:**
+
 ```typescript
 // Source-only: domain/clientId are ok in Auth0.plist, not in .swift files
 notContainsInSource('barkbook_client_abc123xyz', 'No hardcoded client ID in Swift source', GraderLevel.L3),
@@ -191,6 +195,7 @@ notContains('sessionStorage.setItem', 'No tokens stored in sessionStorage', Grad
 **Primitives to use:** `matches`, `judge`
 
 **Examples:**
+
 ```typescript
 // Regex: verifies structural composition, not just presence of two separate strings
 matches(String.raw`<Auth0Provider[\s\S]*?domain`, 'Auth0Provider configured with domain prop', GraderLevel.L4),
@@ -220,6 +225,7 @@ judge(
 **Primitives to use:** `contains`, `matches`, `judge`
 
 **Examples:**
+
 ```typescript
 // React: authorizationParams was introduced to replace direct audience/scope props
 contains('authorizationParams', 'Uses authorizationParams (not deprecated direct props)', GraderLevel.L5),
@@ -259,14 +265,7 @@ judge(
 ### Full Annotated Example
 
 ```typescript
-import {
-  contains,
-  notContains,
-  notContainsInSource,
-  matches,
-  judge,
-  GraderLevel,
-} from '@a0/evals-graders';
+import { contains, notContains, notContainsInSource, matches, judge, GraderLevel } from '@a0/evals-graders';
 
 export function defineGraders() {
   return [
@@ -289,10 +288,7 @@ export function defineGraders() {
 
     // ── L4: Structural / behavioral correctness ───────────────────────────────
     matches(String.raw`<Auth0Provider[\s\S]*?domain`, 'Auth0Provider has domain prop', GraderLevel.L4),
-    judge(
-      'Does the code guard auth-dependent UI behind isLoading check?',
-      GraderLevel.L4,
-    ),
+    judge('Does the code guard auth-dependent UI behind isLoading check?', GraderLevel.L4),
 
     // ── L5: Version-specific API correctness ──────────────────────────────────
     contains('authorizationParams', 'Uses authorizationParams (not deprecated direct props)', GraderLevel.L5),
@@ -337,7 +333,7 @@ No manual registration step is needed. The framework auto-discovers evals by sca
 npm run evals -- --eval my_new_eval --mode agent --tools skills
 
 # Run with a specific model
-npm run evals -- --eval my_new_eval --model claude-sonnet-4-6 --mode agent
+npm run evals -- --eval my_new_eval --model claude-sonnet-5 --mode agent
 
 # Keep the temporary workspace after the run for inspection
 npm run evals -- --eval my_new_eval --mode agent --keep-workspace
@@ -345,13 +341,13 @@ npm run evals -- --eval my_new_eval --mode agent --keep-workspace
 
 ### Modes and tools
 
-| Combo | What it tests |
-|---|---|
-| `baseline` | Single LLM call, no tools; grades extracted code blocks |
-| `agent` | Agent with file/shell tools; grades written workspace files |
-| `agent --tools mcp` | Same as `agent`, with the Auth0 MCP server available |
-| `agent --tools skills` | Same as `agent`, with the `SKILL.md` injected into agent context |
-| `agent --tools mcp,skills` | Both skill injection and MCP together |
+| Combo                      | What it tests                                                    |
+| -------------------------- | ---------------------------------------------------------------- |
+| `baseline`                 | Single LLM call, no tools; grades extracted code blocks          |
+| `agent`                    | Agent with file/shell tools; grades written workspace files      |
+| `agent --tools mcp`        | Same as `agent`, with the Auth0 MCP server available             |
+| `agent --tools skills`     | Same as `agent`, with the `SKILL.md` injected into agent context |
+| `agent --tools mcp,skills` | Both skill injection and MCP together                            |
 
 To run all combos and measure the delta each investment provides, combine `--mode all` with `--tools` for each tool set you want to compare.
 


### PR DESCRIPTION
## Summary

Corrects five claims in `docs/ADDING_EVALS.md` that had drifted from the framework code:

- **`setup_command`** — it *does* support `&&`-chained sub-commands (run in sequence by `runSetupCommand`, relied on by the `flask`/`fastapi` evals). The doc wrongly said "no operators, one command only."
- **`notContainsInSource`** — lists the full set of non-source extensions it actually skips (`.env*`, `.json`, `.plist`, `.xml`, `.yaml`, `.yml`, `.toml`, `.ini`, `.cfg`, `.conf`, `.md`) per `text-search-utils.ts`, instead of just three.
- **`matches`** — defaults to case-**insensitive** (per `primitives.ts`), and its signature accepts an `options?` arg; both were misdocumented.
- **`caseSensitive` default** — clarified: `true` for `contains`/`notContains`/`notContainsInSource`, `false` for `matches`.
- **Stale example model** — `claude-sonnet-4-6` → `claude-sonnet-5` (matches `eval.config.js` `models.known`).

## Test plan

Docs-only change. Verified each claim against the source:
- `packages/evals-core/src/workspace/workspace.ts` (`runSetupCommand`)
- `packages/evals-core/src/graders/executors/text-search-utils.ts`
- `packages/evals-graders/src/primitives.ts`
- `apps/auth0-evals/eval.config.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the eval creation guide with clearer frontmatter field descriptions and examples.
  * Documented sequential `setup_command` behavior using `&&`.
  * Clarified grader semantics, defaults, skipped file types, case sensitivity, and compilation behavior.
  * Refined grader examples and updated the sample model command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->