### PR TITLE
feat(evals): add Swift and Android MFA step-up evals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,10 @@ report.html
 # Swift package manager
 **/.swiftpm/
 **/Package.resolved
+**/.build/
+
+# Gradle
+**/.gradle/
 
 # macOS
 .DS_Store

--- a/apps/auth0-evals/README.md
+++ b/apps/auth0-evals/README.md
@@ -50,6 +50,13 @@ See [`@a0/evals` CLI docs](../../packages/evals/) for the full list of flags and
 | `fastapi_quickstart` | quickstarts | Protect a FastAPI API using `auth0-fastapi-api` |
 | `fastify_api_quickstart` | quickstarts | Protect a Fastify API using `@auth0/auth0-fastify-api` |
 | `flask_quickstart` | quickstarts | Add Auth0 login to a Flask web app |
+| `react_mfa` | mfa | Gate a sensitive action in a React SPA behind MFA step-up |
+| `vue_mfa` | mfa | Gate a sensitive action in a Vue 3 SPA behind MFA step-up |
+| `angular_mfa` | mfa | Gate a sensitive action in an Angular app behind MFA step-up |
+| `swift_mfa` | mfa | Gate a sensitive action in a Swift iOS app behind MFA step-up |
+| `android_mfa` | mfa | Gate a sensitive action in an Android app behind MFA step-up |
+| `mfa_tenant_cli` | mfa | Enable and enforce a required MFA factor on a live tenant using the Auth0 CLI |
+| `spa_js_dpop` | dpop | Add DPoP token binding to a vanilla JS SPA using `@auth0/auth0-spa-js` |
 
 ## Configuration
 

--- a/apps/auth0-evals/src/evals/mfa/android/PROMPT.md
+++ b/apps/auth0-evals/src/evals/mfa/android/PROMPT.md
@@ -1,0 +1,14 @@
+---
+id: android_mfa
+name: Android MFA Step-Up
+scaffold: src/evals/scaffolds/android/auth0
+skills: auth0
+---
+
+## Task
+
+My Android app already has Auth0 login working through Universal Login. I want to add a Transfer Funds action where users must complete MFA before the transfer runs. If they haven't done MFA yet, prompt them for it.
+
+Domain: dev-barkbook.us.auth0.com
+Client ID: barkbook_client_abc123xyz
+Audience: https://api.barkbook.com

