### PR TITLE
feat(axis): wire AXIS integration into auth0-evals app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ dist/
 scores-*.json
 results_*.jsonl
 report.html
+report-axis.html
 
 # Swift package manager
 **/.swiftpm/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -439,6 +439,15 @@ npm run evals -- --eval react_quickstart --mode agent --keep-workspace
 
 # Generate HTML report from results
 npm run report
+
+# AXIS — run all evals across all agents (claude-code, codex, gemini)
+npm run axis
+npm run axis -- --eval react_quickstart                              # single eval
+npm run axis -- --eval react_quickstart --agent claude-code          # single eval + agent
+npm run axis -- --agent claude-code --model claude-sonnet-5          # override model
+npm run axis -- --workers 4                                          # limit parallelism
+npm run axis -- --output /tmp/scores.json                            # custom output path
+npm run axis -- --eval react_quickstart --agent codex --debug        # capture raw stdout
 ```
 
 ### CLI flags
@@ -455,6 +464,19 @@ npm run report
 | `--keep-workspace`           | flag                                            | off                  | Don't delete temp workspace after run                    |
 | `--dangerously-skip-sandbox` | flag                                            | off                  | Disable Docker sandbox — run agent jobs directly on host |
 | `--braintrust`               | flag                                            | off                  | Log results to Braintrust experiment                     |
+
+### AXIS flags (`npm run axis`)
+
+| Flag | Values | Default | Notes |
+| ---- | ------ | ------- | ----- |
+| `--eval <id>` | Any registered eval ID | all evals | Repeatable |
+| `--agent <name>` | `claude-code`, `codex`, `gemini` | all agents | Repeatable |
+| `--workers <n>` | number | AXIS default | Parallel job limit |
+| `--model <model>` | Any model string | per-agent default | Override model for all configured agents |
+| `--output <path>` | file path | `scores-axis.json` in app root | Where to write the scores file |
+| `--debug` | flag | off | Capture raw adapter stdout as `.raw.ndjson` for debugging |
+
+Flags take precedence over the equivalent env vars (`AXIS_EVAL`, `AXIS_AGENT`, `AXIS_WORKERS`, `AXIS_MODEL`).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ npm run axis -- --eval react_quickstart --agent claude-code
 npm run axis -- --model claude-sonnet-5
 ```
 
-Results are written to `scores-axis.json` and `report-axis.html` in `apps/auth0-evals/`. Run `npm run report` to include them in the combined leaderboard.
+Results are written to `scores-axis.json` (in `apps/auth0-evals/` by default, or the path from `--output`) and `report-axis.html` in `apps/auth0-evals/`. Run `npm run report` to include them in the combined leaderboard.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ We use `auth0-evals` to measure how well AI agents integrate Auth0 across our SD
 - [`@a0/evals-core`](packages/evals-core/) - Framework core - config loader, eval discovery, grader engine, workspace lifecycle, type definitions.
 - [`@a0/evals-graders`](packages/evals-graders/) - Grader factory functions (`contains`, `notContains`, `matches`, `judge`) and the `GraderLevel` enum.
 - [`@a0/evals-reporter`](packages/evals-reporter/) - Generates HTML reports from scored results.
+- [`@a0/evals-axis`](packages/evals-axis/) - AXIS integration bridge - runs AXIS multi-agent orchestration and layers auth0-evals graders on top of every job result.
 - [`auth0-evals`](apps/auth0-evals/) - The Auth0 eval suite - task prompts, graders, scaffolds, and configuration.
 
 ## Running Evals
