### PR TITLE
chore: bump package versions to next patch

### DIFF
--- a/apps/auth0-evals/package.json
+++ b/apps/auth0-evals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-evals",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "build": "tsc",

--- a/packages/evals-core/package.json
+++ b/packages/evals-core/package.json
@@ -1,10 +1,12 @@
 {
   "name": "@a0/evals-core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/packages/evals-graders/package.json
+++ b/packages/evals-graders/package.json
@@ -1,10 +1,12 @@
 {
   "name": "@a0/evals-graders",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/packages/evals-reporter/package.json
+++ b/packages/evals-reporter/package.json
@@ -1,10 +1,13 @@
 {
   "name": "@a0/evals-reporter",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist", "src/templates"],
+  "files": [
+    "dist",
+    "src/templates"
+  ],
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@a0/evals",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
     "a0-eval": "./dist/cli/bin.js"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "exports": {
     ".": {
       "import": "./dist/index.js",


### PR DESCRIPTION
## ✏️ Changes

Bumps every workspace package to the next patch version as a maintenance release. No functional code changed; only version fields in the manifests.

- All `@a0/*` packages: `0.1.0` to `0.1.1` (`evals-core`, `evals-graders`, `evals-reporter`, `evals`)
- `auth0-evals` app: `1.0.0` to `1.0.1`

Internal `@a0/*` dependencies use `*` ranges, so no dependency ranges needed updating. The root `auth0-evals-monorepo` has no version field and was left untouched.

- [x] I described the changes on this PR.

## 🔮 Type of Change

- [ ] Standard
- [ ] Emergency
- [ ] Significant

## 🔗 References

No tracking issue; this is a routine version bump.

- [ ] I added at least one link (task, Slack thread, etc.) to explain why this change is needed.

## 📖 Documentation

N/A. Version-only change, no documented behavior affected.

- [ ] I reflected this change in the documentation, or explained why no update is needed.

## 🎯 Testing

No functional change to exercise. Version fields only; internal deps resolve via `*`.

- [ ] I described how I tested these changes, or explained why I did not.
- [ ] This change has test coverage, or I explained why it does not.

## 🚀 Deployment

- [ ] This change can support multiple releases of the code serving traffic at the same time.
- [ ] This can be deployed at any time.

## 🔥 Rollback

Revert the commit; version fields return to their prior values with no side effects.

- [ ] I explained what rollback for this change looks like and how we recover quickly.