### PR TITLE
chore: bump package versions to 0.1.2

### DIFF
--- a/apps/auth0-evals/package.json
+++ b/apps/auth0-evals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-evals",
-  "version": "0.1.2",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "build": "tsc",

--- a/apps/auth0-evals/package.json
+++ b/apps/auth0-evals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-evals",
-  "version": "1.0.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "build": "tsc",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6381,7 +6381,7 @@
     },
     "packages/evals": {
       "name": "@a0/evals",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@a0/evals-core": "*",
         "@a0/evals-reporter": "*",
@@ -6423,7 +6423,7 @@
     },
     "packages/evals-core": {
       "name": "@a0/evals-core",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@a0/evals-graders": "*"
       },
@@ -6435,7 +6435,7 @@
     },
     "packages/evals-graders": {
       "name": "@a0/evals-graders",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "devDependencies": {
         "@types/node": "^26.2.0",
         "@vitest/coverage-v8": "^4.1.9",
@@ -6444,7 +6444,7 @@
     },
     "packages/evals-reporter": {
       "name": "@a0/evals-reporter",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@a0/evals-core": "*",
         "@a0/evals-graders": "*",

--- a/packages/evals-core/package.json
+++ b/packages/evals-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a0/evals-core",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/evals-graders/package.json
+++ b/packages/evals-graders/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a0/evals-graders",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/evals-reporter/package.json
+++ b/packages/evals-reporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a0/evals-reporter",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a0/evals",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Changes

Bumps the version field in five package manifests from their previous values to `0.1.2`. `evals-axis` is excluded and stays at `1.0.0`.

| Package | Before | After |
|---|---|---|
| `auth0-evals` (app) | `1.0.1` | `0.1.2` |
| `@a0/evals-core` | `0.1.1` | `0.1.2` |
| `@a0/evals-graders` | `0.1.1` | `0.1.2` |
| `@a0/evals-reporter` | `0.1.1` | `0.1.2` |
| `@a0/evals` | `0.1.1` | `0.1.2` |

No logic or dependency changes.

- [x] I described the changes on this PR.


## 🔮 Type of Change

- [ ] Standard
- [ ] Emergency
- [ ] Significant


## 🔗 References

- [ ] I added at least one link (task, Slack thread, etc.) to explain why this change is needed.

- [GitHub Actions](https://github.com/auth0/auth0-evals/actions?query=branch%3Achore%2Fbump-package-versions-0.1.2)

## 📖 Documentation

No documentation changes needed -- version bumps only.

- [x] I reflected this change in the documentation, or explained why no update is needed.


## 🎯 Testing

Version-only change; no logic to test.

- [x] I described how I tested these changes, or explained why I did not.
- [x] This change has integration, unit, or performance test coverage, or I explained why it does not.


## 🚀 Deployment

- [ ] This change can support multiple releases of the code serving traffic at the same time.
- [ ] This can be deployed at any time. If there are prerequisites, I listed them below and will ensure they are met before merging.


## 🔥 Rollback

- [ ] I explained what rollback for this change looks like and how we recover quickly.

<sub>🤖 via /[writing-prs](https://github.com/atko-cic/claude-marketplace/blob/main/plugins/auth0-developer-tools/skills/writing-prs/SKILL.md)</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated package versions to `0.1.2` across the evaluation tools and related packages.
  - No user-facing functionality or public API changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->