### PR TITLE
feat(evals): Adds Organisations evals for React 

### DIFF
--- a/apps/auth0-evals/README.md
+++ b/apps/auth0-evals/README.md
@@ -61,6 +61,7 @@ See [`@a0/evals` CLI docs](../../packages/evals/) for the full list of flags and
 | `express_api_dpop` | dpop | Enforce DPoP-bound access tokens on an Express API via `auth({ dpop: … })` |
 | `express_api_rbac` | rbac | Fine-grained authorization with `requiredScopes` / `scopeIncludesAny` / `claimIncludes` / `claimEquals` |
 | `express_api_mcd` | multi-tenant | Accept tokens from several Auth0 custom domains via `auth({ mcd: { issuers } })` |
+| `react_organizations` | organizations | Add Auth0 Organizations to a React SPA — org login, invitation acceptance, and org read-back from the `org_id` claim |
 
 ## Configuration
 

--- a/apps/auth0-evals/src/evals/organizations/react/PROMPT.md
+++ b/apps/auth0-evals/src/evals/organizations/react/PROMPT.md
@@ -1,0 +1,17 @@
+---
+id: react_organizations
+name: React Organizations Login
+scaffold: src/evals/scaffolds/react/auth0
+skills: auth0
+setup_command: npm install
+compile_command: npm run build
+---
+
+## Task
+
+Our React app already has Auth0 login working. Add Auth0 Organizations support: log users in to our "Acme" org (`org_barkbook_acme`), accept organization invitation links, and show which organization the
+signed-in user belongs to.
+
+Domain: dev-barkbook.us.auth0.com
+Client ID: barkbook_client_abc123xyz
+Audience: https://api.barkbook.com

--- a/apps/auth0-evals/src/evals/organizations/react/graders.ts
+++ b/apps/auth0-evals/src/evals/organizations/react/graders.ts
@@ -1,0 +1,47 @@
+import { contains, notContains, judge, compiles, GraderLevel } from '@a0/evals-graders';
+
+export function defineGraders() {
+  return [
+    // ── L1: Required Organizations symbols present ─────────────────────────
+    contains('organization', 'Passes the organization parameter for org-scoped login', GraderLevel.L1),
+    contains('invitation', 'Handles the organization invitation parameter', GraderLevel.L1),
+    contains('org_id', 'Reads the org_id claim to identify the logged-in organization', GraderLevel.L1),
+
+    // ── L2: Hallucination / wrong approach ─────────────────────────────────
+    notContains('@auth0/organizations', 'No hallucinated @auth0/organizations package', GraderLevel.L2),
+    notContains('useOrganization', 'No non-existent useOrganization hook (not in @auth0/auth0-react)', GraderLevel.L2),
+    notContains('client_secret', 'No client_secret in SPA (public client)', GraderLevel.L2),
+
+    // ── L3: Security ───────────────────────────────────────────────────────
+    notContains('localStorage.setItem', 'No tokens stored in localStorage', GraderLevel.L3),
+    notContains('sessionStorage.setItem', 'No tokens stored in sessionStorage', GraderLevel.L3),
+
+    // ── L4: Structural correctness ─────────────────────────────────────────
+    compiles('Project compiles (build succeeds)', GraderLevel.L4),
+    judge(
+      'Does the code read the "invitation" and "organization" parameters from the URL query string ' +
+        'and forward both to loginWithRedirect when they are present, so an invitation link is accepted?',
+      GraderLevel.L4,
+    ),
+    judge(
+      'Does the code surface the organization the user logged into by reading the org_id claim ' +
+        '(via user.org_id or getIdTokenClaims), rather than hardcoding or guessing it?',
+      GraderLevel.L4,
+    ),
+
+    // ── L5: Current API patterns ───────────────────────────────────────────
+    judge(
+      'Does the code pass the organization value inside an authorizationParams object ' +
+        '(on Auth0Provider or loginWithRedirect) rather than as a top-level "organization" prop ' +
+        'or a positional argument?',
+      GraderLevel.L5,
+    ),
+
+    // ── Holistic judge (no level — always runs) ────────────────────────────
+    judge(
+      'Does the solution correctly add Auth0 Organizations support to the React app — logging users ' +
+        'into the specified organization, accepting organization invitation links via the invitation ' +
+        'and organization query parameters, and identifying the logged-in organization from the org_id claim?',
+    ),
+  ];
+}

