### PR TITLE
feat(cli): accept comma-separated values for --eval and --model flags

### DIFF
--- a/packages/evals/src/cli/config.ts
+++ b/packages/evals/src/cli/config.ts
@@ -110,11 +110,28 @@ export function parseRunConfig(argv: string[], options: ParseRunConfigOptions = 
   const program = new Command();
   program
     .description('Eval Runner')
-    .option('--eval <id>', 'Eval ID(s) to run (default: all)', (v, prev: string[]) => [...prev, v], [] as string[])
+    .option(
+      '--eval <id>',
+      'Eval ID(s) to run (default: all)',
+      (v, prev: string[]) => [
+        ...prev,
+        ...v
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean),
+      ],
+      [] as string[],
+    )
     .option(
       '--model <model>',
       `Model(s) to run (default: ${options.defaultModel && options.defaultModel.length > 0 ? options.defaultModel : DEFAULT_MODEL})`,
-      (v, prev: string[]) => [...prev, v],
+      (v, prev: string[]) => [
+        ...prev,
+        ...v
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean),
+      ],
       [] as string[],
     )
     .option('--mode <mode>', 'Execution mode: baseline | agent | all (default: baseline)')

--- a/packages/evals/tests/cli-config.test.ts
+++ b/packages/evals/tests/cli-config.test.ts
@@ -140,6 +140,16 @@ describe('--model', () => {
     expect(config.models).toEqual(['gpt-5.2', 'claude-sonnet-4-6']);
   });
 
+  it('accepts comma-separated models in a single --model flag', () => {
+    const config = parse('--model', 'gpt-5.2,claude-sonnet-4-6');
+    expect(config.models).toEqual(['gpt-5.2', 'claude-sonnet-4-6']);
+  });
+
+  it('trims whitespace from comma-separated models', () => {
+    const config = parse('--model', 'gpt-5.2, claude-sonnet-4-6');
+    expect(config.models).toEqual(['gpt-5.2', 'claude-sonnet-4-6']);
+  });
+
   it('--model all expands to every known working model', () => {
     const config = parse('--model', 'all');
     expect(config.models).toEqual(KNOWN_WORKING_MODELS);
@@ -232,6 +242,16 @@ describe('--eval', () => {
 
   it('accumulates multiple --eval flags', () => {
     const config = parse('--eval', VALID_EVAL_ID, '--eval', VALID_EVAL_ID_2);
+    expect(config.evalIds).toEqual([VALID_EVAL_ID, VALID_EVAL_ID_2]);
+  });
+
+  it('accepts comma-separated eval IDs in a single --eval flag', () => {
+    const config = parse('--eval', `${VALID_EVAL_ID},${VALID_EVAL_ID_2}`);
+    expect(config.evalIds).toEqual([VALID_EVAL_ID, VALID_EVAL_ID_2]);
+  });
+
+  it('trims whitespace from comma-separated eval IDs', () => {
+    const config = parse('--eval', `${VALID_EVAL_ID}, ${VALID_EVAL_ID_2}`);
     expect(config.evalIds).toEqual([VALID_EVAL_ID, VALID_EVAL_ID_2]);
   });
 


### PR DESCRIPTION
## Summary

- `--eval` and `--model` flags now accept comma-separated values in a single invocation
- Values are trimmed and filtered so trailing commas or extra whitespace produce no empty entries

## Before

```sh
npm run eval -- --eval react_quickstart --eval express_api
npm run eval -- --model claude-sonnet-5 --model gpt-5.6-luna
```

## After

```sh
npm run eval -- --eval react_quickstart,express_api
npm run eval -- --model claude-sonnet-5,gpt-5.6-luna
```

Repeated flag usage still works as before. Both styles can be mixed.