--- a/apps/auth0-evals/src/evals/mfa/android/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/android/graders.ts
@@ -23,10 +23,13 @@ export function defineGraders() {
     notContains('auth0-java', 'No auth0-java (server-side SDK, not for Android)', GraderLevel.L2),
     // Auth0.Android has no Credentials.claims property — claims come from credentials.user.
     notContains('credentials.claims', 'No hallucinated Credentials.claims property', GraderLevel.L2),
+    // Every embedded-MFA path carries the mfa_token, whether or not the
+    // MfaApiClient type is ever named.
     notContains(
-      'mfaClient',
-      'Does not use the embedded MFA grant (MFAClient) — wrong approach for a Universal Login app',
+      'mfaToken',
+      'Does not use the embedded MFA grant (MfaApiClient) — wrong approach for a Universal Login app',
       GraderLevel.L2,
+      { caseSensitive: false },
     ),
     notContains('mfa/challenge', 'Does not call the raw MFA challenge endpoint', GraderLevel.L2),
 

--- a/apps/auth0-evals/src/evals/mfa/android/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/android/graders.ts
@@ -1,0 +1,86 @@
+import { contains, notContains, notContainsInSource, matches, judge, GraderLevel } from '@a0/evals-graders';
+
+export function defineGraders() {
+  return [
+    // ── L1: Required MFA step-up symbols present ───────────────────────────
+    contains('acr_values', 'Step-up request uses acr_values parameter', GraderLevel.L1),
+    contains('amr', 'AMR claim checked to detect prior MFA completion', GraderLevel.L1),
+    contains(
+      'schemas.openid.net/pape/policies/2007/06/multi-factor',
+      'Uses correct multi-factor acr_values policy URI',
+      GraderLevel.L1,
+    ),
+    contains('withParameters', 'Passes acr_values through WebAuthProvider withParameters', GraderLevel.L1),
+    // The SDK surfaces custom claims through UserProfile.getExtraInfo(); the separate
+    // com.auth0.android:jwtdecode library is an equally valid way to read amr.
+    matches(
+      String.raw`getExtraInfo\(\)|com\.auth0\.android:jwtdecode`,
+      'Reads ID token claims via UserProfile.getExtraInfo() or the jwtdecode library',
+      GraderLevel.L1,
+    ),
+
+    // ── L2: Hallucination / wrong approach ────────────────────────────────
+    notContains('auth0-java', 'No auth0-java (server-side SDK, not for Android)', GraderLevel.L2),
+    // Auth0.Android has no Credentials.claims property — claims come from credentials.user.
+    notContains('credentials.claims', 'No hallucinated Credentials.claims property', GraderLevel.L2),
+    notContains(
+      'mfaClient',
+      'Does not use the embedded MFA grant (MFAClient) — wrong approach for a Universal Login app',
+      GraderLevel.L2,
+    ),
+    notContains('mfa/challenge', 'Does not call the raw MFA challenge endpoint', GraderLevel.L2),
+
+    // ── L3: Security ──────────────────────────────────────────────────────
+    notContainsInSource(
+      'barkbook_client_abc123xyz',
+      'No hardcoded client ID in Kotlin source files (ok in strings.xml)',
+      GraderLevel.L3,
+    ),
+    notContainsInSource(
+      'dev-barkbook.us.auth0.com',
+      'No hardcoded domain in Kotlin source files (ok in strings.xml)',
+      GraderLevel.L3,
+    ),
+    judge(
+      'Does the code let SecureCredentialsManager (or CredentialsManager) handle token storage rather than ' +
+        'persisting Auth0 tokens (access tokens, ID tokens, refresh tokens) by hand in SharedPreferences? ' +
+        'Storing application state such as a pending transfer is acceptable — only manual token storage is a violation.',
+      GraderLevel.L3,
+    ),
+
+    // ── L4: Structural correctness ────────────────────────────────────────
+    judge(
+      'Does the code check the amr claim before executing the transfer action, and only proceed when ' +
+        '"mfa" is present in the amr array? Reading amr via credentials.user.getExtraInfo()["amr"] or via ' +
+        'the com.auth0.android:jwtdecode library are both acceptable.',
+      GraderLevel.L4,
+    ),
+    judge(
+      'When MFA is missing, is step-up performed by launching a new WebAuthProvider.login(...) — with ' +
+        'withScheme and the MFA acr_values — rather than by calling the Authentication API MFA endpoints ' +
+        '(challenge/verify) directly?',
+      GraderLevel.L4,
+    ),
+
+    // ── L5: Current API patterns ──────────────────────────────────────────
+    judge(
+      'Does the step-up request force fresh authentication with a max_age of 0, so a cached session is not ' +
+        'reused? Either the dedicated withMaxAge(0) builder or a "max_age" entry inside withParameters(...) counts.',
+      GraderLevel.L5,
+    ),
+    judge(
+      'Is the step-up request built with the current v2+ builder API — WebAuthProvider.login(account) ' +
+        'with withScheme and withParameters/withMaxAge — rather than by hand-building an /authorize URL ' +
+        'or using the removed WebAuthProvider.init entry point?',
+      GraderLevel.L5,
+    ),
+
+    // ── Holistic judge (no level — always runs) ───────────────────────────
+    judge(
+      'Does the solution correctly implement MFA step-up authentication in an Android app — reading the amr ' +
+        'claim from the ID token (via credentials.user.getExtraInfo() or the jwtdecode library), requesting ' +
+        'step-up through WebAuthProvider.login with acr_values and max_age 0 when MFA is not present, and ' +
+        'gating the Transfer Funds action behind MFA verification?',
+    ),
+  ];
+}

--- a/apps/auth0-evals/src/evals/mfa/swift/PROMPT.md
+++ b/apps/auth0-evals/src/evals/mfa/swift/PROMPT.md
@@ -1,0 +1,14 @@
+---
+id: swift_mfa
+name: Swift MFA Step-Up
+scaffold: src/evals/scaffolds/swift/auth0
+skills: auth0
+---
+
+## Task
+
+My iOS app already has Auth0 login working through Universal Login. I want to add a Transfer Funds action where users must complete MFA before the transfer runs. If they haven't done MFA yet, prompt them for it.
+
+Domain: dev-barkbook.us.auth0.com
+Client ID: barkbook_client_abc123xyz
+Audience: https://api.barkbook.com

--- a/apps/auth0-evals/src/evals/mfa/swift/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/swift/graders.ts
@@ -20,10 +20,13 @@ export function defineGraders() {
 
     // ── L2: Hallucination / wrong approach ────────────────────────────────
     notContains('Auth0SDK', 'No hallucinated Auth0SDK package name (correct package is Auth0)', GraderLevel.L2),
+    // Every embedded-MFA path carries the mfa_token, whether or not the
+    // MFAClient type is ever named (Auth0.mfa().verify(otp:mfaToken:)).
     notContains(
-      'mfaClient',
-      'Does not use the embedded MFA grant (MFAClient) — wrong approach for a Universal Login app',
+      'mfaToken',
+      'Does not use the embedded MFA grant (Auth0.mfa()/MFAClient) — wrong approach for a Universal Login app',
       GraderLevel.L2,
+      { caseSensitive: false },
     ),
     notContains('mfa/challenge', 'Does not call the raw MFA challenge endpoint', GraderLevel.L2),
 

--- a/apps/auth0-evals/src/evals/mfa/swift/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/swift/graders.ts
@@ -1,0 +1,85 @@
+import { contains, notContains, notContainsInSource, matches, judge, GraderLevel } from '@a0/evals-graders';
+
+export function defineGraders() {
+  return [
+    // ── L1: Required MFA step-up symbols present ───────────────────────────
+    contains('acr_values', 'Step-up request uses acr_values parameter', GraderLevel.L1),
+    contains('amr', 'AMR claim checked to detect prior MFA completion', GraderLevel.L1),
+    contains(
+      'schemas.openid.net/pape/policies/2007/06/multi-factor',
+      'Uses correct multi-factor acr_values policy URI',
+      GraderLevel.L1,
+    ),
+    // Auth0.swift exposes claims two legitimate ways: JWTDecode (a public
+    // dependency of the SDK) or CredentialsManager.userProfile()?.customClaims.
+    matches(
+      String.raw`decode\(jwt:|customClaims`,
+      'Reads ID token claims via JWTDecode or UserProfile.customClaims',
+      GraderLevel.L1,
+    ),
+
+    // ── L2: Hallucination / wrong approach ────────────────────────────────
+    notContains('Auth0SDK', 'No hallucinated Auth0SDK package name (correct package is Auth0)', GraderLevel.L2),
+    notContains(
+      'mfaClient',
+      'Does not use the embedded MFA grant (MFAClient) — wrong approach for a Universal Login app',
+      GraderLevel.L2,
+    ),
+    notContains('mfa/challenge', 'Does not call the raw MFA challenge endpoint', GraderLevel.L2),
+
+    // ── L3: Security ──────────────────────────────────────────────────────
+    notContainsInSource(
+      'barkbook_client_abc123xyz',
+      'No hardcoded client ID in Swift source files (ok in Auth0.plist)',
+      GraderLevel.L3,
+    ),
+    notContainsInSource(
+      'dev-barkbook.us.auth0.com',
+      'No hardcoded domain in Swift source files (ok in Auth0.plist)',
+      GraderLevel.L3,
+    ),
+    judge(
+      'Does the code let CredentialsManager handle token storage rather than persisting Auth0 tokens ' +
+        '(access tokens, ID tokens, refresh tokens) by hand in UserDefaults or the Keychain? Storing ' +
+        'application state such as a pending transfer is acceptable — only manual token storage is a violation.',
+      GraderLevel.L3,
+    ),
+
+    // ── L4: Structural correctness ────────────────────────────────────────
+    judge(
+      'Does the code check the amr claim before executing the transfer action, and only proceed when ' +
+        '"mfa" is present in the amr array? Reading amr via JWTDecode (decode(jwt:).claim(name: "amr")) ' +
+        'or via CredentialsManager.userProfile()?.customClaims are both acceptable.',
+      GraderLevel.L4,
+    ),
+    judge(
+      'When MFA is missing, is step-up performed by starting a new Universal Login web auth session — ' +
+        'Auth0.webAuth() with the MFA acr_values — rather than by calling the Authentication API MFA ' +
+        'endpoints (challenge/verify) directly?',
+      GraderLevel.L4,
+    ),
+
+    // ── L5: Current API patterns ──────────────────────────────────────────
+    // `.parameters` / `.maxAge` are the current builders for extra authorization
+    // parameters. The scaffold's login call uses neither, so this only passes if
+    // the agent built the step-up request itself.
+    matches(
+      String.raw`\.parameters\(|\.maxAge\(`,
+      'Step-up parameters passed through the current .parameters/.maxAge builders',
+      GraderLevel.L5,
+    ),
+    judge(
+      'Does the step-up request force fresh authentication with a max_age of 0, so a cached session is ' +
+        'not reused? Either the dedicated .maxAge(0) builder or "max_age" inside .parameters([...]) counts.',
+      GraderLevel.L5,
+    ),
+
+    // ── Holistic judge (no level — always runs) ───────────────────────────
+    judge(
+      'Does the solution correctly implement MFA step-up authentication in a Swift iOS app — reading the ' +
+        'amr claim from the ID token (via JWTDecode or UserProfile.customClaims), requesting step-up ' +
+        'through Auth0.webAuth() with acr_values and max_age 0 when MFA is not present, and gating the ' +
+        'Transfer Funds action behind MFA verification?',
+    ),
+  ];
+}

--- a/apps/auth0-evals/src/evals/scaffolds/android/auth0/AGENTS.md
+++ b/apps/auth0-evals/src/evals/scaffolds/android/auth0/AGENTS.md
@@ -1,0 +1,3 @@
+# Android MFA — Agent Guidance
+
+Do not run build or compile commands (do not run `./gradlew`, `gradle assembleDebug`, or similar). You may edit any project files — Kotlin source, `build.gradle`, `strings.xml`, `AndroidManifest.xml` — but do not attempt to compile or verify the build.

--- a/apps/auth0-evals/src/evals/scaffolds/android/auth0/app/build.gradle
+++ b/apps/auth0-evals/src/evals/scaffolds/android/auth0/app/build.gradle
@@ -1,0 +1,48 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    namespace 'com.barkbook.app'
+    compileSdk 34
+
+    defaultConfig {
+        applicationId "com.barkbook.app"
+        minSdk 26
+        targetSdk 34
+        versionCode 1
+        versionName "1.0"
+
+        manifestPlaceholders = [
+            auth0Domain: "@string/com_auth0_domain",
+            auth0Scheme: "@string/com_auth0_scheme"
+        ]
+    }
+
+    buildFeatures {
+        compose true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion '1.5.1'
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+}
+
+dependencies {
+    implementation 'androidx.core:core-ktx:1.12.0'
+    implementation 'androidx.compose.ui:ui:1.5.4'
+    implementation 'androidx.compose.material3:material3:1.1.2'
+    implementation 'androidx.activity:activity-compose:1.8.0'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.2'
+    implementation 'com.auth0.android:auth0:4.0.1'
+}

--- a/apps/auth0-evals/src/evals/scaffolds/android/auth0/app/src/main/AndroidManifest.xml
+++ b/apps/auth0-evals/src/evals/scaffolds/android/auth0/app/src/main/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+        android:allowBackup="true"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.Material3.DayNight">
+
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+    </application>
+
+</manifest>

--- a/apps/auth0-evals/src/evals/scaffolds/android/auth0/app/src/main/java/com/barkbook/app/MainActivity.kt
+++ b/apps/auth0-evals/src/evals/scaffolds/android/auth0/app/src/main/java/com/barkbook/app/MainActivity.kt
@@ -1,0 +1,139 @@
+package com.barkbook.app
+
+import android.os.Bundle
+import android.util.Log
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.auth0.android.Auth0
+import com.auth0.android.authentication.AuthenticationAPIClient
+import com.auth0.android.authentication.AuthenticationException
+import com.auth0.android.authentication.storage.SecureCredentialsManager
+import com.auth0.android.authentication.storage.SharedPreferencesStorage
+import com.auth0.android.callback.Callback
+import com.auth0.android.provider.WebAuthProvider
+import com.auth0.android.result.Credentials
+
+class MainActivity : ComponentActivity() {
+    private lateinit var account: Auth0
+    private lateinit var credentialsManager: SecureCredentialsManager
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        account = Auth0.getInstance(this)
+        credentialsManager = SecureCredentialsManager(
+            AuthenticationAPIClient(account),
+            this,
+            SharedPreferencesStorage(this)
+        )
+
+        setContent {
+            BarkbookApp(
+                isLoggedIn = credentialsManager.hasValidCredentials(),
+                onLogin = { onLoggedIn -> login(onLoggedIn) },
+                onLogout = { onLoggedOut -> logout(onLoggedOut) }
+            )
+        }
+    }
+
+    private fun login(onLoggedIn: (String?) -> Unit) {
+        WebAuthProvider.login(account)
+            .withScheme(getString(R.string.com_auth0_scheme))
+            .withAudience("https://api.barkbook.com")
+            .withScope("openid profile email offline_access")
+            .start(this, object : Callback<Credentials, AuthenticationException> {
+                override fun onSuccess(result: Credentials) {
+                    credentialsManager.saveCredentials(result)
+                    onLoggedIn(result.user.email)
+                }
+
+                override fun onFailure(error: AuthenticationException) {
+                    Log.e("Barkbook", "Login failed", error)
+                }
+            })
+    }
+
+    private fun logout(onLoggedOut: () -> Unit) {
+        WebAuthProvider.logout(account)
+            .withScheme(getString(R.string.com_auth0_scheme))
+            .start(this, object : Callback<Void?, AuthenticationException> {
+                override fun onSuccess(result: Void?) {
+                    credentialsManager.clearCredentials()
+                    onLoggedOut()
+                }
+
+                override fun onFailure(error: AuthenticationException) {
+                    Log.e("Barkbook", "Logout failed", error)
+                }
+            })
+    }
+}
+
+@Composable
+fun BarkbookApp(
+    isLoggedIn: Boolean,
+    onLogin: ((String?) -> Unit) -> Unit,
+    onLogout: (() -> Unit) -> Unit
+) {
+    var isAuthenticated by remember { mutableStateOf(isLoggedIn) }
+    var userEmail by remember { mutableStateOf("") }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Barkbook",
+            style = MaterialTheme.typography.headlineLarge
+        )
+        Spacer(modifier = Modifier.height(32.dp))
+
+        if (isAuthenticated) {
+            Text("Welcome!")
+            if (userEmail.isNotEmpty()) {
+                Text(
+                    text = userEmail,
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(onClick = {
+                onLogout {
+                    isAuthenticated = false
+                    userEmail = ""
+                }
+            }) {
+                Text("Logout")
+            }
+        } else {
+            Button(onClick = {
+                onLogin { email ->
+                    isAuthenticated = true
+                    userEmail = email.orEmpty()
+                }
+            }) {
+                Text("Login")
+            }
+        }
+    }
+}

--- a/apps/auth0-evals/src/evals/scaffolds/android/auth0/app/src/main/res/values/strings.xml
+++ b/apps/auth0-evals/src/evals/scaffolds/android/auth0/app/src/main/res/values/strings.xml
@@ -1,0 +1,6 @@
+<resources>
+    <string name="app_name">Barkbook</string>
+    <string name="com_auth0_domain">dev-barkbook.us.auth0.com</string>
+    <string name="com_auth0_client_id">barkbook_client_abc123xyz</string>
+    <string name="com_auth0_scheme">com.barkbook.app</string>
+</resources>

--- a/apps/auth0-evals/src/evals/scaffolds/swift/auth0/AGENTS.md
+++ b/apps/auth0-evals/src/evals/scaffolds/swift/auth0/AGENTS.md
@@ -1,0 +1,3 @@
+# Swift MFA — Agent Guidance
+
+Do not run build or compile commands (do not run `swift build`, `xcodebuild`, or similar). You may edit any project files — Swift source, `Package.swift`, `Auth0.plist` — but do not attempt to compile or verify the build.

--- a/apps/auth0-evals/src/evals/scaffolds/swift/auth0/Auth0.plist
+++ b/apps/auth0-evals/src/evals/scaffolds/swift/auth0/Auth0.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>ClientId</key>
+    <string>barkbook_client_abc123xyz</string>
+    <key>Domain</key>
+    <string>dev-barkbook.us.auth0.com</string>
+</dict>
+</plist>

--- a/apps/auth0-evals/src/evals/scaffolds/swift/auth0/Package.swift
+++ b/apps/auth0-evals/src/evals/scaffolds/swift/auth0/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "BarkbookApp",
+    platforms: [
+        .iOS(.v14)
+    ],
+    products: [
+        .library(
+            name: "BarkbookApp",
+            targets: ["BarkbookApp"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/auth0/Auth0.swift.git", from: "3.0.0"),
+    ],
+    targets: [
+        .target(
+            name: "BarkbookApp",
+            dependencies: [
+                .product(name: "Auth0", package: "Auth0.swift"),
+            ]),
+    ]
+)

--- a/apps/auth0-evals/src/evals/scaffolds/swift/auth0/Sources/BarkbookApp/AuthenticationService.swift
+++ b/apps/auth0-evals/src/evals/scaffolds/swift/auth0/Sources/BarkbookApp/AuthenticationService.swift
@@ -1,0 +1,42 @@
+import Auth0
+import SwiftUI
+
+@MainActor
+final class AuthenticationService: ObservableObject {
+    @Published var isAuthenticated: Bool
+    @Published var email: String?
+
+    private let credentialsManager = CredentialsManager(authentication: Auth0.authentication())
+
+    init() {
+        isAuthenticated = credentialsManager.canRenew()
+        email = try? credentialsManager.userProfile()?.email
+    }
+
+    func login() async {
+        do {
+            let credentials = try await Auth0
+                .webAuth()
+                .useHTTPS()
+                .audience("https://api.barkbook.com")
+                .scope("openid profile email offline_access")
+                .start()
+            _ = credentialsManager.store(credentials: credentials)
+            isAuthenticated = true
+            email = try? credentialsManager.userProfile()?.email
+        } catch {
+            print("Login failed: \(error)")
+        }
+    }
+
+    func logout() async {
+        do {
+            try await Auth0.webAuth().useHTTPS().logout()
+        } catch {
+            print("Logout failed: \(error)")
+        }
+        _ = credentialsManager.clear()
+        isAuthenticated = false
+        email = nil
+    }
+}

--- a/apps/auth0-evals/src/evals/scaffolds/swift/auth0/Sources/BarkbookApp/ContentView.swift
+++ b/apps/auth0-evals/src/evals/scaffolds/swift/auth0/Sources/BarkbookApp/ContentView.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+@main
+struct BarkbookApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}
+
+struct ContentView: View {
+    @StateObject private var auth = AuthenticationService()
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Barkbook")
+                .font(.largeTitle)
+
+            if auth.isAuthenticated {
+                Text("Welcome!")
+                if let email = auth.email {
+                    Text(email)
+                        .font(.caption)
+                }
+
+                Button("Logout") {
+                    Task { await auth.logout() }
+                }
+            } else {
+                Button("Login") {
+                    Task { await auth.login() }
+                }
+            }
+        }
+        .padding()
+    }
+}


