### PR TITLE
fix: stop Opus 5 judge truncating before its verdict line

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -383,13 +383,15 @@ Opus 4.5 is still supported by the framework (present in the effort-capable set 
 
 All LLM-as-judge graders use `claude-opus-5` via the configured LLM proxy (`proxy.baseUrl` in `eval.config.js`).
 
+The judge sends `thinking: { type: 'disabled' }`. Opus 5 runs adaptive thinking by default and counts reasoning tokens against `max_tokens`, so a thinking judge spends its budget on reasoning and gets truncated before emitting the final `yes`/`no` line — scoring correct solutions as failures. The judge only needs 1–3 sentences plus a verdict, so the whole budget goes to visible output. `judge.maxTokens` is also set to 4096 for headroom in case a proxy ignores the flag, and a truncated response now reports itself as truncated rather than as an unexpected verdict.
+
 ### Settings
 
 | Setting              | Value                                            |
 | -------------------- | ------------------------------------------------ |
 | Base URL             | Configured in `eval.config.js` (`proxy.baseUrl`) |
 | Judge model          | `claude-opus-5`                                  |
-| Judge max tokens     | 1024                                             |
+| Judge max tokens     | 4096                                             |
 | Judge max code chars | 32,768                                           |
 | Max agent turns      | 75                                               |
 | Runner task timeout  | 30 min (per eval, graceful abort)                |

--- a/apps/auth0-evals/eval.config.js
+++ b/apps/auth0-evals/eval.config.js
@@ -81,7 +81,10 @@ export default {
 
   judge: {
     model: 'claude-opus-5',
-    maxTokens: 1024,
+    // Headroom so a verbose judge still reaches its final yes/no line. Opus 5
+    // counts thinking against max_tokens; the judge disables thinking, but this
+    // also covers proxies that ignore that flag.
+    maxTokens: 4096,
     maxCodeChars: 32_768,
   },
 

--- a/packages/evals-core/src/config/defaults.ts
+++ b/packages/evals-core/src/config/defaults.ts
@@ -1,4 +1,5 @@
 import type { FrameworkConfig } from './framework.js';
+import { JUDGE_DEFAULT_MAX_TOKENS } from '../graders/llm-judge.js';
 
 /**
  * Sensible generic defaults for every optional field.
@@ -25,7 +26,7 @@ export const DEFAULT_FRAMEWORK_CONFIG: Required<FrameworkConfig> = {
 
   judge: {
     model: '',
-    maxTokens: 1024,
+    maxTokens: JUDGE_DEFAULT_MAX_TOKENS,
     maxCodeChars: 32_768,
   },
 

--- a/packages/evals-core/src/graders/engine.ts
+++ b/packages/evals-core/src/graders/engine.ts
@@ -22,8 +22,10 @@ import { llmJudgeExecutor } from './executors/llm-judge.js';
 import { eventExecutor } from './executors/event.js';
 import { compileExecutor } from './executors/compile.js';
 
+import { JUDGE_DEFAULT_MAX_TOKENS } from './llm-judge.js';
+
 // Re-export llmJudge from its dedicated module for backward compatibility.
-export { llmJudge } from './llm-judge.js';
+export { llmJudge, JUDGE_DEFAULT_MAX_TOKENS } from './llm-judge.js';
 
 // ── Register built-in executors ──────────────────────────────────────────────
 
@@ -122,7 +124,7 @@ export async function runGraders(
   const config = getFrameworkConfig();
   const resolvedJudgeModel = judgeModel ?? config.judge.model ?? '';
   const judgeMaxCodeChars = config.judge.maxCodeChars ?? 32_768;
-  const judgeMaxTokens = config.judge.maxTokens ?? 1024;
+  const judgeMaxTokens = config.judge.maxTokens ?? JUDGE_DEFAULT_MAX_TOKENS;
   const judgeBaseUrl = config.proxy.baseUrl;
   const active = allowedLevels
     ? graderDefs.filter((g) => g.level === undefined || allowedLevels.has(g.level))

--- a/packages/evals-core/src/graders/index.ts
+++ b/packages/evals-core/src/graders/index.ts
@@ -1,6 +1,7 @@
 export {
   runGraders,
   llmJudge,
+  JUDGE_DEFAULT_MAX_TOKENS,
   passRate,
   collectFiles as collectGraderFiles,
   walkFiles,

--- a/packages/evals-core/src/graders/llm-judge.ts
+++ b/packages/evals-core/src/graders/llm-judge.ts
@@ -82,6 +82,15 @@ export async function llmJudge(opts: LlmJudgeOptions): Promise<LlmJudgeResult> {
   // reasoning tokens ate the budget and the response was cut off before the
   // final verdict line, failing correct solutions. The judge only needs 1-3
   // sentences plus a yes/no, so the whole budget should go to visible output.
+  //
+  // It also keeps the grading instrument stable: every judge verdict recorded
+  // before Opus 5 came from a non-thinking judge (Opus 4.8 did not think unless
+  // asked), so disabling it here keeps old and new eval scores comparable.
+  //
+  // Careful if you add `output_config.effort`: Opus 5 only accepts
+  // `thinking: disabled` at effort `high` or lower, and rejects `xhigh`/`max`
+  // with a 400 — validated per request. We send no effort, so the default
+  // (`high`) applies and this is in bounds.
   const payload = JSON.stringify({
     model,
     messages: [

--- a/packages/evals-core/src/graders/llm-judge.ts
+++ b/packages/evals-core/src/graders/llm-judge.ts
@@ -12,6 +12,17 @@ import { SYSTEM_PROMPT, USER_TEMPLATE } from './prompts.generated.js';
 
 // ── LLM Judge ─────────────────────────────────────────────────────────────────
 
+/**
+ * Default output budget for a judge call.
+ *
+ * Sized with headroom rather than to the ~150 tokens a verdict actually needs:
+ * thinking-capable models (e.g. Opus 5) count reasoning tokens against
+ * `max_tokens`, so a tight budget truncates the response before its final
+ * yes/no line. The judge disables thinking, but this also covers proxies that
+ * ignore that flag.
+ */
+export const JUDGE_DEFAULT_MAX_TOKENS = 4096;
+
 export interface LlmJudgeOptions {
   question: string;
   code: string;
@@ -33,7 +44,7 @@ export interface LlmJudgeResult {
 export async function llmJudge(opts: LlmJudgeOptions): Promise<LlmJudgeResult> {
   const { question, code, apiKey, model, baseUrl, enforceMaxChars = true } = opts;
   const judgeMaxCodeChars = opts.maxCodeChars ?? 32_768;
-  const judgeMaxTokens = opts.maxTokens ?? 1024;
+  const judgeMaxTokens = opts.maxTokens ?? JUDGE_DEFAULT_MAX_TOKENS;
 
   if (!model) {
     throw new JudgeError(
@@ -65,6 +76,12 @@ export async function llmJudge(opts: LlmJudgeOptions): Promise<LlmJudgeResult> {
 
   // The judge hits the /chat/completions endpoint, which serves models under
   // their plain alias, so the model is sent as-is (no Bedrock ID mapping).
+  //
+  // `thinking: disabled` is deliberate. Claude Opus 5 runs adaptive thinking by
+  // default, and `max_tokens` caps thinking *plus* visible text together — so
+  // reasoning tokens ate the budget and the response was cut off before the
+  // final verdict line, failing correct solutions. The judge only needs 1-3
+  // sentences plus a yes/no, so the whole budget should go to visible output.
   const payload = JSON.stringify({
     model,
     messages: [
@@ -72,6 +89,7 @@ export async function llmJudge(opts: LlmJudgeOptions): Promise<LlmJudgeResult> {
       { role: 'user', content: user },
     ],
     max_tokens: judgeMaxTokens,
+    thinking: { type: 'disabled' },
   });
 
   try {
@@ -95,6 +113,7 @@ export async function llmJudge(opts: LlmJudgeOptions): Promise<LlmJudgeResult> {
     });
     const choices = data.choices as Record<string, unknown>[] | undefined;
     const message = choices?.[0]?.message as Record<string, unknown> | undefined;
+    const finishReason = choices?.[0]?.finish_reason as string | undefined;
     const answer = ((message?.content as string | undefined) ?? '').trim();
     if (!answer) {
       throw new JudgeError(model, 'empty response from LLM');
@@ -106,6 +125,17 @@ export async function llmJudge(opts: LlmJudgeOptions): Promise<LlmJudgeResult> {
     const lastLine = lines[lines.length - 1]!.toLowerCase();
     const m = /^(yes|no)\b/.exec(lastLine);
     if (!m) {
+      // Distinguish a genuinely malformed verdict from a response the provider
+      // cut off at the token ceiling. Reporting the latter as an "unexpected
+      // verdict" is actively misleading — it looks like the judge disagreed
+      // when in fact it never got to answer.
+      if (finishReason === 'length' || finishReason === 'max_tokens') {
+        throw new JudgeError(
+          model,
+          `response truncated at the ${judgeMaxTokens}-token limit before a verdict was emitted — ` +
+            `raise judge.maxTokens. Partial response: ${answer}`,
+        );
+      }
       throw new JudgeError(model, `unexpected verdict ${JSON.stringify(lastLine)}: ${answer}`);
     }
 

--- a/packages/evals-core/src/graders/llm-judge.ts
+++ b/packages/evals-core/src/graders/llm-judge.ts
@@ -115,7 +115,24 @@ export async function llmJudge(opts: LlmJudgeOptions): Promise<LlmJudgeResult> {
     const message = choices?.[0]?.message as Record<string, unknown> | undefined;
     const finishReason = choices?.[0]?.finish_reason as string | undefined;
     const answer = ((message?.content as string | undefined) ?? '').trim();
+
+    // Distinguish a response the provider cut off at the token ceiling from a
+    // genuinely malformed one. Reporting truncation as an "unexpected verdict"
+    // is actively misleading — it looks like the judge disagreed when in fact
+    // it never got to answer. Checked before the empty-answer branch because a
+    // model that spent the whole budget on reasoning returns no visible text at
+    // all, which would otherwise surface as a bare "empty response from LLM".
+    const wasTruncated = finishReason === 'length' || finishReason === 'max_tokens';
+    const reportTruncated = (): never => {
+      throw new JudgeError(
+        model,
+        `response truncated at the ${judgeMaxTokens}-token limit before a verdict was emitted — ` +
+          `raise judge.maxTokens.${answer ? ` Partial response: ${answer}` : ' No visible output was returned.'}`,
+      );
+    };
+
     if (!answer) {
+      if (wasTruncated) reportTruncated();
       throw new JudgeError(model, 'empty response from LLM');
     }
     const lines = answer
@@ -125,17 +142,7 @@ export async function llmJudge(opts: LlmJudgeOptions): Promise<LlmJudgeResult> {
     const lastLine = lines[lines.length - 1]!.toLowerCase();
     const m = /^(yes|no)\b/.exec(lastLine);
     if (!m) {
-      // Distinguish a genuinely malformed verdict from a response the provider
-      // cut off at the token ceiling. Reporting the latter as an "unexpected
-      // verdict" is actively misleading — it looks like the judge disagreed
-      // when in fact it never got to answer.
-      if (finishReason === 'length' || finishReason === 'max_tokens') {
-        throw new JudgeError(
-          model,
-          `response truncated at the ${judgeMaxTokens}-token limit before a verdict was emitted — ` +
-            `raise judge.maxTokens. Partial response: ${answer}`,
-        );
-      }
+      if (wasTruncated) reportTruncated();
       throw new JudgeError(model, `unexpected verdict ${JSON.stringify(lastLine)}: ${answer}`);
     }
 

--- a/packages/evals-core/src/index.ts
+++ b/packages/evals-core/src/index.ts
@@ -149,6 +149,7 @@ export { isBedrockModel, isClaudeModel, isGeminiModel, isGptModel } from './conf
 export {
   runGraders,
   llmJudge,
+  JUDGE_DEFAULT_MAX_TOKENS,
   passRate,
   collectGraderFiles,
   gradeText,

--- a/packages/evals-core/tests/config/defaults.test.ts
+++ b/packages/evals-core/tests/config/defaults.test.ts
@@ -16,7 +16,7 @@ describe('DEFAULT_FRAMEWORK_CONFIG', () => {
 
   it('has generic judge defaults', () => {
     expect(DEFAULT_FRAMEWORK_CONFIG.judge.model).toBe('');
-    expect(DEFAULT_FRAMEWORK_CONFIG.judge.maxTokens).toBe(1024);
+    expect(DEFAULT_FRAMEWORK_CONFIG.judge.maxTokens).toBe(4096);
     expect(DEFAULT_FRAMEWORK_CONFIG.judge.maxCodeChars).toBe(32_768);
   });
 

--- a/packages/evals-core/tests/config/loader.test.ts
+++ b/packages/evals-core/tests/config/loader.test.ts
@@ -86,7 +86,7 @@ describe('loadConfig', () => {
   it('deep-merges user config with defaults', async () => {
     const config = await loadConfig({ searchDir: join(FIXTURES_DIR, 'partial-judge') });
     expect(config.judge.model).toBe('claude-opus-4-7');
-    expect(config.judge.maxTokens).toBe(1024); // default preserved
+    expect(config.judge.maxTokens).toBe(4096); // default preserved
   });
 
   it('throws EvalConfigError when configPath does not exist', async () => {

--- a/packages/evals-core/tests/graders/engine.test.ts
+++ b/packages/evals-core/tests/graders/engine.test.ts
@@ -564,11 +564,56 @@ describe('llmJudge', () => {
   // thinking + visible text together. The judge's reasoning was cut off before
   // it could emit the final verdict line, which surfaced as a confusing
   // "unexpected verdict" and scored a passing solution as a hard failure.
-  it('reports truncation rather than an unexpected verdict when cut off at the token ceiling', async () => {
-    vi.stubGlobal('fetch', mockTruncatedResponse('The implementation covers the essentials correctly: `Auth0.plist`'));
+  it.each(['length', 'max_tokens'])(
+    'reports truncation rather than an unexpected verdict on finish_reason=%s',
+    async (finishReason) => {
+      const partial = 'The implementation covers the essentials correctly: `Auth0.plist`';
+      vi.stubGlobal('fetch', mockTruncatedResponse(partial, finishReason));
+      const err = await llmJudge({
+        question: 'question',
+        code: 'code',
+        apiKey: 'key',
+        model: 'model',
+        baseUrl: 'http://test',
+        maxTokens: 1024,
+      }).catch((e: unknown) => e as Error);
+
+      expect(err.message).toMatch(/truncated/i);
+      // The diagnostic has to name the knob to turn and preserve what the judge
+      // did manage to say, or it's no more actionable than the old message.
+      expect(err.message).toContain('1024');
+      expect(err.message).toContain('judge.maxTokens');
+      expect(err.message).toContain(partial);
+      expect(err.message).not.toContain('unexpected verdict');
+    },
+  );
+
+  // The worst case of the same bug: reasoning consumed the entire budget, so
+  // there is no visible text at all. This must still report truncation rather
+  // than a bare "empty response from LLM", which points nowhere.
+  it.each(['length', 'max_tokens'])(
+    'reports truncation when the whole budget was consumed and no text was returned (finish_reason=%s)',
+    async (finishReason) => {
+      vi.stubGlobal('fetch', mockTruncatedResponse('', finishReason));
+      const err = await llmJudge({
+        question: 'question',
+        code: 'code',
+        apiKey: 'key',
+        model: 'model',
+        baseUrl: 'http://test',
+      }).catch((e: unknown) => e as Error);
+
+      expect(err.message).toMatch(/truncated/i);
+      expect(err.message).toContain('judge.maxTokens');
+      expect(err.message).not.toContain('empty response from LLM');
+    },
+  );
+
+  it('still reports an empty response when it was not truncated', async () => {
+    vi.stubGlobal('fetch', mockFetchResponse(''));
     await expect(
       llmJudge({ question: 'question', code: 'code', apiKey: 'key', model: 'model', baseUrl: 'http://test' }),
-    ).rejects.toThrow(/truncated/i);
+    ).rejects.toThrow('empty response from LLM');
   });
 
   it('does not report truncation when a verdict is present despite a length finish_reason', async () => {

--- a/packages/evals-core/tests/graders/engine.test.ts
+++ b/packages/evals-core/tests/graders/engine.test.ts
@@ -43,14 +43,13 @@ const TEST_CONFIG: Required<FrameworkConfig> = {
 
 // Note: engine.ts reads config lazily (inside function calls, not at import time),
 // so setFrameworkConfig in beforeAll runs before any config access.
-import { passRate, runGraders, llmJudge } from '../../src/graders/engine.js';
+import { passRate, runGraders, llmJudge, JUDGE_DEFAULT_MAX_TOKENS } from '../../src/graders/engine.js';
 
 beforeAll(() => {
   setFrameworkConfig(TEST_CONFIG);
 });
 
 const JUDGE_MAX_CODE_CHARS = TEST_CONFIG.judge.maxCodeChars!;
-const JUDGE_MAX_TOKENS = TEST_CONFIG.judge.maxTokens!;
 
 const tmpDir = makeTmpDir('graders_test_');
 
@@ -395,6 +394,14 @@ function mockFetchResponse(content: string) {
   } as unknown as Response);
 }
 
+/** Mocks a response the provider truncated at the max_tokens ceiling. */
+function mockTruncatedResponse(content: string, finishReason = 'length') {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ choices: [{ message: { content }, finish_reason: finishReason }] }),
+  } as unknown as Response);
+}
+
 describe('llmJudge', () => {
   afterEach(() => vi.unstubAllGlobals());
 
@@ -435,7 +442,9 @@ describe('llmJudge', () => {
     expect(detail).toContain('loginWithRedirect call is present');
   });
 
-  it('request sends max_tokens equal to JUDGE_MAX_TOKENS by default', async () => {
+  // llmJudge takes maxTokens from its options, not the framework config, so this
+  // asserts its own fallback rather than TEST_CONFIG's value.
+  it('request falls back to the built-in max_tokens when maxTokens is omitted', async () => {
     let capturedBody: Record<string, unknown> | undefined;
     vi.stubGlobal(
       'fetch',
@@ -445,7 +454,7 @@ describe('llmJudge', () => {
       }),
     );
     await llmJudge({ question: 'question', code: 'code', apiKey: 'key', model: 'model', baseUrl: 'http://test' });
-    expect(capturedBody?.max_tokens).toBe(JUDGE_MAX_TOKENS);
+    expect(capturedBody?.max_tokens).toBe(JUDGE_DEFAULT_MAX_TOKENS);
   });
 
   it('request sends explicit maxTokens when provided', async () => {
@@ -549,6 +558,48 @@ describe('llmJudge', () => {
     await expect(
       llmJudge({ question: 'question', code: 'code', apiKey: 'key', model: 'model', baseUrl: 'http://test' }),
     ).rejects.toThrow('unexpected verdict');
+  });
+
+  // Regression: Opus 5 runs adaptive thinking by default, and `max_tokens` caps
+  // thinking + visible text together. The judge's reasoning was cut off before
+  // it could emit the final verdict line, which surfaced as a confusing
+  // "unexpected verdict" and scored a passing solution as a hard failure.
+  it('reports truncation rather than an unexpected verdict when cut off at the token ceiling', async () => {
+    vi.stubGlobal('fetch', mockTruncatedResponse('The implementation covers the essentials correctly: `Auth0.plist`'));
+    await expect(
+      llmJudge({ question: 'question', code: 'code', apiKey: 'key', model: 'model', baseUrl: 'http://test' }),
+    ).rejects.toThrow(/truncated/i);
+  });
+
+  it('does not report truncation when a verdict is present despite a length finish_reason', async () => {
+    vi.stubGlobal('fetch', mockTruncatedResponse('The provider is wired up correctly.\n\nyes'));
+    const { passed } = await llmJudge({
+      question: 'question',
+      code: 'code',
+      apiKey: 'key',
+      model: 'model',
+      baseUrl: 'http://test',
+    });
+    expect(passed).toBe(true);
+  });
+
+  it('disables thinking so the token budget is spent on the verdict, not reasoning', async () => {
+    let capturedBody: Record<string, unknown> | undefined;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (_url: string, opts: RequestInit) => {
+        capturedBody = JSON.parse(opts.body as string) as Record<string, unknown>;
+        return { ok: true, json: async () => ({ choices: [{ message: { content: 'yes' } }] }) };
+      }),
+    );
+    await llmJudge({
+      question: 'question',
+      code: 'code',
+      apiKey: 'key',
+      model: 'claude-opus-5',
+      baseUrl: 'http://test',
+    });
+    expect(capturedBody?.thinking).toEqual({ type: 'disabled' });
   });
 
   it('extracts token usage from OpenAI-style usage (prompt_tokens/completion_tokens)', async () => {

--- a/packages/evals/README.md
+++ b/packages/evals/README.md
@@ -69,7 +69,7 @@ export default {
   // LLM-as-judge settings
   judge: {
     model: 'claude-sonnet-4-5',
-    maxTokens: 1024,
+    maxTokens: 4096,
     maxCodeChars: 16_384,
   },
 
@@ -106,7 +106,7 @@ export default defineConfig({
 | `skills.remoteRepos` | `RemoteSkillRepo[]` | No | Git repos containing skill files |
 | `skills.localDirs` | `string[]` | No | Local directories with skill files |
 | `judge.model` | `string` | Yes | Model for LLM-as-judge grading |
-| `judge.maxTokens` | `number` | No | Max tokens for judge responses |
+| `judge.maxTokens` | `number` | No | Max tokens for judge responses (default 4096). Thinking-capable models count reasoning against this budget, so keep headroom or the verdict line can be truncated. |
 | `judge.maxCodeChars` | `number` | No | Max source code chars sent to judge |
 | `models.known` | `string[]` | No | Models available via `--model all` |
 | `models.default` | `string` | Yes | Default model when `--model` is omitted |


### PR DESCRIPTION
## Problem

Adopting `claude-opus-5` as the judge (#161) swapped only the model string. But Opus 5 changes behaviour in two ways that interact badly:

- **Thinking is ON by default.** On Opus 4.8, omitting `thinking` ran *without* it.
- **`max_tokens` caps thinking *plus* visible text together.**

With `judge.maxTokens: 1024`, reasoning consumed the budget and the response was cut off before the required final `yes`/`no` line. The judge then threw `unexpected verdict "..."` — which reads as the judge *disagreeing*, when in fact it never got to answer. Correct solutions were scored as hard failures, intermittently.

## Evidence

From a `swift_quickstart` / `agent+skills` / `claude-opus-5` run:

- The failing judge emitted only **~95 tokens** of visible text against a 1024 budget, truncated mid-identifier at `` `@Env ``.
- The reconstructed text is unambiguously an **approval**: *"The implementation covers the essentials correctly: `Auth0.plist` for domain/clientId, `Auth0.webAuth().scope(...).start()` for login, `clearSession()` … "*
- All **11 deterministic graders passed**. The eval scored 96.4/A with this spurious failure dragging `grader_pass_rate` to 0.917.
- A sibling judge on the same run **passed at ~140 tokens** — just under the cliff. That proximity is why this presented as flakiness rather than a clean break.

## Fix — three layers

1. **Send `thinking: { type: 'disabled' }`.** The root-cause fix. A judge needs 1–3 sentences plus a verdict, so the whole budget should go to visible output.
2. **Raise the default budget 1024 → 4096**, via a single exported `JUDGE_DEFAULT_MAX_TOKENS` rather than a magic number duplicated across three call sites. This covers proxies that ignore the thinking flag.
3. **Report truncation as truncation.** A `length` / `max_tokens` finish reason with no verdict now names the limit and points at `judge.maxTokens`, instead of masquerading as a disagreement.

## Tests

4 new tests in `engine.test.ts`. The two targeting the bug **failed first** against the old code, reproducing the production failure:

- `expected undefined to deeply equal { type: 'disabled' }`
- `expected [Function] to throw error matching /truncated/i but got 'Judge (model) failed: unexpected verd…'`

Also renames a `max_tokens` test that only passed because the config fixture and the `llmJudge` fallback happened to share the value `1024` — `llmJudge` reads its own options, not the framework config, so the old name was misleading.

## Verification

- `npm run build`, `npm run lint`, `npm run format` — clean
- Full suite: **1338 passed, 0 failed** (56 + 490 + 75 + 717)

## Docs

`AGENTS.md` settings table plus a new paragraph explaining *why* thinking is disabled (this is non-obvious and easy to regress), and `packages/evals/README.md`.

## Note for reviewers

Judge results produced since #161 are suspect wherever a judge approved verbosely — worth re-running rather than trusting those scores.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved evaluation judge reliability by increasing the default response budget.
  * Disabled adaptive thinking where applicable to preserve clear yes/no verdicts.
  * Truncated responses now produce a clear truncation error instead of an unexpected verdict.

* **Documentation**
  * Updated configuration guidance and examples to reflect the new default token budget and truncation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->