### PR TITLE
feat(evals): add MFA API evals for auth0-auth-js and auth0-server-js

### DIFF
--- a/apps/auth0-evals/src/evals/mfa/auth0-auth-js/PROMPT.md
+++ b/apps/auth0-evals/src/evals/mfa/auth0-auth-js/PROMPT.md
@@ -1,0 +1,25 @@
+---
+id: auth0_auth_js_mfa
+name: Auth0 Auth JS MFA
+scaffold: src/evals/scaffolds/auth0-auth-js/auth0
+skills: auth0
+setup_command: npm install
+compile_command: npm run build
+---
+
+## Task
+
+Barkbook's auth service signs users in with their username and password and hands back tokens. We just turned on multi-factor authentication in our Auth0 tenant, and now sign-in fails for any user the policy applies to.
+
+Add multi-factor support to the service, as HTTP routes my mobile client can drive:
+
+- A user who has no second factor yet should be able to set up an authenticator app — return whatever the app needs to show a QR code.
+- A user who already has a factor should be prompted for the code from their app instead.
+- Either way, once they submit a valid code, sign-in finishes and we hand back tokens like we do today.
+- Someone who has lost their phone should be able to finish sign-in with a recovery code.
+- Let a user see the factors on their account and remove one they no longer use.
+
+Domain: dev-barkbook.us.auth0.com
+Client ID: barkbook_client_abc123xyz
+Client Secret: barkbook_secret_def456uvw
+Audience: https://api.barkbook.com