### PR DESCRIPTION
## ✏️ Changes

Adds MFA step-up evals for the two mobile SDKs: `swift_mfa` and `android_mfa`. Same shape as `mfa/react` — gate a Transfer Funds action behind MFA by requesting step-up through Universal Login with `acr_values` and `max_age` 0, reading `amr` off the ID token, and only then running the transfer. Mobile had no MFA coverage before this.

Both use a new shared scaffold (`src/evals/scaffolds/{swift,android}/auth0`): a login-only app with Auth0 already wired, no Transfer Funds UI, since building the feature is the task. No `compile_command` — there is no native toolchain in the sandbox, same as the mobile quickstarts.

The graders accept either legitimate way of doing each step, so correct solutions aren't failed on style: `amr` via JWTDecode / `customClaims` on Swift and `getExtraInfo()` / jwtdecode on Android, and `max_age` via the dedicated builder or a `max_age` parameter. L2 penalises the embedded MFA grant, which is wrong for a Universal Login app.

Two side fixes: the README eval table listed quickstarts only, so the existing MFA and DPoP evals are backfilled; and `.build/` / `.gradle/` are gitignored, since both scaffolds pick up build residue locally.

- [x] I described the changes on this PR.


## 🔮 Type of Change

- [x] Standard
- [ ] Emergency
- [ ] Significant