--- a/apps/auth0-evals/src/evals/organizations/react/graders.ts
+++ b/apps/auth0-evals/src/evals/organizations/react/graders.ts
@@ -1,15 +1,16 @@
-import { contains, notContains, judge, compiles, GraderLevel } from '@a0/evals-graders';
+import { contains, notContains, matches, judge, compiles, GraderLevel } from '@a0/evals-graders';
 
 export function defineGraders() {
   return [
     // ── L1: Required Organizations symbols present ─────────────────────────
     contains('organization', 'Passes the organization parameter for org-scoped login', GraderLevel.L1),
+    contains('org_barkbook_acme', 'Wires the specific Acme org (org_barkbook_acme)', GraderLevel.L1),
     contains('invitation', 'Handles the organization invitation parameter', GraderLevel.L1),
     contains('org_id', 'Reads the org_id claim to identify the logged-in organization', GraderLevel.L1),
 
     // ── L2: Hallucination / wrong approach ─────────────────────────────────
     notContains('@auth0/organizations', 'No hallucinated @auth0/organizations package', GraderLevel.L2),
-    notContains('useOrganization', 'No non-existent useOrganization hook (not in @auth0/auth0-react)', GraderLevel.L2),
+    notContains('useOrganization(', 'No non-existent useOrganization hook (not in @auth0/auth0-react)', GraderLevel.L2),
     notContains('client_secret', 'No client_secret in SPA (public client)', GraderLevel.L2),
 
     // ── L3: Security ───────────────────────────────────────────────────────
@@ -18,9 +19,17 @@ export function defineGraders() {
 
     // ── L4: Structural correctness ─────────────────────────────────────────
     compiles('Project compiles (build succeeds)', GraderLevel.L4),
+    matches(
+      String.raw`authorizationParams[\s\S]{0,160}organization`,
+      'Passes organization inside an authorizationParams object',
+      GraderLevel.L4,
+    ),
     judge(
       'Does the code read the "invitation" and "organization" parameters from the URL query string ' +
-        'and forward both to loginWithRedirect when they are present, so an invitation link is accepted?',
+        'and forward them to loginWithRedirect when present? To pass, the invitation\'s own ' +
+        '"organization" must be forwarded (overriding any default/configured org), and the code ' +
+        'must NOT reject or block a valid invitation solely because its organization differs from ' +
+        'the app\'s configured default org.',
       GraderLevel.L4,
     ),
     judge(
@@ -41,7 +50,9 @@ export function defineGraders() {
     judge(
       'Does the solution correctly add Auth0 Organizations support to the React app — logging users ' +
         'into the specified organization, accepting organization invitation links via the invitation ' +
-        'and organization query parameters, and identifying the logged-in organization from the org_id claim?',
+        'and organization query parameters, and identifying the logged-in organization from the org_id claim? ' +
+        'Rejecting or blocking a valid invitation because its organization differs from the configured ' +
+        'default org is a correctness defect, not a cosmetic one — treat it as a failure of invitation acceptance.',
     ),
   ];
 }


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Adds a new **React Organizations** eval (`react_organizations`) under the `organizations` category, measuring how accurately agents integrate Auth0 Organizations into an existing React SPA.

The task asks the agent to add three capabilities on top of a working Auth0 React scaffold:
- **Org-scoped login** - sign users into the "Acme" org (`org_barkbook_acme`).
- **Invitation acceptance** - read the `invitation` and `organization` query params from the URL and forward them to `loginWithRedirect`.
- **Org read-back** - surface the signed-in organization from the `org_id` claim.

#### Graders 
- Also adds L1 to L5 graders and a  Holistic judge for overall Organizations correctness. 
- The eval is also registered in the app README eval table.

### References

### Testing
- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a React Organizations evaluation covering organization login through “Acme.”
  * Added checks for invitation-link acceptance and displaying the signed-in user’s organization.
  * Added validation for required organization settings, claims, secure token handling, compilation, and current Auth0 API usage.
  * Included the new evaluation in the list of available Auth0 evaluation tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->