--- a/apps/auth0-evals/src/evals/mfa/auth0-auth-js/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/auth0-auth-js/graders.ts
@@ -1,0 +1,87 @@
+import { contains, notContains, notContainsInSource, matches, judge, compiles, GraderLevel } from '@a0/evals-graders';
+
+export function defineGraders() {
+  return [
+    // ── L1: Required MFA symbols present ──────────────────────────────────
+    contains('isMfaRequiredError', 'Detects mfa_required via the isMfaRequiredError type guard', GraderLevel.L1),
+    contains('mfa_token', 'Reads the MFA token off the error cause', GraderLevel.L1),
+    contains('mfaToken', 'Passes the token to MFA methods as mfaToken', GraderLevel.L1),
+    contains('listAuthenticators', 'Lists enrolled authenticators', GraderLevel.L1),
+    contains('enrollAuthenticator', 'Enrolls a new authenticator', GraderLevel.L1),
+    contains('challengeAuthenticator', 'Challenges an enrolled authenticator', GraderLevel.L1),
+    contains('deleteAuthenticator', 'Removes an enrolled authenticator', GraderLevel.L1),
+    contains('authenticatorTypes', 'Enrollment passes authenticatorTypes', GraderLevel.L1),
+    contains('factorType', 'Verify passes the factorType discriminator', GraderLevel.L1),
+    contains('barcodeUri', 'Surfaces the OTP barcodeUri for QR enrollment', GraderLevel.L1),
+
+    // ── L2: Hallucination / wrong approach ────────────────────────────────
+    notContains('mfa/associate', 'Does not hand-roll a call to the /mfa/associate endpoint', GraderLevel.L2),
+    notContains('/oauth/token', 'Does not hand-roll a raw token grant', GraderLevel.L2),
+    notContains('grant-type/mfa-otp', 'Does not build the MFA OTP grant type by hand', GraderLevel.L2),
+    notContains('grant-type/mfa-oob', 'Does not build the MFA OOB grant type by hand', GraderLevel.L2),
+    notContains('speakeasy', 'No server-side TOTP library (speakeasy)', GraderLevel.L2),
+    notContains('otplib', 'No server-side TOTP library (otplib)', GraderLevel.L2),
+    notContains('@auth0/auth0-server-js', 'Does not pull in the sibling server SDK', GraderLevel.L2),
+
+    // ── L3: Security ──────────────────────────────────────────────────────
+    notContainsInSource(
+      'barkbook_secret_def456uvw',
+      'No hardcoded client secret in source files (ok in .env)',
+      GraderLevel.L3,
+    ),
+    notContainsInSource(
+      'barkbook_client_abc123xyz',
+      'No hardcoded client ID in source files (ok in .env)',
+      GraderLevel.L3,
+    ),
+    notContainsInSource(
+      'dev-barkbook.us.auth0.com',
+      'No hardcoded Auth0 domain in source files (ok in .env)',
+      GraderLevel.L3,
+    ),
+    judge(
+      'Does the code avoid writing the MFA token, the OTP secret, the barcodeUri, or recovery codes ' +
+        'to logs or to a persistent store? Returning the barcodeUri and secret in the HTTP response ' +
+        'that starts enrollment is required and acceptable, as is returning a recovery code once. ' +
+        'Only logging them (console.log and friends) or persisting them counts as a violation.',
+      GraderLevel.L3,
+    ),
+
+    // ── L4: Structural correctness ────────────────────────────────────────
+    compiles('Project compiles (build succeeds)', GraderLevel.L4),
+    matches(String.raw`\.mfa\.verify\(`, 'Completes sign-in through the MFA client verify method', GraderLevel.L4),
+    judge(
+      'Does the code branch on whether the user already has a factor — enrolling an authenticator ' +
+        'when they have none and challenging an existing one when they do — before verifying? ' +
+        'Branching on mfa_requirements from the error cause and branching on the result of ' +
+        'listAuthenticators are both acceptable.',
+      GraderLevel.L4,
+    ),
+    judge(
+      'Does the code support finishing sign-in with a recovery code, in addition to the ' +
+        'authenticator-app code path?',
+      GraderLevel.L4,
+    ),
+
+    // ── L5: Current API patterns ──────────────────────────────────────────
+    judge(
+      "Does every MFA operation go through the SDK client's mfa sub-client (enrollAuthenticator, " +
+        'listAuthenticators, challengeAuthenticator, deleteAuthenticator, verify) rather than through ' +
+        'hand-written fetch calls to Auth0 MFA endpoints or a hand-built MFA grant on /oauth/token?',
+      GraderLevel.L5,
+    ),
+    judge(
+      'Is the MFA token read from the error cause as snake_case mfa_token and then passed into the ' +
+        'SDK options as camelCase mfaToken? Passing an option key named mfa_token to an SDK method ' +
+        'is wrong — the option is mfaToken.',
+      GraderLevel.L5,
+    ),
+
+    // ── Holistic judge (no level — always runs) ───────────────────────────
+    judge(
+      'Does the solution correctly use the MFA APIs of @auth0/auth0-auth-js — detecting mfa_required, ' +
+        'lifting the MFA token from the error cause, and then enrolling, listing, challenging, ' +
+        'deleting authenticators and verifying the submitted factor to obtain tokens?',
+    ),
+  ];
+}

--- a/apps/auth0-evals/src/evals/mfa/auth0-server-js/PROMPT.md
+++ b/apps/auth0-evals/src/evals/mfa/auth0-server-js/PROMPT.md
@@ -1,0 +1,26 @@
+---
+id: auth0_server_js_mfa
+name: Auth0 Server JS MFA
+scaffold: src/evals/scaffolds/auth0-server-js/auth0
+skills: auth0
+setup_command: npm install
+compile_command: npm run build
+---
+
+## Task
+
+Barkbook's web app logs users in through Auth0 and calls our transfers API with an access token. We just turned on multi-factor authentication in our Auth0 tenant, and now getting that token fails for any user the policy applies to.
+
+Add multi-factor support to the app:
+
+- A user with no second factor yet should be walked through setting up an authenticator app, including showing them the QR code to scan.
+- A user who already has an authenticator app should just be asked for the code from it.
+- Some of our users enrolled with SMS instead — for them, send the code to their phone and let them type it in.
+- After they submit a valid code, their session should be signed in, so /profile and the transfers call work without logging in again.
+- If Auth0 gives us a recovery code during setup, show it to the user once.
+
+Domain: dev-barkbook.us.auth0.com
+Client ID: barkbook_client_abc123xyz
+Client Secret: barkbook_secret_def456uvw
+Audience: https://api.barkbook.com
+Base URL: http://localhost:3000

