### PR TITLE
chore(evals-axis): align version to 0.1.0

### DIFF
--- a/packages/evals-axis/package.json
+++ b/packages/evals-axis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a0/evals-axis",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Sets `@a0/evals-axis` version to `0.1.0` to match the `0.x.x` convention used by all other packages in the monorepo (`evals-core`, `evals-graders`, `evals-reporter`, `evals`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to 0.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->