## 🔗 References

- SDK-10701, SDK-10702 — under epic SDK-10349
- Reference eval: `apps/auth0-evals/src/evals/mfa/react/`

- [x] I added at least one link (task, Slack thread, etc.) to explain why this change is needed.


## 📖 Documentation

Updated the eval table in `apps/auth0-evals/README.md`. No new primitives, levels or flags, so the other docs stay accurate.

- [x] I reflected this change in the (internal and/or user-facing) documentation, or explained why no update is needed.


## 🎯 Testing

`npm run build && npm test && npm run lint` pass. No framework logic changed, so no new package tests.

Ran the deterministic graders against the bare scaffolds and against a hand-written correct solution for each platform: everything positive fails on the scaffold, everything passes on the correct solution. That caught two graders the scaffold itself already satisfied, now scoped to the step-up request.

10/10 jobs green:

| Eval | baseline | agent | agent+skills | agent+mcp | agent+mcp+skills |
| --- | --- | --- | --- | --- | --- |
| `swift_mfa` | 5/11 | 10/13 · 87.2 B | 13/13 · 95.8 A | 7/15 · 71.8 C | 11/15 · 84.5 B |
| `android_mfa` | 7/13 | 13/15 · 78.8 B | 13/15 · 83.7 B | 14/17 · 85.1 B | 16/17 · 97 A |

Failures are specific, not noisy: one run never used `acr_values` at all, two hand-rolled Base64 JWT parsing, one set `withMaxAge(0)` only behind a flag the MFA path passed as `false`, one short-circuited the `amr` check on a session boolean.

Ignore the baseline column — two pre-existing framework bugs make it meaningless. `runBaseline` sets no `maxOutputTokens` and doesn't disable thinking, so on Opus 5 the answer goes to reasoning tokens (`swift_mfa` returned 0 characters). And baseline judges always see an empty corpus, because `gradeText` writes to `llm_response.txt` and the judge excludes `.txt`. Follow-ups to come; neither is caused by this PR.

- [x] I described how I tested these changes, or explained why I did not.
- [ ] This change has integration, unit, or performance test coverage, or I explained why it does not.
