### PR TITLE
feat(axis): add @a0/evals-axis package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,10 @@
       "resolved": "packages/evals",
       "link": true
     },
+    "node_modules/@a0/evals-axis": {
+      "resolved": "packages/evals-axis",
+      "link": true
+    },
     "node_modules/@a0/evals-core": {
       "resolved": "packages/evals-core",
       "link": true
@@ -83,6 +87,14 @@
       "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@agentclientprotocol/sdk": {
+      "version": "0.19.2",
+      "integrity": "sha512-G1Qi50Kc2GZxYjvH6t6yG8KFZMVe5vWTzZH4c7ylb0yiqMfNQSBDHPy0FMxYLPsorMqlM+eyV4yRp4oeUjl/Lw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
     },
     "node_modules/@ai-sdk/gateway": {
       "version": "4.0.36",
@@ -176,6 +188,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize": {
+      "version": "0.3.0",
+      "integrity": "sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
@@ -1813,6 +1837,35 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@netlify/axis": {
+      "version": "1.17.2",
+      "integrity": "sha512-dyLDNbn5MFlZsVGLkNblZLT3ff68x8VN3+4YcQobe3uzLxISdyOnSS8FeJKYJX3MsGlaXrei0RwPHSbGbj1LHg==",
+      "license": "MIT",
+      "workspaces": [
+        "src/docs-site"
+      ],
+      "dependencies": {
+        "@agentclientprotocol/sdk": "^0.19.0",
+        "commander": "^14.0.3",
+        "ink": "^7.0.0",
+        "jiti": "^2.7.0",
+        "react": "^19.2.5"
+      },
+      "bin": {
+        "axis": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@netlify/axis/node_modules/commander": {
+      "version": "14.0.3",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@next/env": {
       "version": "14.2.35",
       "integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==",
@@ -2861,6 +2914,42 @@
         }
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
@@ -2902,6 +2991,17 @@
     "node_modules/auth0-evals": {
       "resolved": "apps/auth0-evals",
       "link": true
+    },
+    "node_modules/auto-bind": {
+      "version": "5.0.1",
+      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
@@ -3062,10 +3162,46 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/cjs-module-lexer": {
       "version": "2.2.0",
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
       "license": "MIT"
+    },
+    "node_modules/cli-boxes": {
+      "version": "4.0.1",
+      "integrity": "sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.20 <19 || >=20.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/cli-progress": {
       "version": "3.12.0",
@@ -3182,6 +3318,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/cli-truncate": {
+      "version": "6.1.1",
+      "integrity": "sha512-06p9vyLahLa4zkGcgsGxU6iEkSOiuI4fhCH6Emhe2lPAcoUv73n72DnODsnHA+5wwXGnV0n9M9/qOQJSjYhFhw==",
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^9.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/code-excerpt": {
+      "version": "4.0.0",
+      "integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
+      "license": "MIT",
+      "dependencies": {
+        "convert-to-spaces": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/commander": {
       "version": "15.0.0",
       "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
@@ -3215,6 +3377,14 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/convert-to-spaces": {
+      "version": "2.0.1",
+      "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -3341,6 +3511,17 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
@@ -3373,6 +3554,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.50.0",
+      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks",
+        "tests/types"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
@@ -3858,6 +4049,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
@@ -4029,10 +4231,69 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "5.0.0",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ink": {
+      "version": "7.1.1",
+      "integrity": "sha512-Y43xxa1ZSPvpmfLHcN5o+OdP8Rf8ykkNJEuKYOUNZKT8wXVNLFTtEm1nSDMQkfBH+YANF4Xuu0hhZ4ejqAtN2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@alcalzone/ansi-tokenize": "^0.3.0",
+        "ansi-escapes": "^7.3.0",
+        "ansi-styles": "^6.2.3",
+        "auto-bind": "^5.0.1",
+        "chalk": "^5.6.2",
+        "cli-boxes": "^4.0.1",
+        "cli-cursor": "^4.0.0",
+        "cli-truncate": "^6.0.0",
+        "code-excerpt": "^4.0.0",
+        "es-toolkit": "^1.45.1",
+        "indent-string": "^5.0.0",
+        "is-in-ci": "^2.0.0",
+        "patch-console": "^2.0.0",
+        "react-reconciler": "^0.33.0",
+        "scheduler": "^0.27.0",
+        "signal-exit": "^3.0.7",
+        "slice-ansi": "^9.0.0",
+        "stack-utils": "^2.0.6",
+        "string-width": "^8.2.0",
+        "terminal-size": "^4.0.1",
+        "type-fest": "^5.5.0",
+        "widest-line": "^6.0.0",
+        "wrap-ansi": "^10.0.0",
+        "ws": "^8.20.0",
+        "yoga-layout": "~3.2.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "@types/react": ">=19.2.0",
+        "react": ">=19.2.0",
+        "react-devtools-core": ">=6.1.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-devtools-core": {
+          "optional": true
+        }
+      }
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
@@ -4060,6 +4321,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
@@ -4070,6 +4345,20 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-in-ci": {
+      "version": "2.0.0",
+      "integrity": "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==",
+      "license": "MIT",
+      "bin": {
+        "is-in-ci": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-promise": {
@@ -4116,6 +4405,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/jose": {
@@ -4613,6 +4910,14 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
@@ -4782,6 +5087,20 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
@@ -4835,6 +5154,14 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/patch-console": {
+      "version": "2.0.0",
+      "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/path-exists": {
@@ -5012,12 +5339,49 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.33.0",
+      "integrity": "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/rolldown": {
@@ -5071,6 +5435,11 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
     "node_modules/semifies": {
@@ -5231,6 +5600,11 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
     "node_modules/simple-git": {
       "version": "3.36.0",
       "integrity": "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==",
@@ -5245,6 +5619,21 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/steveukx/git-js?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "9.0.0",
+      "integrity": "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
     "node_modules/source-map": {
@@ -5262,6 +5651,25 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/stackback": {
@@ -5293,6 +5701,35 @@
         "node": ">=0.6.19"
       }
     },
+    "node_modules/string-width": {
+      "version": "8.2.2",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
@@ -5305,12 +5742,34 @@
         "node": ">=8"
       }
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/termi-link": {
       "version": "1.1.0",
       "integrity": "sha512-2qSN6TnomHgVLtk+htSWbaYs4Rd2MH/RU7VpHTy6MBstyNyWbM4yKd1DCYpE3fDg8dmGWojXCngNi/MHCzGuAA==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/terminal-size": {
+      "version": "4.0.1",
+      "integrity": "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tinybench": {
@@ -5422,6 +5881,20 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "5.8.0",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -5748,6 +6221,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/widest-line": {
+      "version": "6.0.0",
+      "integrity": "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
@@ -5757,10 +6244,46 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "10.0.0",
+      "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "string-width": "^8.2.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yaml": {
       "version": "2.9.0",
@@ -5789,6 +6312,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "4.4.3",
@@ -5832,6 +6360,19 @@
         "@a0/evals-graders": "*",
         "@types/node": "^26.1.2",
         "@vitest/coverage-v8": "^4.1.9",
+        "vitest": "^4.1.10"
+      }
+    },
+    "packages/evals-axis": {
+      "name": "@a0/evals-axis",
+      "version": "1.0.0",
+      "dependencies": {
+        "@a0/evals-core": "*",
+        "@a0/evals-graders": "*",
+        "@netlify/axis": "^1.17.2"
+      },
+      "devDependencies": {
+        "@types/node": "^26.1.2",
         "vitest": "^4.1.10"
       }
     },

--- a/packages/evals-axis/eslint.config.mjs
+++ b/packages/evals-axis/eslint.config.mjs
@@ -1,0 +1,2 @@
+// @ts-check
+export { default } from '../../eslint.config.base.mjs';

--- a/packages/evals-axis/package.json
+++ b/packages/evals-axis/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@a0/evals-axis",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:ci": "vitest run --silent",
+    "test:watch": "vitest",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "@a0/evals-core": "*",
+    "@a0/evals-graders": "*",
+    "@netlify/axis": "^1.17.2"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.2",
+    "vitest": "^4.1.10"
+  }
+}

--- a/packages/evals-axis/src/adapter.ts
+++ b/packages/evals-axis/src/adapter.ts
@@ -1,0 +1,58 @@
+/**
+ * AXIS transcript adapter.
+ *
+ * Converts an AXIS TranscriptEntry[] to the EventToolCall[] format the
+ * auth0-evals grader engine expects.
+ *
+ * AXIS represents tool interactions as paired entries:
+ *   - tool_use:    carries the tool name and input arguments
+ *   - tool_result: carries the output and error flag
+ *
+ * We join pairs by tool ID and produce one EventToolCall per pair.
+ */
+
+import type { TranscriptEntry } from '@netlify/axis';
+import type { EventToolCall } from '@a0/evals-graders';
+
+export function axisTranscriptToToolCalls(transcript: TranscriptEntry[]): EventToolCall[] {
+  // First pass: index tool_use entries by their ID.
+  const toolUseById = new Map<string, { name: string; args: Record<string, unknown> }>();
+
+  for (const entry of transcript) {
+    if (entry.type !== 'tool_use') continue;
+    const c = entry.content as Record<string, unknown>;
+    const id = c['id'] as string | undefined;
+    const name = c['name'] as string | undefined;
+    if (!id || !name) continue;
+    toolUseById.set(id, {
+      name,
+      args: (c['input'] as Record<string, unknown> | undefined) ?? {},
+    });
+  }
+
+  // Second pass: emit EventToolCall for each tool_result paired with a tool_use.
+  const toolCalls: EventToolCall[] = [];
+
+  for (const entry of transcript) {
+    if (entry.type !== 'tool_result') continue;
+    const c = entry.content as Record<string, unknown>;
+    const toolUseId = c['tool_use_id'] as string | undefined;
+    if (!toolUseId) continue;
+
+    const toolUse = toolUseById.get(toolUseId);
+    if (!toolUse) continue;
+
+    const isError = (c['is_error'] as boolean | undefined) ?? false;
+    const contentVal = c['content'];
+    const result = typeof contentVal === 'string' ? contentVal : contentVal != null ? JSON.stringify(contentVal) : '';
+
+    toolCalls.push({
+      name: toolUse.name,
+      args: toolUse.args,
+      result,
+      causedError: isError,
+    });
+  }
+
+  return toolCalls;
+}

--- a/packages/evals-axis/src/grader-hook.ts
+++ b/packages/evals-axis/src/grader-hook.ts
@@ -1,0 +1,70 @@
+/**
+ * AXIS post-run grader hook.
+ *
+ * After an AXIS job completes (and before workspace teardown), this hook
+ * loads the matching eval's graders, optionally runs the compile command,
+ * and calls the auth0-evals grader engine against the workspace.
+ */
+
+import { discoverEvals, loadEval, runGraders, runCompileCommand, runSetupCommand, AGENT_LEVELS } from '@a0/evals-core';
+import type { GraderResult } from '@a0/evals-graders';
+import type { RunResult } from '@netlify/axis';
+import { axisTranscriptToToolCalls } from './adapter.js';
+
+export interface RunAuth0GradersOptions {
+  /** Absolute path to the framework root (contains eval.config.js and src/evals/). */
+  frameworkRoot: string;
+  /** Relative path to the evals directory inside frameworkRoot. Defaults to 'src/evals'. */
+  evalsDir?: string;
+  /** LLM API key forwarded to the judge model. */
+  apiKey: string;
+  /** Judge model identifier. Falls back to the framework config judge model when omitted. */
+  judgeModel?: string;
+}
+
+/**
+ * Runs auth0-evals graders against a completed AXIS job.
+ *
+ * Discovers the eval matching result.scenarioKey, converts the AXIS transcript
+ * to EventToolCall[], runs the compile command (and setup command, if declared)
+ * or the setup command alone when there is no compile step, then grades the
+ * workspace with L1-L4 graders (AGENT_LEVELS).
+ */
+export async function runAuth0Graders(result: RunResult, options: RunAuth0GradersOptions): Promise<GraderResult[]> {
+  const { frameworkRoot, evalsDir = 'src/evals', apiKey, judgeModel } = options;
+
+  if (!result.workingDirectory) {
+    throw new Error(
+      `workingDirectory missing in RunResult for '${result.scenarioKey}' — workspace was cleaned up before grading`,
+    );
+  }
+
+  const evalConfigs = discoverEvals(evalsDir, frameworkRoot);
+  const evalConfig = evalConfigs.find((c) => c.id === result.scenarioKey);
+  if (!evalConfig) {
+    throw new Error(`No eval found with id '${result.scenarioKey}' in ${frameworkRoot}/${evalsDir}`);
+  }
+
+  const evalDef = await loadEval(evalConfig, frameworkRoot);
+  const toolCalls = axisTranscriptToToolCalls(result.output.transcript);
+
+  let compileResult;
+  if (evalDef.compileCommand) {
+    compileResult = runCompileCommand(result.workingDirectory, evalDef.compileCommand, {
+      setupCommand: evalDef.setupCommand,
+    });
+  } else if (evalDef.setupCommand) {
+    runSetupCommand(result.workingDirectory, evalDef.setupCommand);
+  }
+
+  return runGraders(
+    evalDef.graders,
+    result.workingDirectory,
+    apiKey,
+    judgeModel,
+    AGENT_LEVELS,
+    true, // enforceMaxChars — truncate workspace to judge's 32 768-char limit
+    toolCalls,
+    compileResult,
+  );
+}

--- a/packages/evals-axis/src/index.ts
+++ b/packages/evals-axis/src/index.ts
@@ -1,0 +1,6 @@
+export { axisTranscriptToToolCalls } from './adapter.js';
+export { runAuth0Graders } from './grader-hook.js';
+export type { RunAuth0GradersOptions } from './grader-hook.js';
+export { runAxis } from './run.js';
+export type { RunAxisOptions, RunAxisResult } from './run.js';
+export { buildAxisScores, scoreToGrade } from './report.js';

--- a/packages/evals-axis/src/report.ts
+++ b/packages/evals-axis/src/report.ts
@@ -1,0 +1,200 @@
+/**
+ * Maps AXIS ScoredOutput + auth0-evals grader results to AgentJobResult[],
+ * the format consumed by @a0/evals-reporter's renderHtml().
+ *
+ * Exported as a standalone module so it can be tested independently of the
+ * run entry point, which triggers side-effects on import.
+ */
+
+import type { ScoredOutput, TranscriptEntry } from '@netlify/axis';
+import type { GraderResult } from '@a0/evals-graders';
+import type { AgentJobResult, AgentType, DimensionSummary, GraderSummary } from '@a0/evals-core';
+import { estimateCost } from '@a0/evals-core';
+
+/**
+ * Maps AXIS agent names (the `agent` field in axis.config.ts agents[]) to our
+ * AgentType identifiers. The AXIS gemini adapter is named "gemini" but our
+ * framework uses "gemini-cli" — without this mapping the fallback fires and
+ * every gemini result is mislabelled as "claude-code".
+ */
+const AXIS_AGENT_TO_TYPE: Record<string, AgentType> = {
+  'claude-code': 'claude-code',
+  codex: 'codex',
+  gemini: 'gemini-cli',
+  copilot: 'copilot',
+};
+
+/**
+ * Tool names that represent user-interruption calls across all runners.
+ * claude-code uses AskUserQuestion; copilot uses ask_user.
+ */
+const INTERRUPTION_TOOL_NAMES = new Set(['AskUserQuestion', 'ask_user']);
+
+/**
+ * Sums token usage across judge grader results and estimates cost.
+ * Mirrors the private computeJudgeCost helper in @a0/evals-core serializers.
+ */
+function computeJudgeCost(graderResults: GraderResult[]): number {
+  let total = 0;
+  for (const gr of graderResults) {
+    const input = gr.inputTokens ?? 0;
+    const output = gr.outputTokens ?? 0;
+    if ((input > 0 || output > 0) && gr.judgeModel) {
+      total += estimateCost(gr.judgeModel, input, output);
+    }
+  }
+  return total;
+}
+
+/**
+ * Counts interruption tool calls in an AXIS transcript.
+ *
+ * Two formats are handled:
+ *  - Standard (Codex, Gemini, Copilot): tool calls appear as top-level
+ *    entries with type === 'tool_use' and content.name set.
+ *  - Claude Code: tool calls are embedded inside type === 'assistant' entries
+ *    as content.message.content[].type === 'tool_use' blocks.
+ */
+export function countInterruptions(transcript: TranscriptEntry[]): number {
+  let count = 0;
+  for (const entry of transcript) {
+    const c = (entry.content ?? {}) as Record<string, unknown>;
+    if (entry.type === 'tool_use') {
+      const name = c['name'] as string | undefined;
+      if (name && INTERRUPTION_TOOL_NAMES.has(name)) count++;
+    } else if (entry.type === 'assistant') {
+      const innerContent = (c['message'] as Record<string, unknown> | undefined)?.['content'];
+      if (Array.isArray(innerContent)) {
+        for (const block of innerContent as Record<string, unknown>[]) {
+          if (block['type'] === 'tool_use' && INTERRUPTION_TOOL_NAMES.has(block['name'] as string)) {
+            count++;
+          }
+        }
+      }
+    }
+  }
+  return count;
+}
+
+/**
+ * Converts AXIS scored results and auth0-evals grader results into the
+ * AgentJobResult format used by the HTML reporter.
+ *
+ * tools: ['axis'] puts results in a dedicated AGENT+AXIS tab, keeping them
+ * separate from regular agent runs.
+ *
+ * cost_usd reflects AXIS's combined totalCostUsd (agent + AXIS internal judge);
+ * no per-component AXIS breakdown is available. judge_cost_usd is computed
+ * separately from the auth0-evals grader judge runs (the judge() primitive),
+ * and total_cost_usd is the sum of both.
+ */
+export function buildAxisScores(
+  output: ScoredOutput,
+  allGraderResults: Map<string, GraderResult[]>,
+  /** Maps scenario key → eval category (e.g. 'quickstarts'). Falls back to '' if omitted. */
+  categories: Record<string, string> = {},
+): AgentJobResult[] {
+  return output.results.map((result) => {
+    const key = `${result.scenarioKey}|${result.agentName}`;
+    const graders = allGraderResults.get(key) ?? [];
+    const passed = graders.filter((g) => g.passed).length;
+    const judgeCost = computeJudgeCost(graders);
+
+    // agentName format: "claude-code|global.anthropic.claude-opus-4-8"
+    // This pipe-separated convention is set by axis.config.ts agents[] and is
+    // not guaranteed by the AXIS API — if the format changes, rawAgentType
+    // falls through to the claude-code default and model falls back to agentName.
+    const [rawAgentType, model] = result.agentName.split('|');
+    const agentType: AgentType = AXIS_AGENT_TO_TYPE[rawAgentType ?? ''] ?? 'claude-code';
+
+    const dimensions: DimensionSummary[] = [
+      {
+        name: 'Goal Achievement',
+        score: result.score.goalAchievement.score,
+        grade: scoreToGrade(result.score.goalAchievement.score),
+        weight: 0.4,
+        weighted: result.score.goalAchievement.score * 0.4,
+      },
+      {
+        name: 'Environment',
+        score: result.score.environment.score,
+        grade: scoreToGrade(result.score.environment.score),
+        weight: 0.2,
+        weighted: result.score.environment.score * 0.2,
+      },
+      {
+        name: 'Service',
+        score: result.score.service.score,
+        grade: scoreToGrade(result.score.service.score),
+        weight: 0.2,
+        weighted: result.score.service.score * 0.2,
+      },
+      {
+        name: 'Agent',
+        score: result.score.agent.score,
+        grade: scoreToGrade(result.score.agent.score),
+        weight: 0.2,
+        weighted: result.score.agent.score * 0.2,
+      },
+    ];
+
+    const graderSummaries: GraderSummary[] = graders.map((g) => {
+      const summary: GraderSummary = {
+        name: g.name,
+        kind: g.kind,
+        passed: g.passed,
+        detail: g.detail,
+        level: g.level,
+      };
+      if ((g.inputTokens || g.outputTokens) && g.judgeModel) {
+        summary.cost_usd = estimateCost(g.judgeModel, g.inputTokens ?? 0, g.outputTokens ?? 0);
+      }
+      return summary;
+    });
+
+    const tokenUsage = result.output.metadata.tokenUsage;
+
+    return {
+      eval_id: result.scenarioKey,
+      category: categories[result.scenarioKey] ?? '',
+      prompt: result.prompt,
+      response_text: result.output.result ?? '',
+      model: model ?? result.agentName,
+      mode: 'agent',
+      agent_type: agentType,
+      tools: ['axis'],
+      session_id: result.scenarioKey,
+      status: result.output.metadata.exitCode === 0 ? 'success' : 'failure',
+      overall_score: result.score.axisScore,
+      overall_grade: scoreToGrade(result.score.axisScore),
+      grader_pass_rate: graders.length > 0 ? passed / graders.length : 0,
+      wall_time: result.output.metadata.durationMs / 1000,
+      active_time: (result.score.sparseIndex?.stats.totalDurationMs ?? 0) / 1000,
+      // The AXIS claude-code adapter stores tool calls inside assistant entries,
+      // not as separate tool_use entries. Use transcriptAnalysis.toolUseCount
+      // (populated during scoring and re-classifying claude-code assistant+tool_use
+      // blocks) so the count is correct regardless of adapter.
+      tool_calls:
+        result.output.transcriptAnalysis?.toolUseCount ??
+        result.output.transcript.filter((e) => e.type === 'tool_use').length,
+      interruptions: countInterruptions(result.output.transcript),
+      tokens: tokenUsage ? tokenUsage.input + tokenUsage.output + (tokenUsage.cacheReadInput ?? 0) : 0,
+      cost_usd: result.output.metadata.totalCostUsd ?? 0,
+      judge_cost_usd: judgeCost,
+      total_cost_usd: (result.output.metadata.totalCostUsd ?? 0) + judgeCost,
+      dimensions,
+      graders: graderSummaries,
+      session_trace: [],
+      turn_metrics: [],
+    };
+  });
+}
+
+/** Maps a 0–100 score to a letter grade using the framework's thresholds. */
+export function scoreToGrade(score: number): string {
+  if (score >= 90) return 'A';
+  if (score >= 75) return 'B';
+  if (score >= 60) return 'C';
+  if (score >= 40) return 'D';
+  return 'F';
+}

--- a/packages/evals-axis/src/run.ts
+++ b/packages/evals-axis/src/run.ts
@@ -1,0 +1,136 @@
+/**
+ * Programmatic AXIS runner with auth0-evals grader overlay.
+ *
+ * Wraps AXIS's run() with an onResult hook that fires the auth0-evals grader
+ * engine after each job completes (before workspace teardown), then calls
+ * scoreResults() to compute AXIS's own 4-dimension LLM-judge scores.
+ */
+
+/* eslint-disable no-console */
+
+import { run, scoreResults, loadConfig } from '@netlify/axis';
+import type { ScoredOutput, AgentConfig } from '@netlify/axis';
+import type { GraderResult } from '@a0/evals-graders';
+import { runAuth0Graders } from './grader-hook.js';
+import type { RunAuth0GradersOptions } from './grader-hook.js';
+
+export interface RunAxisOptions extends RunAuth0GradersOptions {
+  /** Path to axis.config.ts. Defaults to axis.config.ts in the current directory. */
+  configPath?: string;
+  /** Called with auth0-evals grader results after each job. Defaults to console logging. */
+  onGraderResults?: (scenarioKey: string, agentName: string, results: GraderResult[]) => void;
+  /** Called with the AXIS score after scoring completes for each result. Defaults to console logging. */
+  onAxisScore?: (scenarioKey: string, agentName: string, score: ScoredOutput['results'][number]['score']) => void;
+  /** When true, adapters capture raw stdout lines for debugging (written as .raw.ndjson files). */
+  debug?: boolean;
+}
+
+export interface RunAxisResult {
+  /** AXIS scored output with goal/env/svc/agent scores for each result. */
+  scoredOutput: ScoredOutput;
+  /**
+   * auth0-evals grader results collected during the run.
+   * Keyed by "scenarioKey|agentName" — matches ScoredOutput.results entries.
+   */
+  graderResults: Map<string, GraderResult[]>;
+}
+
+/**
+ * Runs AXIS, layers auth0-evals graders on top of every job result, then
+ * scores all results with AXIS's LLM judge.
+ *
+ * Returns the full ScoredOutput so callers can persist or report the AXIS
+ * scores alongside auth0-evals grader results.
+ *
+ * Call setFrameworkConfig() before this if you need custom judge / proxy
+ * settings — runGraders() reads them via the framework config singleton.
+ */
+export async function runAxis(options: RunAxisOptions): Promise<RunAxisResult> {
+  const { configPath, onGraderResults, onAxisScore, debug, ...graderOptions } = options;
+
+  // Collect grader results for each job so callers can build reports.
+  const allGraderResults = new Map<string, GraderResult[]>();
+
+  // Step 1: run agents, fire our grader hook after each job.
+  const runOutput = await run({
+    ...(configPath ? { configPath } : {}),
+    ...(debug ? { debug } : {}),
+    onResult: async (result) => {
+      try {
+        const graderResults = await runAuth0Graders(result, graderOptions);
+        allGraderResults.set(`${result.scenarioKey}|${result.agentName}`, graderResults);
+        const reporter = onGraderResults ?? logGraderResults;
+        reporter(result.scenarioKey, result.agentName, graderResults);
+      } catch (err) {
+        console.error(`[auth0-graders] Error grading ${result.scenarioKey}:`, err);
+        // Store an explicit failure so callers can distinguish "grading crashed"
+        // from "no graders configured" (which also produces an empty array).
+        const errorResult: GraderResult = {
+          name: 'grading-error',
+          kind: 'error',
+          passed: false,
+          detail: `Grading failed: ${err instanceof Error ? err.message : String(err)}`,
+        };
+        const key = `${result.scenarioKey}|${result.agentName}`;
+        allGraderResults.set(key, [errorResult]);
+        const reporter = onGraderResults ?? logGraderResults;
+        reporter(result.scenarioKey, result.agentName, [errorResult]);
+      }
+    },
+  });
+
+  // Step 2: score with AXIS's LLM judge (goal achievement + 3 process dimensions).
+  // Pass workingDirectory as undefined so the judge runs in a fresh empty temp
+  // dir (AXIS's callJudge() fallback). The judging agent has filesystem and web
+  // tools blocked in axis.config.ts (Bash,Read,Glob,Grep,WebFetch,WebSearch) so
+  // it evaluates purely from the transcript + final result text in its prompt —
+  // no file reads that would put JSON into the response and break parseJsonFromText.
+  console.log('[axis] Scoring results with AXIS judge...');
+  const runOutputForScoring = {
+    ...runOutput,
+    results: runOutput.results.map((r) => ({ ...r, workingDirectory: undefined })),
+  };
+
+  const axisConfig = configPath ? await loadConfig(configPath) : undefined;
+  const judgingAgents = axisConfig?.config?.judging?.agents?.filter(
+    (a: string | AgentConfig): a is AgentConfig => typeof a !== 'string',
+  );
+
+  const scoredOutput = await scoreResults(runOutputForScoring, {
+    ...(judgingAgents?.length ? { judging: judgingAgents } : {}),
+  });
+
+  for (const result of scoredOutput.results) {
+    const reporter = onAxisScore ?? logAxisScore;
+    reporter(result.scenarioKey, result.agentName, result.score);
+    // Temporary: log goal rationale to diagnose goal=0
+    const goalCriteria = result.score.goalAchievement?.criteria ?? [];
+    if (goalCriteria.length === 0) {
+      console.log(`[axis-debug] goal: no criteria (result.judge was falsy — judge never called)`);
+    } else {
+      console.log(`[axis-debug] goal rationale: ${goalCriteria[0]?.rationale ?? '(none)'}`);
+    }
+  }
+
+  return { scoredOutput, graderResults: allGraderResults };
+}
+
+function logGraderResults(scenarioKey: string, agentName: string, results: GraderResult[]): void {
+  const passed = results.filter((r) => r.passed).length;
+  console.log(`[auth0-graders] ${scenarioKey} (${agentName}): ${passed}/${results.length} passed`);
+  for (const r of results) {
+    const icon = r.passed ? '✓' : '✗';
+    const detail = r.detail ? ` — ${r.detail}` : '';
+    console.log(`  ${icon} ${r.name}${detail}`);
+  }
+}
+
+function logAxisScore(scenarioKey: string, agentName: string, score: ScoredOutput['results'][number]['score']): void {
+  console.log(
+    `[axis-score] ${scenarioKey} (${agentName}): ${score.axisScore.toFixed(1)}/100` +
+      ` | goal=${score.goalAchievement.score.toFixed(1)}` +
+      ` env=${score.environment.score.toFixed(1)}` +
+      ` svc=${score.service.score.toFixed(1)}` +
+      ` agent=${score.agent.score.toFixed(1)}`,
+  );
+}

--- a/packages/evals-axis/src/run.ts
+++ b/packages/evals-axis/src/run.ts
@@ -56,10 +56,11 @@ export async function runAxis(options: RunAxisOptions): Promise<RunAxisResult> {
     ...(configPath ? { configPath } : {}),
     ...(debug ? { debug } : {}),
     onResult: async (result) => {
+      const key = `${result.scenarioKey}|${result.agentName}`;
+      const reporter = onGraderResults ?? logGraderResults;
       try {
         const graderResults = await runAuth0Graders(result, graderOptions);
-        allGraderResults.set(`${result.scenarioKey}|${result.agentName}`, graderResults);
-        const reporter = onGraderResults ?? logGraderResults;
+        allGraderResults.set(key, graderResults);
         reporter(result.scenarioKey, result.agentName, graderResults);
       } catch (err) {
         console.error(`[auth0-graders] Error grading ${result.scenarioKey}:`, err);
@@ -71,9 +72,7 @@ export async function runAxis(options: RunAxisOptions): Promise<RunAxisResult> {
           passed: false,
           detail: `Grading failed: ${err instanceof Error ? err.message : String(err)}`,
         };
-        const key = `${result.scenarioKey}|${result.agentName}`;
         allGraderResults.set(key, [errorResult]);
-        const reporter = onGraderResults ?? logGraderResults;
         reporter(result.scenarioKey, result.agentName, [errorResult]);
       }
     },
@@ -91,7 +90,7 @@ export async function runAxis(options: RunAxisOptions): Promise<RunAxisResult> {
     results: runOutput.results.map((r) => ({ ...r, workingDirectory: undefined })),
   };
 
-  const axisConfig = configPath ? await loadConfig(configPath) : undefined;
+  const axisConfig = await loadConfig(configPath);
   const judgingAgents = axisConfig?.config?.judging?.agents?.filter(
     (a: string | AgentConfig): a is AgentConfig => typeof a !== 'string',
   );
@@ -103,13 +102,6 @@ export async function runAxis(options: RunAxisOptions): Promise<RunAxisResult> {
   for (const result of scoredOutput.results) {
     const reporter = onAxisScore ?? logAxisScore;
     reporter(result.scenarioKey, result.agentName, result.score);
-    // Temporary: log goal rationale to diagnose goal=0
-    const goalCriteria = result.score.goalAchievement?.criteria ?? [];
-    if (goalCriteria.length === 0) {
-      console.log(`[axis-debug] goal: no criteria (result.judge was falsy — judge never called)`);
-    } else {
-      console.log(`[axis-debug] goal rationale: ${goalCriteria[0]?.rationale ?? '(none)'}`);
-    }
   }
 
   return { scoredOutput, graderResults: allGraderResults };

--- a/packages/evals-axis/tests/adapter.test.ts
+++ b/packages/evals-axis/tests/adapter.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import { axisTranscriptToToolCalls } from '../src/adapter.js';
+import type { TranscriptEntry } from '@netlify/axis';
+
+describe('axisTranscriptToToolCalls', () => {
+  it('returns empty array for empty transcript', () => {
+    expect(axisTranscriptToToolCalls([])).toEqual([]);
+  });
+
+  it('returns empty array when transcript has no tool calls', () => {
+    const transcript: TranscriptEntry[] = [
+      { type: 'assistant', timestamp: '2024-01-01T00:00:00Z', content: { text: 'Hello' } },
+      { type: 'user', timestamp: '2024-01-01T00:00:01Z', content: { text: 'Hi' } },
+    ];
+    expect(axisTranscriptToToolCalls(transcript)).toEqual([]);
+  });
+
+  it('converts a matched tool_use + tool_result pair', () => {
+    const transcript: TranscriptEntry[] = [
+      {
+        type: 'tool_use',
+        timestamp: '2024-01-01T00:00:00Z',
+        content: { id: 'call_1', name: 'read_file', input: { path: 'src/app.ts' } },
+      },
+      {
+        type: 'tool_result',
+        timestamp: '2024-01-01T00:00:01Z',
+        content: { tool_use_id: 'call_1', content: 'import React from "react";', is_error: false },
+      },
+    ];
+
+    const result = axisTranscriptToToolCalls(transcript);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      name: 'read_file',
+      args: { path: 'src/app.ts' },
+      result: 'import React from "react";',
+      causedError: false,
+    });
+  });
+
+  it('defaults causedError to false when is_error is absent', () => {
+    const transcript: TranscriptEntry[] = [
+      {
+        type: 'tool_use',
+        timestamp: '2024-01-01T00:00:00Z',
+        content: { id: 'call_1', name: 'write_file', input: {} },
+      },
+      {
+        type: 'tool_result',
+        timestamp: '2024-01-01T00:00:01Z',
+        content: { tool_use_id: 'call_1', content: 'ok' },
+      },
+    ];
+
+    expect(axisTranscriptToToolCalls(transcript)[0].causedError).toBe(false);
+  });
+
+  it('marks causedError true when is_error is set', () => {
+    const transcript: TranscriptEntry[] = [
+      {
+        type: 'tool_use',
+        timestamp: '2024-01-01T00:00:00Z',
+        content: { id: 'call_2', name: 'run_command', input: { command: 'npm install' } },
+      },
+      {
+        type: 'tool_result',
+        timestamp: '2024-01-01T00:00:01Z',
+        content: { tool_use_id: 'call_2', content: 'ENOENT: no such file', is_error: true },
+      },
+    ];
+
+    expect(axisTranscriptToToolCalls(transcript)[0].causedError).toBe(true);
+  });
+
+  it('skips tool_result entries with no matching tool_use', () => {
+    const transcript: TranscriptEntry[] = [
+      {
+        type: 'tool_result',
+        timestamp: '2024-01-01T00:00:00Z',
+        content: { tool_use_id: 'unknown_id', content: 'some output' },
+      },
+    ];
+
+    expect(axisTranscriptToToolCalls(transcript)).toEqual([]);
+  });
+
+  it('skips tool_use entries missing id or name', () => {
+    const transcript: TranscriptEntry[] = [
+      {
+        type: 'tool_use',
+        timestamp: '2024-01-01T00:00:00Z',
+        content: { name: 'read_file', input: {} }, // missing id
+      },
+      {
+        type: 'tool_result',
+        timestamp: '2024-01-01T00:00:01Z',
+        content: { tool_use_id: undefined, content: 'result' },
+      },
+    ];
+
+    expect(axisTranscriptToToolCalls(transcript)).toEqual([]);
+  });
+
+  it('serialises non-string tool result content to JSON', () => {
+    const transcript: TranscriptEntry[] = [
+      {
+        type: 'tool_use',
+        timestamp: '2024-01-01T00:00:00Z',
+        content: { id: 'call_3', name: 'list_files', input: {} },
+      },
+      {
+        type: 'tool_result',
+        timestamp: '2024-01-01T00:00:01Z',
+        content: { tool_use_id: 'call_3', content: ['a.ts', 'b.ts'] },
+      },
+    ];
+
+    expect(axisTranscriptToToolCalls(transcript)[0].result).toBe('["a.ts","b.ts"]');
+  });
+
+  it('produces empty string result when content is absent', () => {
+    const transcript: TranscriptEntry[] = [
+      {
+        type: 'tool_use',
+        timestamp: '2024-01-01T00:00:00Z',
+        content: { id: 'call_4', name: 'think', input: {} },
+      },
+      {
+        type: 'tool_result',
+        timestamp: '2024-01-01T00:00:01Z',
+        content: { tool_use_id: 'call_4' }, // no content field
+      },
+    ];
+
+    expect(axisTranscriptToToolCalls(transcript)[0].result).toBe('');
+  });
+
+  it('handles multiple tool calls preserving result order', () => {
+    const transcript: TranscriptEntry[] = [
+      {
+        type: 'tool_use',
+        timestamp: '2024-01-01T00:00:00Z',
+        content: { id: 'a', name: 'tool_a', input: { x: 1 } },
+      },
+      {
+        type: 'tool_use',
+        timestamp: '2024-01-01T00:00:01Z',
+        content: { id: 'b', name: 'tool_b', input: { x: 2 } },
+      },
+      {
+        type: 'tool_result',
+        timestamp: '2024-01-01T00:00:02Z',
+        content: { tool_use_id: 'a', content: 'result_a' },
+      },
+      {
+        type: 'tool_result',
+        timestamp: '2024-01-01T00:00:03Z',
+        content: { tool_use_id: 'b', content: 'result_b' },
+      },
+    ];
+
+    const results = axisTranscriptToToolCalls(transcript);
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({ name: 'tool_a', result: 'result_a' });
+    expect(results[1]).toMatchObject({ name: 'tool_b', result: 'result_b' });
+  });
+});

--- a/packages/evals-axis/tests/grader-hook.test.ts
+++ b/packages/evals-axis/tests/grader-hook.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { RunResult } from '@netlify/axis';
+
+// vi.mock factories are hoisted to the top of the file, so constants they
+// reference must be declared with vi.hoisted() to be available at that point.
+const { AGENT_LEVELS_FIXTURE, MOCK_TOOL_CALL } = vi.hoisted(() => ({
+  // Complete AGENT_LEVELS set including L5 (version_correctness).
+  AGENT_LEVELS_FIXTURE: new Set([
+    'positive_presence',
+    'hallucination',
+    'security',
+    'structural',
+    'version_correctness',
+  ]),
+  MOCK_TOOL_CALL: { id: 'tc1', name: 'write_file', input: { path: 'src/App.jsx' } },
+}));
+
+vi.mock('@a0/evals-core', () => ({
+  discoverEvals: vi.fn(),
+  loadEval: vi.fn(),
+  runGraders: vi.fn(),
+  runCompileCommand: vi.fn(),
+  runSetupCommand: vi.fn(),
+  AGENT_LEVELS: AGENT_LEVELS_FIXTURE,
+}));
+
+vi.mock('../src/adapter.js', () => ({
+  axisTranscriptToToolCalls: vi.fn(() => [MOCK_TOOL_CALL]),
+}));
+
+import { runAuth0Graders } from '../src/grader-hook.js';
+import { discoverEvals, loadEval, runGraders, runCompileCommand, runSetupCommand } from '@a0/evals-core';
+import { axisTranscriptToToolCalls } from '../src/adapter.js';
+import type { EvalDefinition } from '@a0/evals-core';
+
+const mockAxisTranscriptToToolCalls = vi.mocked(axisTranscriptToToolCalls);
+
+const mockDiscoverEvals = vi.mocked(discoverEvals);
+const mockLoadEval = vi.mocked(loadEval);
+const mockRunGraders = vi.mocked(runGraders);
+const mockRunCompileCommand = vi.mocked(runCompileCommand);
+const mockRunSetupCommand = vi.mocked(runSetupCommand);
+
+function makeResult(overrides: Partial<RunResult> = {}): RunResult {
+  return {
+    scenarioKey: 'react_quickstart',
+    scenarioName: 'React Quickstart',
+    agentName: 'claude-code',
+    prompt: 'Add Auth0 login to a React app',
+    judge: 'Did the agent succeed?',
+    agentConfig: { agent: 'claude-code' },
+    output: {
+      transcript: [],
+      result: null,
+      metadata: { startTime: '', endTime: '', durationMs: 0, exitCode: 0 },
+    },
+    workingDirectory: '/tmp/workspace',
+    ...overrides,
+  };
+}
+
+const BASE_OPTIONS = {
+  frameworkRoot: '/mock/auth0-evals',
+  apiKey: 'test-api-key',
+};
+
+describe('runAuth0Graders', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDiscoverEvals.mockReturnValue([
+      {
+        id: 'react_quickstart',
+        name: 'React Quickstart',
+        category: 'quickstarts',
+        path: 'src/evals/quickstarts/react',
+      },
+    ]);
+    mockLoadEval.mockResolvedValue({
+      id: 'react_quickstart',
+      name: 'React Quickstart',
+      graders: [],
+      compileCommand: undefined,
+      setupCommand: undefined,
+    } as unknown as EvalDefinition);
+    mockRunGraders.mockResolvedValue([]);
+  });
+
+  it('throws when workingDirectory is missing', async () => {
+    const result = makeResult({ workingDirectory: undefined });
+    await expect(runAuth0Graders(result, BASE_OPTIONS)).rejects.toThrow('workingDirectory missing');
+  });
+
+  it('throws when no eval matches the scenarioKey', async () => {
+    mockDiscoverEvals.mockReturnValue([]);
+    await expect(runAuth0Graders(makeResult(), BASE_OPTIONS)).rejects.toThrow('No eval found');
+  });
+
+  it('calls discoverEvals with correct evalsDir and frameworkRoot', async () => {
+    await runAuth0Graders(makeResult(), BASE_OPTIONS);
+    expect(mockDiscoverEvals).toHaveBeenCalledWith('src/evals', '/mock/auth0-evals');
+  });
+
+  it('uses custom evalsDir when provided', async () => {
+    await runAuth0Graders(makeResult(), { ...BASE_OPTIONS, evalsDir: 'custom/evals' });
+    expect(mockDiscoverEvals).toHaveBeenCalledWith('custom/evals', '/mock/auth0-evals');
+  });
+
+  it('calls runGraders with workspace, apiKey, and tool calls', async () => {
+    const transcript = [{ type: 'assistant' as const, timestamp: '', content: {} }];
+    const graderResult = { name: 'auth0 provider present', kind: 'contains', passed: true, detail: '' };
+    mockRunGraders.mockResolvedValue([graderResult]);
+
+    const result = makeResult({
+      output: { transcript, result: null, metadata: { startTime: '', endTime: '', durationMs: 0, exitCode: 0 } },
+    });
+    const results = await runAuth0Graders(result, BASE_OPTIONS);
+
+    // Adapter receives the transcript and returns the mock tool call.
+    expect(mockAxisTranscriptToToolCalls).toHaveBeenCalledWith(transcript);
+
+    expect(mockRunGraders).toHaveBeenCalledWith(
+      [],
+      '/tmp/workspace',
+      'test-api-key',
+      undefined,
+      AGENT_LEVELS_FIXTURE,
+      true,
+      [MOCK_TOOL_CALL],
+      undefined,
+    );
+    expect(results).toEqual([graderResult]);
+  });
+
+  it('passes judgeModel when provided', async () => {
+    await runAuth0Graders(makeResult(), { ...BASE_OPTIONS, judgeModel: 'claude-opus-5' });
+    expect(mockRunGraders).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'test-api-key',
+      'claude-opus-5',
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      undefined,
+    );
+  });
+
+  it('runs compile command when eval declares one', async () => {
+    mockLoadEval.mockResolvedValue({
+      id: 'react_quickstart',
+      name: 'React Quickstart',
+      graders: [],
+      compileCommand: 'tsc --noEmit',
+      setupCommand: undefined,
+    } as unknown as EvalDefinition);
+    mockRunCompileCommand.mockReturnValue({
+      ok: true,
+      exitCode: 0,
+      signal: null,
+      output: '',
+      command: 'tsc --noEmit',
+    });
+
+    await runAuth0Graders(makeResult(), BASE_OPTIONS);
+
+    expect(mockRunCompileCommand).toHaveBeenCalledWith('/tmp/workspace', 'tsc --noEmit', {
+      setupCommand: undefined,
+    });
+  });
+
+  it('skips compile command when eval has none', async () => {
+    await runAuth0Graders(makeResult(), BASE_OPTIONS);
+    expect(mockRunCompileCommand).not.toHaveBeenCalled();
+  });
+
+  it('runs setupCommand alone when eval has setup but no compile command', async () => {
+    mockLoadEval.mockResolvedValue({
+      id: 'react_quickstart',
+      name: 'React Quickstart',
+      graders: [],
+      compileCommand: undefined,
+      setupCommand: 'npm install',
+    } as unknown as EvalDefinition);
+
+    await runAuth0Graders(makeResult(), BASE_OPTIONS);
+
+    expect(mockRunSetupCommand).toHaveBeenCalledWith('/tmp/workspace', 'npm install');
+    expect(mockRunCompileCommand).not.toHaveBeenCalled();
+  });
+
+  it('skips setupCommand when eval has neither compile nor setup command', async () => {
+    await runAuth0Graders(makeResult(), BASE_OPTIONS);
+
+    expect(mockRunSetupCommand).not.toHaveBeenCalled();
+    expect(mockRunCompileCommand).not.toHaveBeenCalled();
+  });
+
+  it('passes compile result into runGraders', async () => {
+    const compileResult = { ok: false, exitCode: 1, signal: null, output: 'error', command: 'tsc' };
+    mockLoadEval.mockResolvedValue({
+      id: 'react_quickstart',
+      name: 'React Quickstart',
+      graders: [],
+      compileCommand: 'tsc',
+      setupCommand: undefined,
+    } as unknown as EvalDefinition);
+    mockRunCompileCommand.mockReturnValue(compileResult);
+
+    await runAuth0Graders(makeResult(), BASE_OPTIONS);
+
+    expect(mockRunGraders).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      undefined,
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      compileResult,
+    );
+  });
+});

--- a/packages/evals-axis/tests/report.test.ts
+++ b/packages/evals-axis/tests/report.test.ts
@@ -1,0 +1,401 @@
+import { describe, it, expect } from 'vitest';
+import { buildAxisScores, countInterruptions, scoreToGrade } from '../src/report.js';
+import type { ScoredOutput } from '@netlify/axis';
+import type { GraderResult } from '@a0/evals-graders';
+
+// Minimal ScoredOutput fixture for a single result.
+function makeScoredOutput(overrides: {
+  scenarioKey?: string;
+  agentName?: string;
+  exitCode?: number;
+  axisScore?: number;
+  totalCostUsd?: number;
+  tokenUsage?: { input: number; output: number; cacheReadInput?: number };
+}): ScoredOutput {
+  const {
+    scenarioKey = 'react_quickstart',
+    agentName = 'claude-code|global.anthropic.claude-opus-4-8',
+    exitCode = 0,
+    axisScore = 80,
+    totalCostUsd,
+    tokenUsage,
+  } = overrides;
+
+  return {
+    version: '1',
+    timestamp: '2026-01-01T00:00:00Z',
+    durationMs: 1000,
+    summary: { total: 1, completed: 1, failed: 0 },
+    results: [
+      {
+        scenarioKey,
+        scenarioName: scenarioKey,
+        agentName,
+        prompt: 'Test prompt',
+        judge: 'Did it work?',
+        agentConfig: {} as never,
+        output: {
+          transcript: [],
+          result: 'Done.',
+          metadata: {
+            startTime: '2026-01-01T00:00:00Z',
+            endTime: '2026-01-01T00:00:01Z',
+            durationMs: 1000,
+            exitCode,
+            ...(totalCostUsd !== undefined ? { totalCostUsd } : {}),
+            ...(tokenUsage !== undefined ? { tokenUsage } : {}),
+          },
+        },
+        score: {
+          axisScore,
+          goalAchievement: { score: axisScore },
+          environment: { score: 90 },
+          service: { score: 100 },
+          agent: { score: 85 },
+          weights: {} as never,
+        },
+      },
+    ],
+  } as unknown as ScoredOutput;
+}
+
+// ---------------------------------------------------------------------------
+// scoreToGrade
+// ---------------------------------------------------------------------------
+
+describe('scoreToGrade', () => {
+  it('returns A for scores >= 90', () => {
+    expect(scoreToGrade(90)).toBe('A');
+    expect(scoreToGrade(100)).toBe('A');
+  });
+
+  it('returns B for scores >= 75 and < 90', () => {
+    expect(scoreToGrade(75)).toBe('B');
+    expect(scoreToGrade(89)).toBe('B');
+  });
+
+  it('returns C for scores >= 60 and < 75', () => {
+    expect(scoreToGrade(60)).toBe('C');
+    expect(scoreToGrade(74)).toBe('C');
+  });
+
+  it('returns D for scores >= 40 and < 60', () => {
+    expect(scoreToGrade(40)).toBe('D');
+    expect(scoreToGrade(59)).toBe('D');
+  });
+
+  it('returns F for scores below 40', () => {
+    expect(scoreToGrade(39)).toBe('F');
+    expect(scoreToGrade(0)).toBe('F');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// countInterruptions
+// ---------------------------------------------------------------------------
+
+describe('countInterruptions', () => {
+  it('returns 0 for an empty transcript', () => {
+    expect(countInterruptions([])).toBe(0);
+  });
+
+  it('returns 0 when no interruption tools are called', () => {
+    const transcript = [
+      { type: 'tool_use', timestamp: '', content: { name: 'write_file', id: 't1', input: {} } },
+      { type: 'tool_result', timestamp: '', content: { tool_use_id: 't1', content: 'ok' } },
+    ] as never;
+    expect(countInterruptions(transcript)).toBe(0);
+  });
+
+  it('counts AskUserQuestion in standard tool_use entries (claude-code runner)', () => {
+    const transcript = [
+      { type: 'tool_use', timestamp: '', content: { name: 'AskUserQuestion', id: 't1', input: {} } },
+      { type: 'tool_use', timestamp: '', content: { name: 'AskUserQuestion', id: 't2', input: {} } },
+      { type: 'tool_use', timestamp: '', content: { name: 'write_file', id: 't3', input: {} } },
+    ] as never;
+    expect(countInterruptions(transcript)).toBe(2);
+  });
+
+  it('counts ask_user in standard tool_use entries (copilot runner)', () => {
+    const transcript = [
+      { type: 'tool_use', timestamp: '', content: { name: 'ask_user', id: 't1', input: {} } },
+    ] as never;
+    expect(countInterruptions(transcript)).toBe(1);
+  });
+
+  it('counts AskUserQuestion nested inside assistant entries (claude-code AXIS adapter)', () => {
+    const transcript = [
+      {
+        type: 'assistant',
+        timestamp: '',
+        content: {
+          message: {
+            content: [
+              { type: 'tool_use', name: 'write_file' },
+              { type: 'tool_use', name: 'AskUserQuestion' },
+            ],
+          },
+        },
+      },
+    ] as never;
+    expect(countInterruptions(transcript)).toBe(1);
+  });
+
+  it('handles mixed standard and assistant-nested formats', () => {
+    const transcript = [
+      { type: 'tool_use', timestamp: '', content: { name: 'AskUserQuestion', id: 't1', input: {} } },
+      {
+        type: 'assistant',
+        timestamp: '',
+        content: {
+          message: { content: [{ type: 'tool_use', name: 'AskUserQuestion' }] },
+        },
+      },
+    ] as never;
+    expect(countInterruptions(transcript)).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildAxisScores
+// ---------------------------------------------------------------------------
+
+describe('buildAxisScores', () => {
+  it('maps a result with graders to AgentJobResult', () => {
+    const graders: GraderResult[] = [
+      { name: 'Uses SDK', kind: 'contains', passed: true, detail: 'found' },
+      { name: 'No secrets', kind: 'not_contains', passed: false, detail: 'found secret' },
+    ];
+    const output = makeScoredOutput({ axisScore: 80 });
+    const map = new Map([['react_quickstart|claude-code|global.anthropic.claude-opus-4-8', graders]]);
+
+    const [result] = buildAxisScores(output, map);
+
+    expect(result.eval_id).toBe('react_quickstart');
+    expect(result.overall_score).toBe(80);
+    expect(result.overall_grade).toBe('B');
+    expect(result.grader_pass_rate).toBe(0.5);
+    expect(result.graders).toHaveLength(2);
+    expect(result.tools).toEqual(['axis']);
+    expect(result.mode).toBe('agent');
+  });
+
+  it('produces grader_pass_rate of 0 when no graders are in the map', () => {
+    const output = makeScoredOutput({});
+    const [result] = buildAxisScores(output, new Map());
+
+    expect(result.grader_pass_rate).toBe(0);
+    expect(result.graders).toHaveLength(0);
+  });
+
+  it('extracts model and agent_type from agentName', () => {
+    const output = makeScoredOutput({ agentName: 'codex|gpt-5-codex' });
+    const [result] = buildAxisScores(output, new Map());
+
+    expect(result.model).toBe('gpt-5-codex');
+    expect(result.agent_type).toBe('codex');
+  });
+
+  it('maps gemini AXIS agent name to gemini-cli agent_type', () => {
+    const output = makeScoredOutput({ agentName: 'gemini|gemini-3.1-pro-preview' });
+    const [result] = buildAxisScores(output, new Map());
+
+    expect(result.agent_type).toBe('gemini-cli');
+    expect(result.model).toBe('gemini-3.1-pro-preview');
+  });
+
+  it('falls back to claude-code for an unrecognised agent type', () => {
+    const output = makeScoredOutput({ agentName: 'unknown-runner|some-model' });
+    const [result] = buildAxisScores(output, new Map());
+
+    expect(result.agent_type).toBe('claude-code');
+    expect(result.model).toBe('some-model');
+  });
+
+  it('uses agentName as model when there is no pipe separator', () => {
+    const output = makeScoredOutput({ agentName: 'claude-code' });
+    const [result] = buildAxisScores(output, new Map());
+
+    expect(result.model).toBe('claude-code');
+  });
+
+  it('sets status to failure when exitCode is non-zero', () => {
+    const output = makeScoredOutput({ exitCode: 1 });
+    const [result] = buildAxisScores(output, new Map());
+
+    expect(result.status).toBe('failure');
+  });
+
+  it('populates tokens from tokenUsage when available', () => {
+    const output = makeScoredOutput({
+      tokenUsage: { input: 1000, output: 500, cacheReadInput: 200 },
+    });
+    const [result] = buildAxisScores(output, new Map());
+
+    expect(result.tokens).toBe(1700);
+  });
+
+  it('sets tokens to 0 when tokenUsage is absent', () => {
+    const output = makeScoredOutput({});
+    const [result] = buildAxisScores(output, new Map());
+
+    expect(result.tokens).toBe(0);
+  });
+
+  it('maps totalCostUsd to cost_usd and total_cost_usd, leaving judge_cost_usd as 0 when no judge graders ran', () => {
+    const output = makeScoredOutput({ totalCostUsd: 0.05 });
+    const [result] = buildAxisScores(output, new Map());
+
+    expect(result.cost_usd).toBe(0.05);
+    expect(result.total_cost_usd).toBe(0.05);
+    expect(result.judge_cost_usd).toBe(0);
+  });
+
+  it('computes judge_cost_usd from grader token usage and adds it to total_cost_usd', () => {
+    // claude-opus-5: $5/M input, $25/M output
+    // 1000 input + 200 output = (1000×5 + 200×25) / 1_000_000 = 0.01
+    const graders: GraderResult[] = [
+      {
+        name: 'Holistic judge',
+        kind: 'judge',
+        passed: true,
+        detail: 'yes',
+        inputTokens: 1000,
+        outputTokens: 200,
+        judgeModel: 'claude-opus-5',
+      },
+    ];
+    const output = makeScoredOutput({ totalCostUsd: 0.05 });
+    const map = new Map([['react_quickstart|claude-code|global.anthropic.claude-opus-4-8', graders]]);
+    const [result] = buildAxisScores(output, map);
+
+    expect(result.cost_usd).toBe(0.05);
+    expect(result.judge_cost_usd).toBeCloseTo(0.01, 6);
+    expect(result.total_cost_usd).toBeCloseTo(0.06, 6);
+  });
+
+  it('sets judge_cost_usd to 0 when graders have no token usage', () => {
+    const graders: GraderResult[] = [{ name: 'Uses SDK', kind: 'contains', passed: true, detail: 'found' }];
+    const output = makeScoredOutput({ totalCostUsd: 0.02 });
+    const map = new Map([['react_quickstart|claude-code|global.anthropic.claude-opus-4-8', graders]]);
+    const [result] = buildAxisScores(output, map);
+
+    expect(result.judge_cost_usd).toBe(0);
+    expect(result.total_cost_usd).toBe(0.02);
+  });
+
+  it('produces 4 AXIS dimensions with correct weights', () => {
+    const output = makeScoredOutput({ axisScore: 90 });
+    const [result] = buildAxisScores(output, new Map());
+
+    expect(result.dimensions).toHaveLength(4);
+    const weights = result.dimensions.map((d) => d.weight);
+    expect(weights).toEqual([0.4, 0.2, 0.2, 0.2]);
+  });
+
+  it('counts only tool_use transcript entries for tool_calls', () => {
+    const output = makeScoredOutput({});
+    // Inject a transcript with one tool_use and one text entry directly.
+    output.results[0].output.transcript = [
+      { type: 'tool_use', id: 'tc1', name: 'write_file', input: {} },
+      { type: 'text', text: 'Done.' },
+    ] as never;
+    const [result] = buildAxisScores(output, new Map());
+
+    expect(result.tool_calls).toBe(1);
+  });
+
+  it('uses transcriptAnalysis.toolUseCount for tool_calls when available (claude-code adapter)', () => {
+    // The claude-code adapter embeds tool calls inside assistant entries — the raw
+    // transcript never has type==='tool_use'. transcriptAnalysis.toolUseCount is
+    // populated by AXIS scoring after re-classifying those entries, so it reflects
+    // the real call count even when the raw transcript count is 0.
+    const output = makeScoredOutput({});
+    output.results[0].output.transcript = [
+      { type: 'assistant', content: { message: { content: [{ type: 'tool_use', name: 'write_file' }] } } },
+    ] as never;
+    output.results[0].output.transcriptAnalysis = { toolUseCount: 5 } as never;
+    const [result] = buildAxisScores(output, new Map());
+
+    expect(result.tool_calls).toBe(5);
+  });
+
+  it('uses category from the categories map when provided', () => {
+    const output = makeScoredOutput({ scenarioKey: 'react_quickstart' });
+    const [result] = buildAxisScores(output, new Map(), { react_quickstart: 'quickstarts' });
+
+    expect(result.category).toBe('quickstarts');
+  });
+
+  it('falls back to empty string when scenarioKey is not in the categories map', () => {
+    const output = makeScoredOutput({ scenarioKey: 'react_quickstart' });
+    const [result] = buildAxisScores(output, new Map(), {});
+
+    expect(result.category).toBe('');
+  });
+
+  it('falls back to empty string when categories map is omitted', () => {
+    const output = makeScoredOutput({ scenarioKey: 'react_quickstart' });
+    const [result] = buildAxisScores(output, new Map());
+
+    expect(result.category).toBe('');
+  });
+
+  it('computes active_time from sparseIndex.stats.totalDurationMs', () => {
+    const output = makeScoredOutput({});
+    output.results[0].score.sparseIndex = { stats: { totalDurationMs: 11840 } } as never;
+    const [result] = buildAxisScores(output, new Map());
+
+    expect(result.active_time).toBe(11.84);
+  });
+
+  it('sets active_time to 0 when sparseIndex is absent', () => {
+    const output = makeScoredOutput({});
+    const [result] = buildAxisScores(output, new Map());
+
+    expect(result.active_time).toBe(0);
+  });
+
+  it('counts AskUserQuestion tool_use entries as interruptions', () => {
+    const output = makeScoredOutput({});
+    output.results[0].output.transcript = [
+      { type: 'tool_use', timestamp: '', content: { name: 'AskUserQuestion', id: 't1', input: {} } },
+      { type: 'tool_use', timestamp: '', content: { name: 'write_file', id: 't2', input: {} } },
+    ] as never;
+    const [result] = buildAxisScores(output, new Map());
+
+    expect(result.interruptions).toBe(1);
+  });
+
+  it('sets cost_usd on GraderSummary for judge graders with token usage', () => {
+    // claude-opus-5: $5/M input, $25/M output → (1000×5 + 200×25) / 1_000_000 = 0.01
+    const graders: GraderResult[] = [
+      {
+        name: 'Holistic judge',
+        kind: 'judge',
+        passed: true,
+        detail: 'yes',
+        inputTokens: 1000,
+        outputTokens: 200,
+        judgeModel: 'claude-opus-5',
+      },
+      { name: 'Uses SDK', kind: 'contains', passed: true, detail: 'found' },
+    ];
+    const output = makeScoredOutput({});
+    const map = new Map([['react_quickstart|claude-code|global.anthropic.claude-opus-4-8', graders]]);
+    const [result] = buildAxisScores(output, map);
+
+    expect(result.graders[0].cost_usd).toBeCloseTo(0.01, 6);
+    expect(result.graders[1].cost_usd).toBeUndefined();
+  });
+
+  it('sets interruptions to 0 when no interruption tools appear in the transcript', () => {
+    const output = makeScoredOutput({});
+    output.results[0].output.transcript = [
+      { type: 'tool_use', timestamp: '', content: { name: 'write_file', id: 't1', input: {} } },
+    ] as never;
+    const [result] = buildAxisScores(output, new Map());
+
+    expect(result.interruptions).toBe(0);
+  });
+});

--- a/packages/evals-axis/tests/run.test.ts
+++ b/packages/evals-axis/tests/run.test.ts
@@ -4,6 +4,7 @@ import type { RunResult, ScoredOutput } from '@netlify/axis';
 vi.mock('@netlify/axis', () => ({
   run: vi.fn(),
   scoreResults: vi.fn(),
+  loadConfig: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('../src/grader-hook.js', () => ({

--- a/packages/evals-axis/tests/run.test.ts
+++ b/packages/evals-axis/tests/run.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { RunResult, ScoredOutput } from '@netlify/axis';
+
+vi.mock('@netlify/axis', () => ({
+  run: vi.fn(),
+  scoreResults: vi.fn(),
+}));
+
+vi.mock('../src/grader-hook.js', () => ({
+  runAuth0Graders: vi.fn(),
+}));
+
+import { runAxis } from '../src/run.js';
+import { run, scoreResults } from '@netlify/axis';
+import { runAuth0Graders } from '../src/grader-hook.js';
+
+const mockRun = vi.mocked(run);
+const mockScoreResults = vi.mocked(scoreResults);
+const mockRunAuth0Graders = vi.mocked(runAuth0Graders);
+
+function makeRunResult(overrides: Partial<RunResult> = {}): RunResult {
+  return {
+    scenarioKey: 'react_quickstart',
+    scenarioName: 'React Quickstart',
+    agentName: 'claude-code|global.anthropic.claude-opus-4-8',
+    prompt: 'Add Auth0 login to my React app.',
+    judge: 'Did it work?',
+    agentConfig: { agent: 'claude-code' },
+    output: {
+      transcript: [],
+      result: 'Done.',
+      metadata: { startTime: '', endTime: '', durationMs: 1000, exitCode: 0 },
+    },
+    ...overrides,
+  };
+}
+
+function makeScoredOutput(result: RunResult): ScoredOutput {
+  return {
+    version: '1',
+    timestamp: '2026-01-01T00:00:00Z',
+    durationMs: 1000,
+    summary: { total: 1, completed: 1, failed: 0 },
+    results: [
+      {
+        ...result,
+        score: {
+          axisScore: 80,
+          goalAchievement: { score: 80 },
+          environment: { score: 90 },
+          service: { score: 100 },
+          agent: { score: 85 },
+          weights: {} as never,
+        },
+      },
+    ],
+  } as unknown as ScoredOutput;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('runAxis', () => {
+  it('collects grader results under scenarioKey|agentName key', async () => {
+    const result = makeRunResult();
+    const graders = [{ name: 'Uses SDK', kind: 'contains', passed: true, detail: 'found' }];
+
+    // Simulate AXIS calling onResult for each job.
+    mockRun.mockImplementation(async (opts) => {
+      await opts.onResult?.(result);
+      return {
+        version: '1',
+        timestamp: '2026-01-01T00:00:00Z',
+        durationMs: 1000,
+        summary: { total: 1, completed: 1, failed: 0 },
+        results: [result],
+      };
+    });
+    mockRunAuth0Graders.mockResolvedValue(graders);
+    mockScoreResults.mockResolvedValue(makeScoredOutput(result));
+
+    const { graderResults } = await runAxis({ frameworkRoot: '/tmp', apiKey: 'key' });
+
+    expect(graderResults.get('react_quickstart|claude-code|global.anthropic.claude-opus-4-8')).toEqual(graders);
+  });
+
+  it('returns scoredOutput from scoreResults', async () => {
+    const result = makeRunResult();
+    const scored = makeScoredOutput(result);
+
+    mockRun.mockImplementation(async (opts) => {
+      await opts.onResult?.(result);
+      return {
+        version: '1',
+        timestamp: '2026-01-01T00:00:00Z',
+        durationMs: 1000,
+        summary: { total: 1, completed: 1, failed: 0 },
+        results: [result],
+      };
+    });
+    mockRunAuth0Graders.mockResolvedValue([]);
+    mockScoreResults.mockResolvedValue(scored);
+
+    const { scoredOutput } = await runAxis({ frameworkRoot: '/tmp', apiKey: 'key' });
+
+    expect(scoredOutput).toBe(scored);
+  });
+
+  it('stores a grading-error entry when runAuth0Graders rejects', async () => {
+    const result = makeRunResult();
+    const onGraderResults = vi.fn();
+
+    mockRun.mockImplementation(async (opts) => {
+      await opts.onResult?.(result);
+      return {
+        version: '1',
+        timestamp: '2026-01-01T00:00:00Z',
+        durationMs: 1000,
+        summary: { total: 1, completed: 1, failed: 0 },
+        results: [result],
+      };
+    });
+    mockRunAuth0Graders.mockRejectedValue(new Error('workspace not found'));
+    mockScoreResults.mockResolvedValue(makeScoredOutput(result));
+
+    const { graderResults, scoredOutput } = await runAxis({
+      frameworkRoot: '/tmp',
+      apiKey: 'key',
+      onGraderResults,
+    });
+
+    const key = 'react_quickstart|claude-code|global.anthropic.claude-opus-4-8';
+    const stored = graderResults.get(key);
+    expect(stored).toHaveLength(1);
+    expect(stored?.[0].passed).toBe(false);
+    expect(stored?.[0].name).toBe('grading-error');
+    expect(stored?.[0].detail).toContain('workspace not found');
+
+    // onGraderResults is called with the error entry so callers can surface it.
+    expect(onGraderResults).toHaveBeenCalledWith(
+      'react_quickstart',
+      'claude-code|global.anthropic.claude-opus-4-8',
+      stored,
+    );
+
+    // Scoring still completes despite the grading failure.
+    expect(scoredOutput.summary.completed).toBe(1);
+  });
+
+  it('calls onGraderResults callback with scenarioKey, agentName, and results', async () => {
+    const result = makeRunResult();
+    const graders = [{ name: 'Uses SDK', kind: 'contains', passed: true, detail: 'found' }];
+    const onGraderResults = vi.fn();
+
+    mockRun.mockImplementation(async (opts) => {
+      await opts.onResult?.(result);
+      return {
+        version: '1',
+        timestamp: '',
+        durationMs: 0,
+        summary: { total: 1, completed: 1, failed: 0 },
+        results: [result],
+      };
+    });
+    mockRunAuth0Graders.mockResolvedValue(graders);
+    mockScoreResults.mockResolvedValue(makeScoredOutput(result));
+
+    await runAxis({ frameworkRoot: '/tmp', apiKey: 'key', onGraderResults });
+
+    expect(onGraderResults).toHaveBeenCalledWith(
+      'react_quickstart',
+      'claude-code|global.anthropic.claude-opus-4-8',
+      graders,
+    );
+  });
+
+  it('calls onAxisScore callback with scenarioKey, agentName, and score', async () => {
+    const result = makeRunResult();
+    const scored = makeScoredOutput(result);
+    const onAxisScore = vi.fn();
+
+    mockRun.mockImplementation(async () => ({
+      version: '1',
+      timestamp: '',
+      durationMs: 0,
+      summary: { total: 1, completed: 1, failed: 0 },
+      results: [result],
+    }));
+    mockRunAuth0Graders.mockResolvedValue([]);
+    mockScoreResults.mockResolvedValue(scored);
+
+    await runAxis({ frameworkRoot: '/tmp', apiKey: 'key', onAxisScore });
+
+    expect(onAxisScore).toHaveBeenCalledWith(
+      'react_quickstart',
+      'claude-code|global.anthropic.claude-opus-4-8',
+      scored.results[0].score,
+    );
+  });
+
+  it('forwards debug:true to run() when set', async () => {
+    const result = makeRunResult();
+
+    mockRun.mockImplementation(async () => ({
+      version: '1',
+      timestamp: '2026-01-01T00:00:00Z',
+      durationMs: 1000,
+      summary: { total: 1, completed: 1, failed: 0 },
+      results: [result],
+    }));
+    mockRunAuth0Graders.mockResolvedValue([]);
+    mockScoreResults.mockResolvedValue(makeScoredOutput(result));
+
+    await runAxis({ frameworkRoot: '/tmp', apiKey: 'key', debug: true });
+
+    expect(mockRun.mock.calls[0][0]).toMatchObject({ debug: true });
+  });
+
+  it('strips workingDirectory before passing results to scoreResults', async () => {
+    const result = makeRunResult({ workingDirectory: '/tmp/workspace' });
+
+    mockRun.mockImplementation(async () => ({
+      version: '1',
+      timestamp: '2026-01-01T00:00:00Z',
+      durationMs: 1000,
+      summary: { total: 1, completed: 1, failed: 0 },
+      results: [result],
+    }));
+    mockRunAuth0Graders.mockResolvedValue([]);
+    mockScoreResults.mockResolvedValue(makeScoredOutput(result));
+
+    await runAxis({ frameworkRoot: '/tmp', apiKey: 'key' });
+
+    const passedToScorer = mockScoreResults.mock.calls[0][0];
+    expect(passedToScorer.results[0].workingDirectory).toBeUndefined();
+  });
+});

--- a/packages/evals-axis/tsconfig.json
+++ b/packages/evals-axis/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declarationDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/evals-axis/vitest.config.ts
+++ b/packages/evals-axis/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary

- Adds the new `@a0/evals-axis` bridge package that connects AXIS multi-agent orchestration to the existing auth0-evals grader engine
- Exports `runAxis()` and `buildAxisScores()` which are consumed by the app integration (follow-up PR)
- Full test coverage across adapter, grader-hook, report, and run modules

## What this package does

**`adapter.ts`** — Converts AXIS `TranscriptEntry[]` to `EventToolCall[]` for the grader engine. Handles both standard transcript format (Codex, Gemini) and the claude-code nested-assistant format where tool calls are embedded inside assistant entries.

**`grader-hook.ts`** — Plugs into AXIS `onJobComplete`. Discovers the matching eval config, runs compile/setup commands against the agent workspace, and executes L1-L4 graders.

**`report.ts`** — Converts AXIS `ScoredOutput` + `GraderResult[]` into `AgentJobResult[]` (same format as `scores-agent.json`). Correctly derives `tool_calls` via `transcriptAnalysis.toolUseCount`, `active_time` from `sparseIndex`, `interruptions`, `judge_cost_usd`, and per-grader `cost_usd`.

**`run.ts`** — Orchestrates the full AXIS run: starts the run, registers the grader hook, collects results, scores via the judge, and returns structured output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AXIS evaluation support, including agent execution, scoring, grading, and result reporting.
  * Added transcript conversion for tool calls, with support for errors and structured results.
  * Added score summaries with letter grades, dimensions, costs, tokens, timing, interruptions, and tool-call metrics.
  * Added configurable grader execution, callbacks, debugging, paths, and judge model options.

* **Tests**
  * Added comprehensive automated coverage for transcript conversion, grading, execution, scoring, and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->