@@ -50,6 +51,21 @@ npm run evals -- --eval react_quickstart --mode baseline
 # Generate an HTML report
 npm run report
 ```
+
+You can also run evals using [AXIS](https://github.com/netlify/axis), Netlify's multi-agent evaluation framework. AXIS runs the same evals across claude-code, codex, and gemini in a single pass, scoring them with its own 4-dimension LLM judge (goal achievement, environment, service, agent) alongside our L1-L4 graders. AXIS runs do not require Docker.
+
+```bash
+# Run all evals across all agents
+npm run axis
+
+# Single eval, single agent
+npm run axis -- --eval react_quickstart --agent claude-code
+
+# Override model for all agents
+npm run axis -- --model claude-sonnet-5
+```
+
+Results are written to `scores-axis.json` and `report-axis.html` in `apps/auth0-evals/`. Run `npm run report` to include them in the combined leaderboard.
 
 ## How it works
 

--- a/apps/auth0-evals/.env.example
+++ b/apps/auth0-evals/.env.example
@@ -24,3 +24,9 @@ CODEX_PROXY_BASE_URL=https://your-llm-proxy.example.com
 
 # For local, when using bedrock, use:
 # CLAUDE_PROXY_BASE_URL=https://your-llm-proxy.example.com/anthropic
+
+# Optional: npm registry for AXIS runs.
+# AXIS isolates the agent HOME directory so ~/.npmrc is not available to the
+# agent process. Set this to your internal registry so npm install works inside
+# the AXIS workspace (no auth token needed if the registry allows anonymous reads).
+# NPM_CONFIG_REGISTRY=https://your-npm-registry.example.com/

--- a/apps/auth0-evals/axis.config.ts
+++ b/apps/auth0-evals/axis.config.ts
@@ -38,8 +38,8 @@ const agentValues =
 const agentFilter = agentValues.length > 0 ? new Set(agentValues) : null;
 
 // Optional: AXIS_WORKERS=4 npm run axis  (parallel job limit)
-const workersRaw = parseInt(process.env.AXIS_WORKERS ?? '', 10);
-const workers = Number.isFinite(workersRaw) ? workersRaw : undefined;
+const workersRaw = Number(process.env.AXIS_WORKERS);
+const workers = Number.isSafeInteger(workersRaw) && workersRaw > 0 ? workersRaw : undefined;
 
 // Optional: AXIS_MODEL=claude-sonnet-5 npm run axis  (override model for all agents)
 const modelOverride = process.env.AXIS_MODEL?.trim() || undefined;

--- a/apps/auth0-evals/axis.config.ts
+++ b/apps/auth0-evals/axis.config.ts
@@ -1,0 +1,165 @@
+/**
+ * AXIS configuration for Auth0 evals.
+ *
+ * Dynamically builds AXIS scenarios from the auth0-evals PROMPT.md files so
+ * the two systems stay in sync automatically — adding a new eval directory
+ * automatically adds a new AXIS scenario with no extra maintenance.
+ *
+ * Run:
+ *   npm run axis                                          # all evals, all agents
+ *   npm run axis -- --eval react_quickstart               # single eval
+ *   npm run axis -- --eval react_quickstart --agent codex # single eval + agent
+ *   npm run axis -- --workers 4                           # limit parallelism
+ *   npx axis run                                          # AXIS CLI only (no grader overlay)
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { discoverEvals } from '@a0/evals-core';
+import type { AxisConfig } from '@netlify/axis';
+
+// This file lives at apps/auth0-evals/axis.config.ts, so import.meta.url
+// resolves to the app root — the same directory as eval.config.js and src/evals/.
+const APP_ROOT = fileURLToPath(new URL('.', import.meta.url));
+
+// Optional: AXIS_EVAL=react_quickstart npm run axis  (comma-separated for multiple)
+const evalValues =
+  process.env.AXIS_EVAL?.split(',')
+    .map((s) => s.trim())
+    .filter(Boolean) ?? [];
+const evalFilter = evalValues.length > 0 ? new Set(evalValues) : null;
+
+// Optional: AXIS_AGENT=claude-code npm run axis  (comma-separated for multiple)
+const agentValues =
+  process.env.AXIS_AGENT?.split(',')
+    .map((s) => s.trim())
+    .filter(Boolean) ?? [];
+const agentFilter = agentValues.length > 0 ? new Set(agentValues) : null;
+
+// Optional: AXIS_WORKERS=4 npm run axis  (parallel job limit)
+const workersRaw = parseInt(process.env.AXIS_WORKERS ?? '', 10);
+const workers = Number.isFinite(workersRaw) ? workersRaw : undefined;
+
+// Optional: AXIS_MODEL=claude-sonnet-5 npm run axis  (override model for all agents)
+const modelOverride = process.env.AXIS_MODEL?.trim() || undefined;
+
+// Route Claude models through the Bedrock proxy when explicitly requested.
+// Set CLAUDE_CODE_USE_BEDROCK_PROXY=1 to use full `global.anthropic.*` model IDs
+// (required by the Bedrock proxy); otherwise short aliases are used.
+const useBedrock = process.env.CLAUDE_CODE_USE_BEDROCK_PROXY === '1';
+const CLAUDE_SONNET_5 = useBedrock ? 'global.anthropic.claude-sonnet-5' : 'claude-sonnet-5';
+const CLAUDE_OPUS_5 = useBedrock ? 'global.anthropic.claude-opus-5' : 'claude-opus-5';
+
+const evalConfigs = discoverEvals('src/evals', APP_ROOT).filter((cfg) => evalFilter === null || evalFilter.has(cfg.id));
+
+/** Extract a single YAML frontmatter field value from raw PROMPT.md text. */
+function fm(raw: string, field: string): string | undefined {
+  return raw.match(new RegExp(`^${field}:\\s*(.+)$`, 'm'))?.[1]?.trim();
+}
+
+const scenarios = evalConfigs.map((cfg) => {
+  const promptPath = join(APP_ROOT, cfg.path, 'PROMPT.md');
+  const raw = readFileSync(promptPath, 'utf-8');
+
+  // Extract the ## Task section — split on headings so multi-paragraph tasks
+  // and blank lines are captured correctly. The multiline $ anchor in a
+  // lookahead would stop at the first blank line, truncating the prompt.
+  const taskSection = raw.split(/^(?=## )/m).find((s) => s.startsWith('## Task'));
+  const prompt = taskSection?.replace(/^## Task[^\n]*\n/, '').trim() ?? '';
+
+  const scaffold = fm(raw, 'scaffold');
+
+  // Seed the agent workspace with the scaffold files.
+  // sourceRoot for CopyAction is configDir (= APP_ROOT), so paths like
+  // "src/evals/scaffolds/react/basic" resolve correctly.
+  // Note: setup_command (e.g. npm install) is intentionally excluded here —
+  // it's a pre-compile step run during grading, not a workspace setup step.
+  // The agent handles its own dependency installation as part of the task.
+  const setup: Array<{ action: 'copy'; match: string; destination: string }> = [];
+  if (scaffold) {
+    setup.push({ action: 'copy', match: `${scaffold}/**`, destination: '.' });
+  }
+
+  return {
+    key: cfg.id,
+    name: cfg.name,
+    prompt,
+    judge: `Did the agent correctly implement the ${cfg.name} Auth0 integration — using the right SDK packages, wiring up the provider correctly, and avoiding hallucinated or deprecated APIs? The task uses intentional test placeholders: the domain (e.g. dev-barkbook.us.auth0.com), client ID (e.g. barkbook_client_abc123xyz), and audience are all fake but structurally correct stand-ins. Treat them as valid values for evaluation purposes — do NOT penalize the agent for using them. Do NOT visit or validate any URLs from the task. Evaluate based on code structure, SDK usage, and configuration correctness alone.\n\nOUTPUT FORMAT: Your entire response must be only the JSON score object — no preamble, no reasoning, no code, no text before or after the JSON. The very first character of your response must be '{'.`,
+    ...(setup.length > 0 ? { setup } : {}),
+  };
+});
+
+// All agents supported by this config. AXIS_AGENT filters to a subset.
+// Models match eval.config.js's known list so proxy aliases resolve correctly.
+// Override the default for all agents with --model (or AXIS_MODEL env var).
+const allAgents: AxisConfig['agents'] = [
+  { agent: 'claude-code', model: CLAUDE_SONNET_5 },
+  // codex 0.140+ removed --full-auto (the AXIS default) in favour of
+  // --dangerously-bypass-approvals-and-sandbox for headless execution.
+  // Proxy config is injected via the `codex` wrapper prepended to PATH by
+  // apps/auth0-evals/src/axis/run.ts at startup.
+  {
+    agent: 'codex',
+    model: 'gpt-5.6-luna',
+    flags: { 'full-auto': false, 'dangerously-bypass-approvals-and-sandbox': true },
+  },
+  { agent: 'gemini', model: 'gemini-3.1-pro-preview' },
+];
+
+const filteredAgents =
+  agentFilter === null ? allAgents : allAgents.filter((a) => typeof a !== 'string' && agentFilter.has(a.agent));
+
+const agents = modelOverride
+  ? filteredAgents.map((a) => (typeof a === 'string' ? a : { ...a, model: modelOverride }))
+  : filteredAgents;
+
+export default {
+  scenarios,
+  agents,
+  // Use claude-code as the judge for all runs. For codex/gemini runs it's a
+  // different adapter (preferred by resolveJudgeAgent); for claude-code runs
+  // it falls back to itself — but claude-code reliably produces the JSON
+  // {"score":0-10,"rationale":"..."} the AXIS scorer expects, whereas codex
+  // (an agentic executor) does not.
+  judging: {
+    // The workspace is deleted before AXIS scoring runs (run() deletes it in
+    // finally), so the judge spawns in an empty temp dir created by callJudge().
+    // disallowedTools blocks:
+    //   - WebFetch/WebSearch: prevents visiting the placeholder domain
+    //     (dev-barkbook.us.auth0.com), which would 404 and score goal=0.
+    //   - Bash/Read/Glob/Grep: prevents the judge from trying to read the empty
+    //     workspace and concluding no files exist → score goal=0.
+    // With all filesystem and web tools blocked the judge evaluates purely from
+    // the transcript + final result text already in its prompt context.
+    agents: [
+      {
+        agent: 'claude-code',
+        model: CLAUDE_OPUS_5,
+        flags: { disallowedTools: 'Bash,Read,Glob,Grep,WebFetch,WebSearch' },
+      },
+    ],
+  },
+  // AXIS passes through the default API key vars automatically. These extra
+  // entries pass through the per-adapter proxy base URL env vars set by
+  // apps/auth0-evals/src/axis/run.ts at startup — without them AXIS strips
+  // the vars before the CLI process sees them.
+  env: [
+    'ANTHROPIC_BASE_URL',
+    'OPENAI_API_KEY',
+    'OPENAI_BASE_URL',
+    'GOOGLE_GEMINI_BASE_URL',
+    'NPM_CONFIG_REGISTRY',
+    'NPM_CONFIG_USERCONFIG',
+  ],
+  settings: {
+    ...(workers !== undefined ? { concurrency: workers } : {}),
+    limits: {
+      scenario: {
+        // 30 minutes per scenario — matches auth0-evals runner task timeout.
+        time_minutes: 30,
+        tokens: 3_000_000,
+      },
+    },
+  },
+} satisfies AxisConfig;

--- a/apps/auth0-evals/axis.config.ts
+++ b/apps/auth0-evals/axis.config.ts
@@ -144,14 +144,7 @@ export default {
   // entries pass through the per-adapter proxy base URL env vars set by
   // apps/auth0-evals/src/axis/run.ts at startup — without them AXIS strips
   // the vars before the CLI process sees them.
-  env: [
-    'ANTHROPIC_BASE_URL',
-    'OPENAI_API_KEY',
-    'OPENAI_BASE_URL',
-    'GOOGLE_GEMINI_BASE_URL',
-    'NPM_CONFIG_REGISTRY',
-    'NPM_CONFIG_USERCONFIG',
-  ],
+  env: ['ANTHROPIC_BASE_URL', 'OPENAI_API_KEY', 'OPENAI_BASE_URL', 'GOOGLE_GEMINI_BASE_URL', 'NPM_CONFIG_REGISTRY'],
   settings: {
     ...(workers !== undefined ? { concurrency: workers } : {}),
     limits: {

--- a/apps/auth0-evals/package.json
+++ b/apps/auth0-evals/package.json
@@ -8,10 +8,13 @@
     "preevals": "npm run build",
     "evals": "a0-eval",
     "prereport": "npm run build",
-    "report": "a0-eval report"
+    "report": "a0-eval report",
+    "preaxis": "npm run build",
+    "axis": "node dist/axis/run.js"
   },
   "dependencies": {
     "@a0/evals": "*",
+    "@a0/evals-axis": "*",
     "@a0/evals-graders": "*",
     "@a0/evals-reporter": "*",
     "commander": "^15.0.0"

--- a/apps/auth0-evals/src/axis/run.ts
+++ b/apps/auth0-evals/src/axis/run.ts
@@ -161,6 +161,12 @@ const frameworkConfig = await loadConfig({
 });
 setFrameworkConfig(frameworkConfig);
 
+const apiKey = process.env.LLM_API_KEY;
+if (!apiKey) {
+  console.error('[axis] LLM_API_KEY is not set — add it to .env or your shell before running');
+  process.exit(1);
+}
+
 // runGraders() uses config.proxy.baseUrl (the LiteLLM proxy) for judge calls,
 // not ANTHROPIC_BASE_URL. No model-ID remapping needed — the framework config's
 // judge model (e.g. 'claude-opus-4-8') is what LiteLLM expects. Passing no
@@ -168,7 +174,7 @@ setFrameworkConfig(frameworkConfig);
 const { scoredOutput, graderResults } = await runAxis({
   configPath: join(APP_ROOT, 'axis.config.ts'),
   frameworkRoot: APP_ROOT,
-  apiKey: process.env.LLM_API_KEY ?? '',
+  apiKey,
   ...(flags.debug === true ? { debug: true } : {}),
 });
 

--- a/apps/auth0-evals/src/axis/run.ts
+++ b/apps/auth0-evals/src/axis/run.ts
@@ -1,0 +1,197 @@
+/**
+ * Entry point for the auth0-evals AXIS integration.
+ *
+ * Loads the auth0-evals framework config, then delegates to runAxis() which
+ * runs AXIS and layers our graders on top of every job result.
+ *
+ * After the run, writes scores-axis.json (same format as scores-agent.json)
+ * and auto-generates report-axis.html using the existing evals reporter.
+ *
+ * Usage:
+ *   npm run axis
+ *   npm run axis -- --eval react_quickstart --agent claude-code --model claude-sonnet-5
+ *   npm run axis -- --output /tmp/scores.json --debug
+ */
+
+/* eslint-disable no-console */
+
+import { runAxis, buildAxisScores } from '@a0/evals-axis';
+import { setFrameworkConfig, loadConfig, discoverEvals } from '@a0/evals-core';
+import { renderHtml } from '@a0/evals-reporter';
+import { config as loadDotenv } from 'dotenv';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { parseArgs } from 'node:util';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Resolve the app root from the compiled output location:
+// apps/auth0-evals/dist/axis/run.js → ../../ = apps/auth0-evals/
+const APP_ROOT = join(__dirname, '..', '..');
+
+// Load .env before anything else so all downstream code sees the vars.
+loadDotenv({ path: join(APP_ROOT, '.env') });
+
+// Parse CLI flags. Values are merged into process.env so axis.config.ts picks
+// them up when AXIS loads it inside run(). Flags take precedence over env vars.
+//
+//   --eval react_quickstart          filter to one scenario (repeatable)
+//   --agent codex                    filter to one agent (repeatable)
+//   --workers 4                      parallel job limit
+//   --model claude-sonnet-5          override model for all configured agents
+//   --output /path/scores.json       where to write scores-axis.json (default: APP_ROOT)
+//   --debug                          capture raw adapter stdout for debugging
+//
+// Examples:
+//   npm run axis -- --eval react_quickstart
+//   npm run axis -- --eval react_quickstart --agent codex --workers 2
+//   npm run axis -- --agent claude-code --model claude-sonnet-5
+const { values: flags } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    eval: { type: 'string', multiple: true, short: 'e' },
+    agent: { type: 'string', multiple: true, short: 'a' },
+    workers: { type: 'string', short: 'w' },
+    model: { type: 'string', short: 'm' },
+    output: { type: 'string', short: 'o' },
+    debug: { type: 'boolean' },
+  },
+  strict: false,
+});
+
+if (flags.eval?.length) process.env.AXIS_EVAL = flags.eval.join(',');
+if (flags.agent?.length) process.env.AXIS_AGENT = flags.agent.join(',');
+if (typeof flags.workers === 'string') process.env.AXIS_WORKERS = flags.workers;
+if (typeof flags.model === 'string') process.env.AXIS_MODEL = flags.model;
+
+// Bridge auth0-evals env vars to the names each AXIS adapter expects.
+// AXIS always passes through the default API key vars (ANTHROPIC_API_KEY,
+// CODEX_API_KEY, GEMINI_API_KEY) but filters out everything else — base URL
+// vars must be listed in axis.config.ts's `env` array to reach the CLI.
+
+// claude-code: AXIS checks ANTHROPIC_API_KEY; our .env uses LLM_API_KEY.
+if (!process.env.ANTHROPIC_API_KEY && process.env.LLM_API_KEY) {
+  process.env.ANTHROPIC_API_KEY = process.env.LLM_API_KEY;
+}
+// Use the proxy base URL directly — appending /anthropic forwards the key
+// straight to Anthropic which rejects non-Anthropic keys in CI.
+if (!process.env.ANTHROPIC_BASE_URL && process.env.CLAUDE_PROXY_BASE_URL) {
+  process.env.ANTHROPIC_BASE_URL = process.env.CLAUDE_PROXY_BASE_URL.replace(/\/+$/, '');
+}
+
+// codex: AXIS checks CODEX_API_KEY; the codex CLI reads OPENAI_API_KEY.
+// Both names are set so auth works regardless of which env var codex uses.
+if (!process.env.CODEX_API_KEY && process.env.LLM_API_KEY) {
+  process.env.CODEX_API_KEY = process.env.LLM_API_KEY;
+}
+if (!process.env.OPENAI_API_KEY && process.env.LLM_API_KEY) {
+  process.env.OPENAI_API_KEY = process.env.LLM_API_KEY;
+}
+if (!process.env.OPENAI_BASE_URL) {
+  const codexBase = process.env.CODEX_PROXY_BASE_URL ?? process.env.LLM_PROXY_BASE_URL;
+  if (codexBase) {
+    const normalized = codexBase.replace(/\/+$/, '');
+    process.env.OPENAI_BASE_URL = normalized.endsWith('/v1') ? normalized : `${normalized}/v1`;
+  }
+}
+
+// Codex 0.140+ ignores OPENAI_BASE_URL and connects to api.openai.com via
+// WebSocket for the Responses API — it reads proxy settings from
+// CODEX_HOME/config.toml. AXIS creates an isolated (empty) CODEX_HOME per
+// run so there is no config file. Prepend a generated `codex` wrapper to PATH
+// so AXIS's `which codex` resolves to the wrapper; the wrapper writes the
+// LiteLLM proxy config into CODEX_HOME then exec-s the real binary.
+if (process.env.OPENAI_BASE_URL) {
+  let realCodexPath: string | undefined;
+  try {
+    realCodexPath = execFileSync('which', ['codex'], { encoding: 'utf-8' }).trim();
+  } catch {
+    // codex not found in PATH — wrapper not needed
+  }
+  if (realCodexPath) {
+    const tmpBin = mkdtempSync(join(tmpdir(), 'codex-proxy-'));
+    const openaiBaseUrl = process.env.OPENAI_BASE_URL;
+    writeFileSync(
+      join(tmpBin, 'codex'),
+      [
+        '#!/usr/bin/env bash',
+        '# Generated by npm run axis — writes LiteLLM proxy config into the',
+        '# AXIS-isolated CODEX_HOME so codex reaches the proxy, not api.openai.com.',
+        'set -euo pipefail',
+        'if [ -n "${CODEX_HOME:-}" ]; then',
+        '  mkdir -p "$CODEX_HOME"',
+        '  if [ ! -f "$CODEX_HOME/config.toml" ]; then',
+        '    cat > "$CODEX_HOME/config.toml" << TOML',
+        'model_provider = "litellm"',
+        '',
+        '[model_providers.litellm]',
+        'name = "Proxy"',
+        `base_url = "${openaiBaseUrl}"`,
+        'env_key = "OPENAI_API_KEY"',
+        'supports_websockets = false',
+        'TOML',
+        '  fi',
+        'fi',
+        `exec "${realCodexPath}" "$@"`,
+      ].join('\n') + '\n',
+      { mode: 0o755 },
+    );
+    process.env.PATH = `${tmpBin}:${process.env.PATH ?? ''}`;
+  }
+}
+
+// gemini: AXIS checks GEMINI_API_KEY; the Gemini CLI reads GOOGLE_GEMINI_BASE_URL.
+if (!process.env.GEMINI_API_KEY && process.env.LLM_API_KEY) {
+  process.env.GEMINI_API_KEY = process.env.LLM_API_KEY;
+}
+if (!process.env.GOOGLE_GEMINI_BASE_URL) {
+  const geminiBase = process.env.GEMINI_PROXY_BASE_URL ?? process.env.LLM_PROXY_BASE_URL;
+  if (geminiBase) {
+    process.env.GOOGLE_GEMINI_BASE_URL = geminiBase.replace(/\/+$/, '');
+  }
+}
+
+// Load auth0-evals framework config so runGraders() has access to judge model,
+// proxy URL, and other settings via the singleton.
+const frameworkConfig = await loadConfig({
+  configPath: join(APP_ROOT, 'eval.config.js'),
+});
+setFrameworkConfig(frameworkConfig);
+
+// runGraders() uses config.proxy.baseUrl (the LiteLLM proxy) for judge calls,
+// not ANTHROPIC_BASE_URL. No model-ID remapping needed — the framework config's
+// judge model (e.g. 'claude-opus-4-8') is what LiteLLM expects. Passing no
+// judgeModel here lets runGraders() fall back to config.judge.model.
+const { scoredOutput, graderResults } = await runAxis({
+  configPath: join(APP_ROOT, 'axis.config.ts'),
+  frameworkRoot: APP_ROOT,
+  apiKey: process.env.LLM_API_KEY ?? '',
+  ...(flags.debug === true ? { debug: true } : {}),
+});
+
+console.log(
+  `[axis] Done — ${scoredOutput.summary.completed}/${scoredOutput.summary.total} completed` +
+    (scoredOutput.summary.failed > 0 ? `, ${scoredOutput.summary.failed} failed` : ''),
+);
+
+// Write scores-axis.json and report-axis.html so results appear in npm run report.
+const evalCategories = Object.fromEntries(discoverEvals('src/evals', APP_ROOT).map((cfg) => [cfg.id, cfg.category]));
+const scores = buildAxisScores(scoredOutput, graderResults, evalCategories);
+const scoresPath = typeof flags.output === 'string' ? flags.output : join(APP_ROOT, 'scores-axis.json');
+writeFileSync(scoresPath, JSON.stringify(scores, null, 2), 'utf-8');
+console.log(`[axis] Scores: ${scoresPath}`);
+
+const now = new Date();
+const generatedAt =
+  `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}` +
+  ` ${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
+const reportPath = join(APP_ROOT, 'report-axis.html');
+// renderHtml's input type is Record<string, unknown>[] — a loose signature that
+// predates the typed JobResult union. AgentJobResult is structurally compatible
+// but TypeScript rejects the direct assignment due to the index signature gap,
+// so the double cast is intentional rather than masking a real type mismatch.
+writeFileSync(reportPath, renderHtml(scores as unknown as Record<string, unknown>[], generatedAt), 'utf-8');
+console.log(`[axis] Report: ${reportPath}`);

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -120,10 +120,16 @@ Bottom-up, with a clean acyclic dependency graph (`@a0/evals-graders` is the lea
 - **Dependencies**: `@a0/evals-core`, `@a0/evals-graders`, `marked`, `nunjucks`.
 - **Type**: Application infrastructure / reporting.
 
+### `@a0/evals-axis`
+- **Purpose**: AXIS integration bridge.
+- **Responsibilities**: Wraps `@netlify/axis` `run()` and layers auth0-evals graders on top of every job result. Exposes `runAxis()` (orchestrates the full AXIS run + grader hook) and `buildAxisScores()` (maps `ScoredOutput` + `GraderResult[]` into the `AgentJobResult[]` shape that `@a0/evals-reporter` expects). The grader hook (`runAuth0Graders`) fires inside the `onResult` callback — before AXIS tears down the workspace — and runs L1–L4 graders against the live workspace. `axisTranscriptToToolCalls()` translates the AXIS transcript into the `EventToolCall[]` format the grader engine understands.
+- **Dependencies**: `@a0/evals-core`, `@a0/evals-graders`, `@netlify/axis`.
+- **Type**: Application infrastructure / bridge.
+
 ### `apps/auth0-evals`
 - **Purpose**: Auth0's concrete deployment.
-- **Responsibilities**: The 14-eval suite (`src/evals/**`), `eval.config.js` (proxy, models, MCP server, skills sources, judge, scoring allowlist), the React scaffolds, and the local skills dir. Publishes thin `evals`/`report` npm scripts that shell out to `a0-eval`.
-- **Dependencies**: `@a0/evals`, `@a0/evals-graders`, `@a0/evals-reporter`, `commander`.
+- **Responsibilities**: The 14-eval suite (`src/evals/**`), `eval.config.js` (proxy, models, MCP server, skills sources, judge, scoring allowlist), the React scaffolds, and the local skills dir. Publishes thin `evals`/`report` npm scripts that shell out to `a0-eval`, and an `axis` script (`src/axis/run.ts`) that wires AXIS to the eval suite via `axis.config.ts`.
+- **Dependencies**: `@a0/evals`, `@a0/evals-axis`, `@a0/evals-graders`, `@a0/evals-reporter`, `commander`.
 - **Type**: Application / deployment.
 
 ## Runners (auto-routed by model prefix)
@@ -215,6 +221,79 @@ sequenceDiagram
     CLI->>CLI: mergeIntoOutput() — dedup by eval|model|mode|tools
     CLI->>Rep: a0-eval report → report.html
 ```
+
+## AXIS integration
+
+`npm run axis` is a **second run path** that delegates execution to [AXIS](https://github.com/netlify/axis) — Netlify's multi-agent evaluation framework — and layers auth0-evals graders on top. It runs the same tasks across **claude-code, codex, and gemini in a single pass** with no Docker dependency (AXIS manages its own workspace isolation).
+
+The bridge lives in `@a0/evals-axis`. `apps/auth0-evals/src/axis/run.ts` is the entry point; `apps/auth0-evals/axis.config.ts` auto-discovers evals as AXIS scenarios by calling `discoverEvals()` on every run (a fast filesystem scan — no caching needed).
+
+```mermaid
+%%{init: {'theme':'base', 'mirrorActors': false, 'themeVariables': {
+  'primaryColor':'#E7F0FF','primaryBorderColor':'#4C6EF5','primaryTextColor':'#1A1A2E',
+  'actorBkg':'#E7F0FF','actorBorder':'#4C6EF5','actorTextColor':'#1A1A2E',
+  'signalColor':'#495057','signalTextColor':'#1A1A2E','noteBkgColor':'#FFF9DB','noteBorderColor':'#F08C00',
+  'fontFamily':'ui-sans-serif, system-ui, sans-serif'
+}}}%%
+sequenceDiagram
+    box rgba(231,240,255,0.6) CLI and Config
+        participant U as User / CI
+        participant Run as axis/run.ts
+        participant Config as axis.config.ts
+    end
+    box rgba(255,232,204,0.55) AXIS
+        participant Axis as runAxis()
+        participant Agent as Agent (claude-code / codex / gemini)
+    end
+    box rgba(211,249,216,0.5) Graders
+        participant Hook as runAuth0Graders()
+        participant GE as runGraders()
+    end
+    box rgba(243,232,255,0.55) Output
+        participant Build as buildAxisScores()
+        participant Out as scores-axis.json + report-axis.html
+    end
+
+    U->>Run: npm run axis [--eval id] [--agent name] [--model model]
+    Run->>Config: discoverEvals() → scenarios[]
+    Run->>Axis: runAxis({ configPath, frameworkRoot, apiKey })
+
+    loop per job [scenario × agent]
+        Axis->>Agent: run task in isolated workspace
+        Agent-->>Axis: edited workspace + transcript
+        Axis->>Hook: onResult hook (before workspace teardown)
+        Hook->>GE: runGraders(workspace, L1–L4)
+        GE-->>Hook: GraderResult[]
+        Hook-->>Axis: GraderResult[]
+    end
+
+    Axis->>Axis: AXIS 4-dimension judge (goal / environment / service / agent)
+    Axis-->>Run: { scoredOutput, graderResults }
+    Run->>Build: buildAxisScores(scoredOutput, graderResults)
+    Build-->>Out: AgentJobResult[] → scores-axis.json + report-axis.html
+```
+
+### How AXIS and auth0-evals scoring combine
+
+AXIS scores every job on **4 dimensions** (0–10 each) via its own LLM judge. auth0-evals adds **L1–L4 grader pass rates** alongside. `buildAxisScores()` maps the combined result into the same `AgentJobResult` shape that `a0-eval run` produces, so `npm run report` renders both in a unified leaderboard.
+
+| Source | What it measures |
+|---|---|
+| AXIS — Goal Achievement | Did the agent satisfy the overall task goal? |
+| AXIS — Environment | Did the agent leave the environment in a clean state? |
+| AXIS — Service | Did the agent use the right services correctly? |
+| AXIS — Agent | Did the agent work efficiently without unnecessary steps? |
+| auth0-evals L1–L4 graders | Required symbols, no hallucinations, no secrets, correct wiring |
+
+### Key differences from `a0-eval run`
+
+| | `a0-eval run` | `npm run axis` |
+|---|---|---|
+| Sandbox | Docker (per-job container) | AXIS-managed workspace isolation |
+| Agents | one model/runner per run | claude-code, codex, gemini in one pass |
+| Scoring | 8-dimension weighted sum | AXIS 4-dimension judge + grader pass rates |
+| Modes | baseline, agent, agent+mcp, … | agent only (no baseline, no MCP toggle) |
+| Output | `scores-agent.json` / `scores-baseline.json` | `scores-axis.json` |
 
 ## Scoring — 8 dimensions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       "version": "1.0.1",
       "dependencies": {
         "@a0/evals": "*",
+        "@a0/evals-axis": "*",
         "@a0/evals-graders": "*",
         "@a0/evals-reporter": "*",
         "commander": "^15.0.0"


### PR DESCRIPTION
## Summary

Wires `@a0/evals-axis` into the `auth0-evals` app, adding `npm run axis` — runs the same tasks across claude-code, codex, and gemini in a single pass with no Docker dependency.

- `apps/auth0-evals/axis.config.ts` — auto-discovers PROMPT.md evals as AXIS scenarios, configures agents, wires judge settings and env passthrough
- `apps/auth0-evals/src/axis/run.ts` — CLI entry point: parses flags, bridges `LLM_API_KEY` and proxy env vars to each adapter, writes `scores-axis.json` and `report-axis.html`
- `apps/auth0-evals/package.json` — adds `npm run axis` script and `@a0/evals-axis` dependency
- `AGENTS.md` — adds AXIS commands and flags table
- `README.md` — adds `@a0/evals-axis` to packages list and AXIS running section
- `docs/ARCHITECTURE.md` — adds AXIS integration section with sequence diagram and component entry

## Test plan

- [ ] `npm run axis -- --eval react_quickstart --agent claude-code` completes and writes `scores-axis.json` and `report-axis.html`
- [ ] `npm run axis -- --model claude-sonnet-5` correctly overrides model for all agents
- [ ] `npm run report` picks up `scores-axis.json` and shows it in combined `report.html`
- [ ] `npm run build` passes with no TypeScript errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added AXIS-based evaluation runs for `auth0-evals`, with multiple agents, model selection, filtering, concurrency, and configurable timeouts.
  - Added standard score output and HTML report generation.
  - Added optional npm registry and proxy configuration support.
  - Added Docker-free execution with isolated workspaces and leaderboard-compatible results.

- **Documentation**
  - Documented AXIS commands, options, agents, models, outputs, environment settings, and report integration.
  - Added architecture guidance for AXIS evaluation workflows.

- **Chores**
  - Added generated AXIS reports to ignored files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->