### PR TITLE
feat(axis): switch to AXIS-style HTML report and fix cost for codex/gemini

### DIFF
--- a/apps/auth0-evals/axis.config.ts
+++ b/apps/auth0-evals/axis.config.ts
@@ -48,7 +48,6 @@ const modelOverride = process.env.AXIS_MODEL?.trim() || undefined;
 // Set CLAUDE_CODE_USE_BEDROCK_PROXY=1 to use full `global.anthropic.*` model IDs
 // (required by the Bedrock proxy); otherwise short aliases are used.
 const useBedrock = process.env.CLAUDE_CODE_USE_BEDROCK_PROXY === '1';
-const CLAUDE_SONNET_5 = useBedrock ? 'global.anthropic.claude-sonnet-5' : 'claude-sonnet-5';
 const CLAUDE_OPUS_5 = useBedrock ? 'global.anthropic.claude-opus-5' : 'claude-opus-5';
 
 const evalConfigs = discoverEvals('src/evals', APP_ROOT).filter((cfg) => evalFilter === null || evalFilter.has(cfg.id));
@@ -94,7 +93,7 @@ const scenarios = evalConfigs.map((cfg) => {
 // Models match eval.config.js's known list so proxy aliases resolve correctly.
 // Override the default for all agents with --model (or AXIS_MODEL env var).
 const allAgents: AxisConfig['agents'] = [
-  { agent: 'claude-code', model: CLAUDE_SONNET_5 },
+  { agent: 'claude-code', model: CLAUDE_OPUS_5 },
   // codex 0.140+ removed --full-auto (the AXIS default) in favour of
   // --dangerously-bypass-approvals-and-sandbox for headless execution.
   // Proxy config is injected via the `codex` wrapper prepended to PATH by

--- a/apps/auth0-evals/axis.config.ts
+++ b/apps/auth0-evals/axis.config.ts
@@ -100,7 +100,7 @@ const allAgents: AxisConfig['agents'] = [
   // apps/auth0-evals/src/axis/run.ts at startup.
   {
     agent: 'codex',
-    model: 'gpt-5.6-luna',
+    model: 'gpt-5.6-sol',
     flags: { 'full-auto': false, 'dangerously-bypass-approvals-and-sandbox': true },
   },
   { agent: 'gemini', model: 'gemini-3.1-pro-preview' },

--- a/apps/auth0-evals/src/axis/run.ts
+++ b/apps/auth0-evals/src/axis/run.ts
@@ -191,5 +191,5 @@ writeFileSync(scoresPath, JSON.stringify(scores, null, 2), 'utf-8');
 console.log(`[axis] Scores: ${scoresPath}`);
 
 const reportPath = join(APP_ROOT, 'report-axis.html');
-writeFileSync(reportPath, generateReportHtml(buildReportManifest(scoredOutput)), 'utf-8');
+writeFileSync(reportPath, generateReportHtml(buildReportManifest(scoredOutput, graderResults)), 'utf-8');
 console.log(`[axis] Report: ${reportPath}`);

--- a/apps/auth0-evals/src/axis/run.ts
+++ b/apps/auth0-evals/src/axis/run.ts
@@ -5,7 +5,7 @@
  * runs AXIS and layers our graders on top of every job result.
  *
  * After the run, writes scores-axis.json (same format as scores-agent.json)
- * and auto-generates report-axis.html using the existing evals reporter.
+ * and auto-generates report-axis.html using @netlify/axis's generateReportHtml().
  *
  * Usage:
  *   npm run axis
@@ -15,9 +15,9 @@
 
 /* eslint-disable no-console */
 
-import { runAxis, buildAxisScores } from '@a0/evals-axis';
+import { runAxis, buildAxisScores, buildReportManifest } from '@a0/evals-axis';
 import { setFrameworkConfig, loadConfig, discoverEvals } from '@a0/evals-core';
-import { renderHtml } from '@a0/evals-reporter';
+import { generateReportHtml } from '@netlify/axis';
 import { config as loadDotenv } from 'dotenv';
 import { execFileSync } from 'node:child_process';
 import { mkdtempSync, writeFileSync } from 'node:fs';
@@ -190,14 +190,6 @@ const scoresPath = typeof flags.output === 'string' ? flags.output : join(APP_RO
 writeFileSync(scoresPath, JSON.stringify(scores, null, 2), 'utf-8');
 console.log(`[axis] Scores: ${scoresPath}`);
 
-const now = new Date();
-const generatedAt =
-  `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}` +
-  ` ${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
 const reportPath = join(APP_ROOT, 'report-axis.html');
-// renderHtml's input type is Record<string, unknown>[] — a loose signature that
-// predates the typed JobResult union. AgentJobResult is structurally compatible
-// but TypeScript rejects the direct assignment due to the index signature gap,
-// so the double cast is intentional rather than masking a real type mismatch.
-writeFileSync(reportPath, renderHtml(scores as unknown as Record<string, unknown>[], generatedAt), 'utf-8');
+writeFileSync(reportPath, generateReportHtml(buildReportManifest(scoredOutput)), 'utf-8');
 console.log(`[axis] Report: ${reportPath}`);

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -122,7 +122,7 @@ Bottom-up, with a clean acyclic dependency graph (`@a0/evals-graders` is the lea
 
 ### `@a0/evals-axis`
 - **Purpose**: AXIS integration bridge.
-- **Responsibilities**: Wraps `@netlify/axis` `run()` and layers auth0-evals graders on top of every job result. Exposes `runAxis()` (orchestrates the full AXIS run + grader hook) and `buildAxisScores()` (maps `ScoredOutput` + `GraderResult[]` into the `AgentJobResult[]` shape that `@a0/evals-reporter` expects). The grader hook (`runAuth0Graders`) fires inside the `onResult` callback — before AXIS tears down the workspace — and runs L1–L4 graders against the live workspace. `axisTranscriptToToolCalls()` translates the AXIS transcript into the `EventToolCall[]` format the grader engine understands.
+- **Responsibilities**: Wraps `@netlify/axis` `run()` and layers auth0-evals graders on top of every job result. Exposes `runAxis()` (orchestrates the full AXIS run + grader hook), `buildAxisScores()` (maps `ScoredOutput` + `GraderResult[]` into the `AgentJobResult[]` shape that `@a0/evals-reporter` expects, written as `scores-axis.json`), and `buildReportManifest()` (converts `ScoredOutput` + `GraderResult[]` into the `ReportManifest` consumed by `@netlify/axis`'s `generateReportHtml()`, written as `report-axis.html`). The grader hook (`runAuth0Graders`) fires inside the `onResult` callback — before AXIS tears down the workspace — and runs L1–L4 graders against the live workspace. `axisTranscriptToToolCalls()` translates the AXIS transcript into the `EventToolCall[]` format the grader engine understands.
 - **Dependencies**: `@a0/evals-core`, `@a0/evals-graders`, `@netlify/axis`.
 - **Type**: Application infrastructure / bridge.
 
@@ -251,6 +251,7 @@ sequenceDiagram
     end
     box rgba(243,232,255,0.55) Output
         participant Build as buildAxisScores()
+        participant Manifest as buildReportManifest()
         participant Out as scores-axis.json + report-axis.html
     end
 
@@ -270,12 +271,14 @@ sequenceDiagram
     Axis->>Axis: AXIS 4-dimension judge (goal / environment / service / agent)
     Axis-->>Run: { scoredOutput, graderResults }
     Run->>Build: buildAxisScores(scoredOutput, graderResults)
-    Build-->>Out: AgentJobResult[] → scores-axis.json + report-axis.html
+    Build-->>Out: AgentJobResult[] → scores-axis.json
+    Run->>Manifest: buildReportManifest(scoredOutput, graderResults)
+    Manifest-->>Out: ReportManifest → generateReportHtml() → report-axis.html
 ```
 
 ### How AXIS and auth0-evals scoring combine
 
-AXIS scores every job on **4 dimensions** (0–10 each) via its own LLM judge. auth0-evals adds **L1–L4 grader pass rates** alongside. `buildAxisScores()` maps the combined result into the same `AgentJobResult` shape that `a0-eval run` produces, so `npm run report` renders both in a unified leaderboard.
+AXIS scores every job on **4 dimensions** (0–10 each) via its own LLM judge. auth0-evals adds **L1–L4 grader pass rates** alongside. `buildAxisScores()` maps the combined result into the same `AgentJobResult` shape that `a0-eval run` produces, written as `scores-axis.json` so `npm run report` renders both in a unified leaderboard. `buildReportManifest()` converts the same data into the `ReportManifest` shape consumed by `@netlify/axis`'s `generateReportHtml()`, producing `report-axis.html` — the native AXIS report UI.
 
 | Source | What it measures |
 |---|---|
@@ -293,7 +296,7 @@ AXIS scores every job on **4 dimensions** (0–10 each) via its own LLM judge. a
 | Agents | one model/runner per run | claude-code, codex, gemini in one pass |
 | Scoring | 8-dimension weighted sum | AXIS 4-dimension judge + grader pass rates |
 | Modes | baseline, agent, agent+mcp, … | agent only (no baseline, no MCP toggle) |
-| Output | `scores-agent.json` / `scores-baseline.json` | `scores-axis.json` |
+| Output | `scores-agent.json` / `scores-baseline.json` | `scores-axis.json` + `report-axis.html` |
 
 ## Scoring — 8 dimensions
 

--- a/packages/evals-axis/src/index.ts
+++ b/packages/evals-axis/src/index.ts
@@ -3,4 +3,4 @@ export { runAuth0Graders } from './grader-hook.js';
 export type { RunAuth0GradersOptions } from './grader-hook.js';
 export { runAxis } from './run.js';
 export type { RunAxisOptions, RunAxisResult } from './run.js';
-export { buildAxisScores, scoreToGrade } from './report.js';
+export { buildAxisScores, buildReportManifest, scoreToGrade } from './report.js';

--- a/packages/evals-axis/src/report.ts
+++ b/packages/evals-axis/src/report.ts
@@ -6,7 +6,7 @@
  * run entry point, which triggers side-effects on import.
  */
 
-import type { ScoredOutput, TranscriptEntry } from '@netlify/axis';
+import type { ScoredOutput, TranscriptEntry, ReportManifest } from '@netlify/axis';
 import type { GraderResult } from '@a0/evals-graders';
 import type { AgentJobResult, AgentType, DimensionSummary, GraderSummary } from '@a0/evals-core';
 import { estimateCost } from '@a0/evals-core';
@@ -188,6 +188,42 @@ export function buildAxisScores(
       turn_metrics: [],
     };
   });
+}
+
+/**
+ * Maps AXIS ScoredOutput to a ReportManifest consumed by @netlify/axis's
+ * generateReportHtml(), producing the official AXIS-style HTML report.
+ */
+export function buildReportManifest(output: ScoredOutput): ReportManifest {
+  return {
+    version: output.version,
+    reportId: `auth0-evals-${output.timestamp}`,
+    name: 'Auth0 SDK Evals',
+    timestamp: output.timestamp,
+    durationMs: output.durationMs,
+    summary: output.summary,
+    results: output.results.map((result) => ({
+      scenarioKey: result.scenarioKey,
+      scenarioName: result.scenarioName,
+      agentName: result.agentName,
+      durationMs: result.output.metadata.durationMs,
+      exitCode: result.output.metadata.exitCode,
+      failed: result.output.metadata.exitCode !== 0 || !!result.output.metadata.error,
+      tokenUsage: result.output.metadata.tokenUsage,
+      totalCostUsd: result.output.metadata.totalCostUsd,
+      score: result.score,
+      error: result.output.metadata.error,
+      // No per-run result files are written — drill-down links are unavailable.
+      file: '',
+      prompt: result.prompt,
+      judge: result.judge,
+      agentConfig: result.agentConfig,
+      resolvedConfig: result.resolvedConfig,
+      artifacts: result.artifacts,
+      setupOutput: result.setupOutput,
+      teardownOutput: result.teardownOutput,
+    })),
+  };
 }
 
 /** Maps a 0–100 score to a letter grade using the framework's thresholds. */

--- a/packages/evals-axis/src/report.ts
+++ b/packages/evals-axis/src/report.ts
@@ -31,6 +31,27 @@ const AXIS_AGENT_TO_TYPE: Record<string, AgentType> = {
 const INTERRUPTION_TOOL_NAMES = new Set(['AskUserQuestion', 'ask_user']);
 
 /**
+ * Infers agent inference cost from an AXIS result metadata block.
+ *
+ * AXIS only populates totalCostUsd for adapters that receive cost from the
+ * protocol (currently claude-code only). For codex and gemini the field is
+ * undefined even though tokenUsage is present, so we fall back to estimateCost()
+ * using the model's pricing table entry. Returns undefined when neither is available
+ * (used by buildReportManifest so the HTML report omits the column rather than
+ * showing $0.0000).
+ */
+function inferAgentCost(
+  agentName: string,
+  metadata: { totalCostUsd?: number; tokenUsage?: { input: number; output: number } },
+): number | undefined {
+  if (metadata.totalCostUsd != null) return metadata.totalCostUsd;
+  const [, model] = agentName.split('|');
+  const resolvedModel = model ?? agentName;
+  if (metadata.tokenUsage) return estimateCost(resolvedModel, metadata.tokenUsage.input, metadata.tokenUsage.output);
+  return undefined;
+}
+
+/**
  * Sums token usage across judge grader results and estimates cost.
  * Mirrors the private computeJudgeCost helper in @a0/evals-core serializers.
  */
@@ -153,13 +174,15 @@ export function buildAxisScores(
     });
 
     const tokenUsage = result.output.metadata.tokenUsage;
+    const resolvedModel = model ?? result.agentName;
+    const inferredCost = inferAgentCost(result.agentName, result.output.metadata) ?? 0;
 
     return {
       eval_id: result.scenarioKey,
       category: categories[result.scenarioKey] ?? '',
       prompt: result.prompt,
       response_text: result.output.result ?? '',
-      model: model ?? result.agentName,
+      model: resolvedModel,
       mode: 'agent',
       agent_type: agentType,
       tools: ['axis'],
@@ -179,9 +202,9 @@ export function buildAxisScores(
         result.output.transcript.filter((e) => e.type === 'tool_use').length,
       interruptions: countInterruptions(result.output.transcript),
       tokens: tokenUsage ? tokenUsage.input + tokenUsage.output + (tokenUsage.cacheReadInput ?? 0) : 0,
-      cost_usd: result.output.metadata.totalCostUsd ?? 0,
+      cost_usd: inferredCost,
       judge_cost_usd: judgeCost,
-      total_cost_usd: (result.output.metadata.totalCostUsd ?? 0) + judgeCost,
+      total_cost_usd: inferredCost + judgeCost,
       dimensions,
       graders: graderSummaries,
       session_trace: [],
@@ -210,7 +233,7 @@ export function buildReportManifest(output: ScoredOutput): ReportManifest {
       exitCode: result.output.metadata.exitCode,
       failed: result.output.metadata.exitCode !== 0 || !!result.output.metadata.error,
       tokenUsage: result.output.metadata.tokenUsage,
-      totalCostUsd: result.output.metadata.totalCostUsd,
+      totalCostUsd: inferAgentCost(result.agentName, result.output.metadata),
       score: result.score,
       error: result.output.metadata.error,
       // No per-run result files are written — drill-down links are unavailable.

--- a/packages/evals-axis/src/report.ts
+++ b/packages/evals-axis/src/report.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 /**
  * Maps AXIS ScoredOutput + auth0-evals grader results to AgentJobResult[],
  * the format consumed by @a0/evals-reporter's renderHtml().
@@ -175,7 +177,11 @@ export function buildAxisScores(
 
     const tokenUsage = result.output.metadata.tokenUsage;
     const resolvedModel = model ?? result.agentName;
-    const inferredCost = inferAgentCost(result.agentName, result.output.metadata) ?? 0;
+    const rawCost = inferAgentCost(result.agentName, result.output.metadata);
+    if (rawCost === undefined) {
+      console.debug(`[report] Cost unavailable for ${result.agentName} — cost_usd will show $0`);
+    }
+    const inferredCost = rawCost ?? 0;
 
     return {
       eval_id: result.scenarioKey,
@@ -217,7 +223,10 @@ export function buildAxisScores(
  * Maps AXIS ScoredOutput to a ReportManifest consumed by @netlify/axis's
  * generateReportHtml(), producing the official AXIS-style HTML report.
  */
-export function buildReportManifest(output: ScoredOutput): ReportManifest {
+export function buildReportManifest(
+  output: ScoredOutput,
+  allGraderResults: Map<string, GraderResult[]> = new Map(),
+): ReportManifest {
   return {
     version: output.version,
     reportId: `auth0-evals-${output.timestamp}`,
@@ -225,27 +234,36 @@ export function buildReportManifest(output: ScoredOutput): ReportManifest {
     timestamp: output.timestamp,
     durationMs: output.durationMs,
     summary: output.summary,
-    results: output.results.map((result) => ({
-      scenarioKey: result.scenarioKey,
-      scenarioName: result.scenarioName,
-      agentName: result.agentName,
-      durationMs: result.output.metadata.durationMs,
-      exitCode: result.output.metadata.exitCode,
-      failed: result.output.metadata.exitCode !== 0 || !!result.output.metadata.error,
-      tokenUsage: result.output.metadata.tokenUsage,
-      totalCostUsd: inferAgentCost(result.agentName, result.output.metadata),
-      score: result.score,
-      error: result.output.metadata.error,
-      // No per-run result files are written — drill-down links are unavailable.
-      file: '',
-      prompt: result.prompt,
-      judge: result.judge,
-      agentConfig: result.agentConfig,
-      resolvedConfig: result.resolvedConfig,
-      artifacts: result.artifacts,
-      setupOutput: result.setupOutput,
-      teardownOutput: result.teardownOutput,
-    })),
+    results: output.results.map((result) => {
+      const key = `${result.scenarioKey}|${result.agentName}`;
+      const judgeCost = computeJudgeCost(allGraderResults.get(key) ?? []);
+      const agentCost = inferAgentCost(result.agentName, result.output.metadata);
+      if (agentCost === undefined) {
+        console.debug(`[manifest] Cost unavailable for ${result.scenarioKey} / ${result.agentName}`);
+      }
+      const totalCostUsd = agentCost !== undefined ? agentCost + judgeCost : undefined;
+      return {
+        scenarioKey: result.scenarioKey,
+        scenarioName: result.scenarioName,
+        agentName: result.agentName,
+        durationMs: result.output.metadata.durationMs,
+        exitCode: result.output.metadata.exitCode,
+        failed: result.output.metadata.exitCode !== 0 || !!result.output.metadata.error,
+        tokenUsage: result.output.metadata.tokenUsage,
+        totalCostUsd,
+        score: result.score,
+        error: result.output.metadata.error,
+        // No per-run result files are written — drill-down links are unavailable.
+        file: '',
+        prompt: result.prompt,
+        judge: result.judge,
+        agentConfig: result.agentConfig,
+        resolvedConfig: result.resolvedConfig,
+        artifacts: result.artifacts,
+        setupOutput: result.setupOutput,
+        teardownOutput: result.teardownOutput,
+      };
+    }),
   };
 }
 

--- a/packages/evals-axis/tests/report.test.ts
+++ b/packages/evals-axis/tests/report.test.ts
@@ -274,6 +274,48 @@ describe('buildAxisScores', () => {
     expect(result.total_cost_usd).toBeCloseTo(0.06, 6);
   });
 
+  it('estimates cost from tokenUsage when totalCostUsd is absent (codex/gemini case)', () => {
+    // gpt-5.6-sol: $5/M input, $30/M output → (1000×5 + 500×30) / 1_000_000 = 0.02
+    const output = makeScoredOutput({
+      agentName: 'codex|gpt-5.6-sol',
+      tokenUsage: { input: 1000, output: 500 },
+      // totalCostUsd intentionally absent
+    });
+    const [result] = buildAxisScores(output, new Map());
+
+    expect(result.cost_usd).toBeCloseTo(0.02, 6);
+    expect(result.total_cost_usd).toBeCloseTo(0.02, 6);
+  });
+
+  it('estimates cost from tokenUsage for gemini when totalCostUsd is absent', () => {
+    // gemini-3.1-pro-preview: $2/M input, $12/M output → (1000×2 + 500×12) / 1_000_000 = 0.008
+    const output = makeScoredOutput({
+      agentName: 'gemini|gemini-3.1-pro-preview',
+      tokenUsage: { input: 1000, output: 500 },
+    });
+    const [result] = buildAxisScores(output, new Map());
+
+    expect(result.cost_usd).toBeCloseTo(0.008, 6);
+  });
+
+  it('sets cost_usd to 0 when both totalCostUsd and tokenUsage are absent', () => {
+    const output = makeScoredOutput({});
+    const [result] = buildAxisScores(output, new Map());
+
+    expect(result.cost_usd).toBe(0);
+    expect(result.total_cost_usd).toBe(0);
+  });
+
+  it('prefers totalCostUsd over tokenUsage-based estimate when both are present', () => {
+    const output = makeScoredOutput({
+      totalCostUsd: 0.05,
+      tokenUsage: { input: 1000, output: 500 },
+    });
+    const [result] = buildAxisScores(output, new Map());
+
+    expect(result.cost_usd).toBe(0.05);
+  });
+
   it('sets judge_cost_usd to 0 when graders have no token usage', () => {
     const graders: GraderResult[] = [{ name: 'Uses SDK', kind: 'contains', passed: true, detail: 'found' }];
     const output = makeScoredOutput({ totalCostUsd: 0.02 });
@@ -474,6 +516,24 @@ describe('buildReportManifest', () => {
     const [entry] = buildReportManifest(output).results;
 
     expect(entry.totalCostUsd).toBe(0.05);
+  });
+
+  it('estimates totalCostUsd from tokenUsage when absent (codex/gemini case)', () => {
+    // gpt-5.6-sol: $5/M input, $30/M output → (1000×5 + 500×30) / 1_000_000 = 0.02
+    const output = makeScoredOutput({
+      agentName: 'codex|gpt-5.6-sol',
+      tokenUsage: { input: 1000, output: 500 },
+    });
+    const [entry] = buildReportManifest(output).results;
+
+    expect(entry.totalCostUsd).toBeCloseTo(0.02, 6);
+  });
+
+  it('leaves totalCostUsd undefined when both are absent', () => {
+    const output = makeScoredOutput({});
+    const [entry] = buildReportManifest(output).results;
+
+    expect(entry.totalCostUsd).toBeUndefined();
   });
 
   it('produces one entry per result', () => {

--- a/packages/evals-axis/tests/report.test.ts
+++ b/packages/evals-axis/tests/report.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildAxisScores, countInterruptions, scoreToGrade } from '../src/report.js';
+import { buildAxisScores, buildReportManifest, countInterruptions, scoreToGrade } from '../src/report.js';
 import type { ScoredOutput } from '@netlify/axis';
 import type { GraderResult } from '@a0/evals-graders';
 
@@ -397,5 +397,89 @@ describe('buildAxisScores', () => {
     const [result] = buildAxisScores(output, new Map());
 
     expect(result.interruptions).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildReportManifest
+// ---------------------------------------------------------------------------
+
+describe('buildReportManifest', () => {
+  it('passes through top-level fields from ScoredOutput', () => {
+    const output = makeScoredOutput({});
+    const manifest = buildReportManifest(output);
+
+    expect(manifest.version).toBe('1');
+    expect(manifest.timestamp).toBe('2026-01-01T00:00:00Z');
+    expect(manifest.durationMs).toBe(1000);
+    expect(manifest.summary).toEqual({ total: 1, completed: 1, failed: 0 });
+    expect(manifest.name).toBe('Auth0 SDK Evals');
+  });
+
+  it('generates reportId from timestamp', () => {
+    const output = makeScoredOutput({});
+    const manifest = buildReportManifest(output);
+
+    expect(manifest.reportId).toBe('auth0-evals-2026-01-01T00:00:00Z');
+  });
+
+  it('maps result fields to ReportResultEntry', () => {
+    const output = makeScoredOutput({ scenarioKey: 'react_quickstart', axisScore: 80 });
+    const manifest = buildReportManifest(output);
+    const [entry] = manifest.results;
+
+    expect(entry.scenarioKey).toBe('react_quickstart');
+    expect(entry.scenarioName).toBe('react_quickstart');
+    expect(entry.agentName).toBe('claude-code|global.anthropic.claude-opus-4-8');
+    expect(entry.durationMs).toBe(1000);
+    expect(entry.exitCode).toBe(0);
+    expect(entry.prompt).toBe('Test prompt');
+    expect(entry.judge).toBe('Did it work?');
+    expect(entry.score).toBeDefined();
+    expect(entry.file).toBe('');
+  });
+
+  it('sets failed to false when exitCode is 0 and no error', () => {
+    const output = makeScoredOutput({ exitCode: 0 });
+    const [entry] = buildReportManifest(output).results;
+
+    expect(entry.failed).toBe(false);
+  });
+
+  it('sets failed to true when exitCode is non-zero', () => {
+    const output = makeScoredOutput({ exitCode: 1 });
+    const [entry] = buildReportManifest(output).results;
+
+    expect(entry.failed).toBe(true);
+  });
+
+  it('sets failed to true when error is present', () => {
+    const output = makeScoredOutput({ exitCode: 0 });
+    output.results[0].output.metadata.error = 'agent timed out';
+    const [entry] = buildReportManifest(output).results;
+
+    expect(entry.failed).toBe(true);
+    expect(entry.error).toBe('agent timed out');
+  });
+
+  it('passes through tokenUsage when present', () => {
+    const output = makeScoredOutput({ tokenUsage: { input: 1000, output: 500 } });
+    const [entry] = buildReportManifest(output).results;
+
+    expect(entry.tokenUsage).toEqual({ input: 1000, output: 500 });
+  });
+
+  it('passes through totalCostUsd when present', () => {
+    const output = makeScoredOutput({ totalCostUsd: 0.05 });
+    const [entry] = buildReportManifest(output).results;
+
+    expect(entry.totalCostUsd).toBe(0.05);
+  });
+
+  it('produces one entry per result', () => {
+    const output = makeScoredOutput({});
+    const manifest = buildReportManifest(output);
+
+    expect(manifest.results).toHaveLength(1);
   });
 });

--- a/packages/evals-axis/tests/report.test.ts
+++ b/packages/evals-axis/tests/report.test.ts
@@ -529,11 +529,48 @@ describe('buildReportManifest', () => {
     expect(entry.totalCostUsd).toBeCloseTo(0.02, 6);
   });
 
-  it('leaves totalCostUsd undefined when both are absent', () => {
+  it('leaves totalCostUsd undefined when both are absent even with judge cost', () => {
+    const graders: GraderResult[] = [
+      {
+        name: 'Holistic judge',
+        kind: 'judge',
+        passed: true,
+        detail: 'yes',
+        inputTokens: 1000,
+        outputTokens: 200,
+        judgeModel: 'claude-opus-5',
+      },
+    ];
     const output = makeScoredOutput({});
-    const [entry] = buildReportManifest(output).results;
+    const map = new Map([['react_quickstart|claude-code|global.anthropic.claude-opus-4-8', graders]]);
+    const [entry] = buildReportManifest(output, map).results;
 
     expect(entry.totalCostUsd).toBeUndefined();
+  });
+
+  it('adds judge cost to totalCostUsd when agent cost is available', () => {
+    // gpt-5.6-sol agent cost: (1000×5 + 500×30) / 1_000_000 = 0.02
+    // claude-opus-5 judge: (1000×5 + 200×25) / 1_000_000 = 0.01
+    // total = 0.03
+    const graders: GraderResult[] = [
+      {
+        name: 'Holistic judge',
+        kind: 'judge',
+        passed: true,
+        detail: 'yes',
+        inputTokens: 1000,
+        outputTokens: 200,
+        judgeModel: 'claude-opus-5',
+      },
+    ];
+    const output = makeScoredOutput({
+      agentName: 'codex|gpt-5.6-sol',
+      tokenUsage: { input: 1000, output: 500 },
+    });
+    const map = new Map([['react_quickstart|codex|gpt-5.6-sol', graders]]);
+    const [entry] = buildReportManifest(output, map).results;
+
+    expect(entry.totalCostUsd).toBeCloseTo(0.03, 6);
   });
 
   it('produces one entry per result', () => {


### PR DESCRIPTION
## Summary

- Switches `report-axis.html` to use `generateReportHtml()` from `@netlify/axis`, producing the native AXIS UI (same as axis.run/sample-report)
- Sets `claude-opus-5` as default model for claude-code runner and `gpt-5.6-sol` for codex
- Fixes missing cost for codex and gemini agents — AXIS only populates `totalCostUsd` for the claude-code adapter; now falls back to `estimateCost()` from token usage in both `buildAxisScores()` and `buildReportManifest()`
- Adds judge cost to `totalCostUsd` in `buildReportManifest()` so `report-axis.html` and `scores-axis.json` show consistent totals
- Updates `ARCHITECTURE.md` to document the `buildReportManifest()` path

## Test plan

- [ ] Download `report-axis.html` from a CI run and verify it matches the AXIS native UI
- [ ] Verify `scores-axis.json` shows non-zero `cost_usd` for codex and gemini agents
- [ ] `npm run build && npm test` passes