--- a/apps/auth0-evals/src/evals/mfa/auth0-server-js/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/auth0-server-js/graders.ts
@@ -1,0 +1,119 @@
+import { contains, notContains, notContainsInSource, matches, judge, compiles, GraderLevel } from '@a0/evals-graders';
+
+export function defineGraders() {
+  return [
+    // ── L1: Required MFA symbols present ──────────────────────────────────
+    contains('isMfaRequiredError', 'Detects mfa_required via the isMfaRequiredError type guard', GraderLevel.L1),
+    contains('mfa_token', 'Reads the MFA token off the error cause', GraderLevel.L1),
+    contains('mfaToken', 'Passes the token to MFA methods as mfaToken', GraderLevel.L1),
+    contains('listAuthenticators', 'Lists enrolled authenticators', GraderLevel.L1),
+    contains('enrollAuthenticator', 'Enrolls a new authenticator', GraderLevel.L1),
+    contains('challengeAuthenticator', 'Challenges an enrolled authenticator', GraderLevel.L1),
+    contains('authenticatorTypes', 'Enrollment passes authenticatorTypes', GraderLevel.L1),
+    contains('factorType', 'Verify passes the factorType discriminator', GraderLevel.L1),
+    contains('barcodeUri', 'Surfaces the OTP barcodeUri for QR enrollment', GraderLevel.L1),
+    contains('oobCode', 'SMS path carries the oobCode from the challenge into verify', GraderLevel.L1),
+    contains('bindingCode', 'SMS verify passes the code the user typed in as bindingCode', GraderLevel.L1),
+    contains('recoveryCode', 'Surfaces the recovery code returned by verify', GraderLevel.L1),
+
+    // ── L2: Hallucination / wrong approach ────────────────────────────────
+    notContains(
+      'deleteAuthenticator',
+      'Does not call deleteAuthenticator — it does not exist on the server MFA client',
+      GraderLevel.L2,
+    ),
+    notContains(
+      '.authClient.mfa',
+      'Does not bypass the server MFA client via the lower-level authClient',
+      GraderLevel.L2,
+    ),
+    notContains(
+      '@auth0/auth0-auth-js',
+      'Does not reach past the server SDK to the lower-level package',
+      GraderLevel.L2,
+    ),
+    notContains('mfa/associate', 'Does not hand-roll a call to the /mfa/associate endpoint', GraderLevel.L2),
+    notContains('/oauth/token', 'Does not hand-roll a raw token grant', GraderLevel.L2),
+    notContains('grant-type/mfa-otp', 'Does not build the MFA OTP grant type by hand', GraderLevel.L2),
+    notContains('speakeasy', 'No server-side TOTP library (speakeasy)', GraderLevel.L2),
+    notContains('otplib', 'No server-side TOTP library (otplib)', GraderLevel.L2),
+
+    // ── L3: Security ──────────────────────────────────────────────────────
+    notContainsInSource(
+      'barkbook_secret_def456uvw',
+      'No hardcoded client secret in source files (ok in .env)',
+      GraderLevel.L3,
+    ),
+    notContainsInSource(
+      'barkbook_session_secret_ghi789rst',
+      'No hardcoded session secret in source files (ok in .env)',
+      GraderLevel.L3,
+    ),
+    notContainsInSource(
+      'barkbook_client_abc123xyz',
+      'No hardcoded client ID in source files (ok in .env)',
+      GraderLevel.L3,
+    ),
+    notContainsInSource(
+      'dev-barkbook.us.auth0.com',
+      'No hardcoded Auth0 domain in source files (ok in .env)',
+      GraderLevel.L3,
+    ),
+    judge(
+      'Does the code avoid writing the MFA token, the OTP secret, the barcodeUri, or the recovery code ' +
+        'to logs, and avoid putting the MFA token in a URL or query string? Rendering the barcodeUri and ' +
+        'secret in the enrollment page, and showing the recovery code once, are required and acceptable. ' +
+        'Holding the MFA token in a signed/httpOnly cookie or server-side session for the duration of ' +
+        'the flow is also acceptable.',
+      GraderLevel.L3,
+    ),
+    judge(
+      'Does the code let the SDK persist the verified tokens in its configured state store, rather than ' +
+        'keeping the access token or refresh token returned by verify in a module-level variable, ' +
+        'an in-memory map, or a separate cookie of its own?',
+      GraderLevel.L3,
+    ),
+
+    // ── L4: Structural correctness ────────────────────────────────────────
+    compiles('Project compiles (build succeeds)', GraderLevel.L4),
+    matches(String.raw`\.mfa\.verify\(`, 'Completes sign-in through the MFA client verify method', GraderLevel.L4),
+    judge(
+      'Does the code branch on the result of listing the enrolled authenticators — enrolling an ' +
+        'authenticator app when the list is empty and challenging an existing factor when it is not?',
+      GraderLevel.L4,
+    ),
+    judge(
+      'Is the request/response store options object passed as the second argument to the MFA verify ' +
+        'call, so the verified session is written for this request? Verify is the only MFA method that ' +
+        'takes store options; omitting it there is the defect being checked.',
+      GraderLevel.L4,
+    ),
+    judge(
+      'For an already-enrolled SMS factor, does the code issue a challenge first and then verify with ' +
+        'the oobCode from that challenge plus the code the user typed in?',
+      GraderLevel.L4,
+    ),
+
+    // ── L5: Current API patterns ──────────────────────────────────────────
+    judge(
+      "Does every MFA operation go through the server client's mfa sub-client (listAuthenticators, " +
+        'enrollAuthenticator, challengeAuthenticator, verify) rather than through hand-written fetch ' +
+        'calls to Auth0 MFA endpoints or a hand-built MFA grant on /oauth/token?',
+      GraderLevel.L5,
+    ),
+    judge(
+      'Is the MFA token read from the error cause as snake_case mfa_token and then passed into the ' +
+        'SDK options as camelCase mfaToken? Passing an option key named mfa_token to an SDK method ' +
+        'is wrong — the option is mfaToken.',
+      GraderLevel.L5,
+    ),
+
+    // ── Holistic judge (no level — always runs) ───────────────────────────
+    judge(
+      'Does the solution correctly use the MFA APIs of @auth0/auth0-server-js — catching mfa_required ' +
+        'when fetching an access token, lifting the MFA token from the error cause, listing the ' +
+        'enrolled authenticators, enrolling or challenging as appropriate, and verifying the submitted ' +
+        'factor so the existing session becomes authenticated?',
+    ),
+  ];
+}

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-auth-js/auth0/package.json
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-auth-js/auth0/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "barkbook-auth-service",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@auth0/auth0-auth-js": "^1.12.1",
+    "dotenv": "^16.4.7",
+    "express": "^5.1.0"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.1",
+    "@types/node": "^22.13.0",
+    "typescript": "~5.8.3"
+  }
+}

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-auth-js/auth0/src/auth0.ts
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-auth-js/auth0/src/auth0.ts
@@ -1,0 +1,9 @@
+import { AuthClient } from '@auth0/auth0-auth-js';
+
+export const authClient = new AuthClient({
+  domain: process.env.AUTH0_DOMAIN as string,
+  clientId: process.env.AUTH0_CLIENT_ID as string,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET,
+});
+
+export const audience = process.env.AUTH0_AUDIENCE;

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-auth-js/auth0/src/index.ts
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-auth-js/auth0/src/index.ts
@@ -1,0 +1,53 @@
+import 'dotenv/config';
+import express from 'express';
+import type { Request, Response } from 'express';
+import { audience, authClient } from './auth0.js';
+
+const app = express();
+app.use(express.json());
+
+app.post('/login', async (request: Request, response: Response) => {
+  const { username, password } = request.body ?? {};
+
+  if (!username || !password) {
+    response.status(400).json({ error: 'username and password are required' });
+    return;
+  }
+
+  try {
+    const tokens = await authClient.getTokenByPassword({
+      username,
+      password,
+      audience,
+      scope: 'openid profile email offline_access',
+    });
+
+    response.json({
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+      expiresAt: tokens.expiresAt,
+    });
+  } catch (error) {
+    response.status(401).json({ error: (error as Error).message });
+  }
+});
+
+app.post('/refresh', async (request: Request, response: Response) => {
+  const { refreshToken } = request.body ?? {};
+
+  if (!refreshToken) {
+    response.status(400).json({ error: 'refreshToken is required' });
+    return;
+  }
+
+  try {
+    const tokens = await authClient.getTokenByRefreshToken({ refreshToken });
+    response.json({ accessToken: tokens.accessToken, expiresAt: tokens.expiresAt });
+  } catch (error) {
+    response.status(401).json({ error: (error as Error).message });
+  }
+});
+
+app.listen(3000, () => {
+  console.log('Barkbook auth service listening on http://localhost:3000');
+});

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-auth-js/auth0/tsconfig.json
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-auth-js/auth0/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "moduleDetection": "force",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-server-js/auth0/package.json
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-server-js/auth0/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "barkbook-web",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@auth0/auth0-server-js": "^1.12.1",
+    "cookie-parser": "^1.4.7",
+    "dotenv": "^16.4.7",
+    "express": "^5.1.0"
+  },
+  "devDependencies": {
+    "@types/cookie-parser": "^1.4.8",
+    "@types/express": "^5.0.1",
+    "@types/node": "^22.13.0",
+    "typescript": "~5.8.3"
+  }
+}

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-server-js/auth0/src/auth0.ts
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-server-js/auth0/src/auth0.ts
@@ -1,0 +1,21 @@
+import { CookieTransactionStore, ServerClient, StatelessStateStore } from '@auth0/auth0-server-js';
+import { ExpressCookieHandler } from './store/express-cookie-handler.js';
+import type { StoreOptions } from './types.js';
+
+export const appBaseUrl = process.env.APP_BASE_URL ?? 'http://localhost:3000';
+
+const cookieHandler = new ExpressCookieHandler();
+const sessionSecret = process.env.AUTH0_SESSION_SECRET as string;
+
+export const serverClient = new ServerClient<StoreOptions>({
+  domain: process.env.AUTH0_DOMAIN as string,
+  clientId: process.env.AUTH0_CLIENT_ID as string,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET as string,
+  authorizationParams: {
+    redirect_uri: new URL('/auth/callback', appBaseUrl).toString(),
+    audience: process.env.AUTH0_AUDIENCE,
+    scope: 'openid profile email offline_access',
+  },
+  transactionStore: new CookieTransactionStore({ secret: sessionSecret }, cookieHandler),
+  stateStore: new StatelessStateStore({ secret: sessionSecret }, cookieHandler),
+});

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-server-js/auth0/src/index.ts
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-server-js/auth0/src/index.ts
@@ -1,0 +1,60 @@
+import 'dotenv/config';
+import cookieParser from 'cookie-parser';
+import express from 'express';
+import type { Request, Response } from 'express';
+import { appBaseUrl, serverClient } from './auth0.js';
+
+const app = express();
+app.use(cookieParser());
+app.use(express.urlencoded({ extended: true }));
+app.use(express.json());
+
+app.get('/auth/login', async (request: Request, response: Response) => {
+  const authorizationUrl = await serverClient.startInteractiveLogin({}, { request, response });
+  response.redirect(authorizationUrl.href);
+});
+
+app.get('/auth/callback', async (request: Request, response: Response) => {
+  await serverClient.completeInteractiveLogin(new URL(request.url, appBaseUrl), {
+    request,
+    response,
+  });
+  response.redirect('/profile');
+});
+
+app.get('/auth/logout', async (request: Request, response: Response) => {
+  const logoutUrl = await serverClient.logout({ returnTo: appBaseUrl }, { request, response });
+  response.redirect(logoutUrl.href);
+});
+
+app.get('/profile', async (request: Request, response: Response) => {
+  const user = await serverClient.getUser({ request, response });
+
+  if (!user) {
+    response.redirect('/auth/login');
+    return;
+  }
+
+  response.json({ user });
+});
+
+app.post('/transfers', async (request: Request, response: Response) => {
+  const { amount, to } = request.body ?? {};
+
+  const tokenSet = await serverClient.getAccessToken({ request, response });
+
+  const upstream = await fetch(new URL('/transfers', process.env.AUTH0_AUDIENCE).toString(), {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${tokenSet.accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ amount, to }),
+  });
+
+  response.status(upstream.status).json(await upstream.json());
+});
+
+app.listen(3000, () => {
+  console.log(`Barkbook web listening on ${appBaseUrl}`);
+});

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-server-js/auth0/src/store/express-cookie-handler.ts
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-server-js/auth0/src/store/express-cookie-handler.ts
@@ -1,0 +1,39 @@
+import type { CookieHandler, CookieSerializeOptions } from '@auth0/auth0-server-js';
+import type { StoreOptions } from '../types.js';
+
+export class ExpressCookieHandler implements CookieHandler<StoreOptions> {
+  setCookie(name: string, value: string, options?: CookieSerializeOptions, storeOptions?: StoreOptions): void {
+    if (!storeOptions) {
+      throw new Error('StoreOptions not provided');
+    }
+
+    // The SDK gives maxAge in seconds; Express expects milliseconds.
+    const maxAge = options?.maxAge != null ? options.maxAge * 1000 : undefined;
+
+    storeOptions.response.cookie(name, value, { ...options, maxAge });
+  }
+
+  getCookie(name: string, storeOptions?: StoreOptions): string | undefined {
+    if (!storeOptions) {
+      throw new Error('StoreOptions not provided');
+    }
+
+    return storeOptions.request.cookies[name];
+  }
+
+  getCookies(storeOptions?: StoreOptions): Record<string, string> {
+    if (!storeOptions) {
+      throw new Error('StoreOptions not provided');
+    }
+
+    return storeOptions.request.cookies;
+  }
+
+  deleteCookie(name: string, storeOptions?: StoreOptions, options?: CookieSerializeOptions): void {
+    if (!storeOptions) {
+      throw new Error('StoreOptions not provided');
+    }
+
+    storeOptions.response.clearCookie(name, options);
+  }
+}

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-server-js/auth0/src/types.ts
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-server-js/auth0/src/types.ts
@@ -1,0 +1,6 @@
+import type { Request, Response } from 'express';
+
+export interface StoreOptions {
+  request: Request;
+  response: Response;
+}

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-server-js/auth0/tsconfig.json
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-server-js/auth0/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "moduleDetection": "force",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Adds two evals covering the MFA APIs in `@auth0/auth0-auth-js` and `@auth0/auth0-server-js` — the flow where an app that exchanges credentials for tokens itself gets `mfa_required` back and has to drive enrollment, challenge and verification through the SDK instead of a hosted login page. The existing `mfa/*` evals all cover step-up via `acr_values`, so nothing measured this surface.

Each eval starts from a minimal Express + TypeScript service with no MFA in it and grades the written code. The two diverge where the SDKs do: the lower-level client exposes factor deletion and the server client does not, so one eval requires it and the other checks it is absent. Credentials come from the prompt and stay out of source, as in the other server-side evals.

`@auth0/auth0-api-js` has no MFA surface, so it gets no eval.