### PR TITLE
feat(scorer): zero Security weight for CLI evals, keep Hallucination

### DIFF
--- a/packages/evals/src/scorer.ts
+++ b/packages/evals/src/scorer.ts
@@ -324,7 +324,20 @@ function scoreDocsQuality(
 
 export function score(record: RunRecord, graderResults?: GraderResult[], opts?: ScoringOptions): ScoredResult {
   const gr = graderResults ?? [];
-  const weights = { ...DEFAULT_WEIGHTS, ...opts?.weights };
+  const baseWeights = { ...DEFAULT_WEIGHTS, ...opts?.weights };
+
+  // CLI evals write no files — Security auto-scores 100 (no L3 graders fire),
+  // inflating every run. Redistribute its weight to Correctness so scores
+  // reflect actual agent behavior. Hallucination (L2) is kept — CLI agents can
+  // still hallucinate commands or flags in their responses.
+  const weights =
+    record.evalType === 'cli'
+      ? {
+          ...baseWeights,
+          Correctness: baseWeights['Correctness'] + baseWeights['Security'],
+          Security: 0,
+        }
+      : baseWeights;
 
   const [frictionScore, frictionNotes] = scoreFriction(record, opts);
   const [speedScore, speedNotes] = scoreSpeed(record, opts);

--- a/packages/evals/tests/scorer.test.ts
+++ b/packages/evals/tests/scorer.test.ts
@@ -332,6 +332,36 @@ describe('score - Efficiency (CLI mode)', () => {
   });
 });
 
+// ── CLI weight redistribution ─────────────────────────────────────────────────
+
+describe('score - CLI weight redistribution', () => {
+  it('CLI eval: Security weight is 0, Hallucination kept, Correctness gets Security weight', () => {
+    const dir = tmpDir();
+    const record = makeRecord({ workspace: dir, evalType: 'cli' });
+    record.toolCalls = [
+      makeToolCall('run_command', 1, { args: { command: 'auth0 api put guardian/factors/otp' } }),
+      makeToolCall('run_command', 1, { args: { command: 'auth0 api put guardian/policies' } }),
+    ];
+    const result = score(record);
+    expect(getDim(result, 'Security').weight).toBe(0);
+    expect(getDim(result, 'Hallucination').weight).toBeCloseTo(0.15, 5);
+    expect(getDim(result, 'Correctness').weight).toBeCloseTo(0.35, 5);
+  });
+
+  it('SDK eval: default weights unchanged', () => {
+    const dir = tmpDir();
+    const record = makeRecord({ workspace: dir, evalType: 'sdk' });
+    record.toolCalls = [
+      makeToolCall('write_file', 1, { args: { path: 'app.ts' } }),
+      makeToolCall('run_command', 1, { args: { command: 'npm install' } }),
+    ];
+    const result = score(record);
+    expect(getDim(result, 'Hallucination').weight).toBeCloseTo(0.15, 5);
+    expect(getDim(result, 'Security').weight).toBeCloseTo(0.1, 5);
+    expect(getDim(result, 'Correctness').weight).toBeCloseTo(0.25, 5);
+  });
+});
+
 // ── analyzeWaste unit tests ───────────────────────────────────────────────────
 
 describe('analyzeWaste', () => {


### PR DESCRIPTION
### Description

CLI evals (e.g. `mfa_cli`) write no files to disk, so no L3 (Security) graders ever fire. This caused Security to auto-score 100 on every CLI run, inflating the overall score by a free 10 points regardless of agent behavior.

This PR zeros the Security weight for `evalType === 'cli'` runs and redistributes it to Correctness (25% -> 35%). Hallucination (L2) is intentionally kept -- CLI agents can still hallucinate commands, flags, or API paths in their responses, so that signal is valid.

SDK eval scoring is unchanged.

- `packages/evals/src/scorer.ts`: CLI branch in `score()` sets `Security: 0` and adds its weight to Correctness; Hallucination weight is untouched
- `packages/evals/tests/scorer.test.ts`: 2 new tests covering the CLI weight redistribution (Security=0, Hallucination=0.15, Correctness=0.35) and SDK defaults unchanged

### References

Follow-on to #219 (CLI command-precision mode for Efficiency).

### Testing

All scorer tests pass. Two new tests specifically cover the weight redistribution:
- CLI eval: Security weight is 0, Hallucination stays at 15%, Correctness gets 35%
- SDK eval: default weights are unchanged (Security 10%, Hallucination 15%, Correctness 25%)

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
