### PR TITLE
fix(gemini): extract URL from web_fetch prompt field in translator

### DIFF
--- a/apps/auth0-evals/src/evals/mfa/auth0-auth-js/PROMPT.md
+++ b/apps/auth0-evals/src/evals/mfa/auth0-auth-js/PROMPT.md
@@ -1,0 +1,25 @@
+---
+id: auth0_auth_js_mfa
+name: Auth0 Auth JS MFA API
+scaffold: src/evals/scaffolds/auth0-auth-js/auth0
+skills: auth0
+setup_command: npm install
+compile_command: npm run build
+---
+
+## Task
+
+Barkbook's auth service signs users in with their username and password and hands back tokens. We just turned on multi-factor authentication in our Auth0 tenant, and now sign-in fails for any user the policy applies to.
+
+Add multi-factor support to the service, as HTTP routes my mobile client can drive:
+
+- A user who has no second factor yet should be able to set up an authenticator app — return whatever the app needs to show a QR code.
+- A user who already has a factor should be prompted for the code from their app instead.
+- Either way, once they submit a valid code, sign-in finishes and we hand back tokens like we do today.
+- Someone who has lost their phone should be able to finish sign-in with a recovery code.
+- Let a user see the factors on their account and remove one they no longer use.
+
+Domain: dev-barkbook.us.auth0.com
+Client ID: barkbook_client_abc123xyz
+Client Secret: barkbook_secret_def456uvw
+Audience: https://api.barkbook.com

--- a/apps/auth0-evals/src/evals/mfa/auth0-auth-js/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/auth0-auth-js/graders.ts
@@ -100,9 +100,11 @@ export function defineGraders() {
 
     // ── Holistic judge (no level — always runs) ───────────────────────────
     judge(
-      'MFA in @auth0/auth0-auth-js is Early Access and postdates your training data — judge against the ' +
-        'installed package types, not recall. Does the code detect mfa_required, lift the MFA token from ' +
-        'the error cause, and enroll, list, challenge, delete and verify through the SDK?',
+      'Does the solution correctly implement MFA API sign-in with @auth0/auth0-auth-js — detecting ' +
+        'mfa_required via isMfaRequiredError and reading mfa_token off the error cause, driving enrollment, ' +
+        'listing, challenge and deletion through enrollAuthenticator, listAuthenticators, ' +
+        'challengeAuthenticator and deleteAuthenticator, and finishing sign-in through mfa.verify with ' +
+        'either an authenticator code or a recovery code?',
     ),
   ];
 }

--- a/apps/auth0-evals/src/evals/mfa/auth0-auth-js/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/auth0-auth-js/graders.ts
@@ -1,0 +1,115 @@
+import { contains, notContains, notContainsInSource, matches, judge, compiles, GraderLevel } from '@a0/evals-graders';
+
+export function defineGraders() {
+  return [
+    // ── L1: Required MFA symbols present ──────────────────────────────────
+    contains('isMfaRequiredError', 'Detects mfa_required via the isMfaRequiredError type guard', GraderLevel.L1),
+    contains('mfa_token', 'Reads the MFA token off the error cause', GraderLevel.L1),
+    contains('mfaToken', 'Passes the token to MFA methods as mfaToken', GraderLevel.L1),
+    contains('listAuthenticators', 'Lists enrolled authenticators', GraderLevel.L1),
+    contains('enrollAuthenticator', 'Enrolls a new authenticator', GraderLevel.L1),
+    contains('challengeAuthenticator', 'Challenges an enrolled authenticator', GraderLevel.L1),
+    contains('deleteAuthenticator', 'Removes an enrolled authenticator', GraderLevel.L1),
+    contains('authenticatorTypes', 'Enrollment passes authenticatorTypes', GraderLevel.L1),
+    contains('factorType', 'Verify passes the factorType discriminator', GraderLevel.L1),
+    contains('barcodeUri', 'Surfaces the OTP barcodeUri for QR enrollment', GraderLevel.L1),
+
+    // ── L2: Hallucination / wrong approach ────────────────────────────────
+    notContains('mfa/associate', 'Does not hand-roll a call to the /mfa/associate endpoint', GraderLevel.L2),
+    notContains('mfa/challenge', 'Does not hand-roll a call to the /mfa/challenge endpoint', GraderLevel.L2),
+    notContains('mfa/associations', 'Does not invent a /mfa/associations endpoint (it does not exist)', GraderLevel.L2),
+    notContains('/oauth/token', 'Does not hand-roll a raw token grant', GraderLevel.L2),
+    notContains('grant-type/mfa-otp', 'Does not build the MFA OTP grant type by hand', GraderLevel.L2),
+    notContains(
+      'grant-type/mfa-recovery-code',
+      'Does not build the MFA recovery-code grant type by hand',
+      GraderLevel.L2,
+    ),
+    notContains('/api/v2/users/', 'Does not reach for the Management API mid-sign-in', GraderLevel.L2),
+    notContains(
+      'authenticator_types',
+      'Uses camelCase authenticatorTypes, not the wire-level snake_case',
+      GraderLevel.L2,
+    ),
+    notContains('challenge_type', 'Uses camelCase challengeType, not the wire-level snake_case', GraderLevel.L2),
+    notContains('barcode_uri', 'Reads camelCase barcodeUri, not the wire-level snake_case', GraderLevel.L2),
+    notContains('auth0-js', 'Does not use the deprecated auth0-js library', GraderLevel.L2),
+    notContains('speakeasy', 'No server-side TOTP library (speakeasy)', GraderLevel.L2),
+    notContains('otplib', 'No server-side TOTP library (otplib)', GraderLevel.L2),
+    notContains('@auth0/auth0-server-js', 'Does not pull in the sibling server SDK', GraderLevel.L2),
+
+    // ── L3: Security ──────────────────────────────────────────────────────
+    notContainsInSource(
+      'barkbook_secret_def456uvw',
+      'No hardcoded client secret in source files (ok in .env)',
+      GraderLevel.L3,
+    ),
+    notContainsInSource(
+      'barkbook_client_abc123xyz',
+      'No hardcoded client ID in source files (ok in .env)',
+      GraderLevel.L3,
+    ),
+    notContainsInSource(
+      'dev-barkbook.us.auth0.com',
+      'No hardcoded Auth0 domain in source files (ok in .env)',
+      GraderLevel.L3,
+    ),
+    judge(
+      'Does the code avoid writing the MFA token, the OTP secret, the barcodeUri, or recovery codes ' +
+        'to logs or to a persistent store? Returning the barcodeUri and secret in the HTTP response ' +
+        'that starts enrollment is required and acceptable, as is returning a recovery code once. ' +
+        'Only logging them (console.log and friends) or persisting them counts as a violation.',
+      GraderLevel.L3,
+    ),
+    judge(
+      'Does the code keep the MFA token out of URLs and query strings, passing it in request bodies ' +
+        'or headers instead? Holding it in a signed/httpOnly cookie or a server-side session for the ' +
+        'duration of the flow is acceptable.',
+      GraderLevel.L3,
+    ),
+
+    // ── L4: Structural correctness ────────────────────────────────────────
+    compiles('Project compiles (build succeeds)', GraderLevel.L4),
+    matches(String.raw`\.mfa\.verify\(`, 'Completes sign-in through the MFA client verify method', GraderLevel.L4),
+    judge(
+      'Does the code branch on whether the user already has a factor — enrolling an authenticator ' +
+        'when they have none and challenging an existing one when they do — before verifying? ' +
+        'Branching on mfa_requirements from the error cause and branching on the result of ' +
+        'listAuthenticators are both acceptable.',
+      GraderLevel.L4,
+    ),
+    judge(
+      'Does the code support finishing sign-in with a recovery code, in addition to the ' +
+        'authenticator-app code path? A correct implementation verifies with a recovery-code ' +
+        'factor type rather than treating the recovery code as an OTP.',
+      GraderLevel.L4,
+    ),
+    judge(
+      'Does the code let a user list the factors on their account and delete one, using the SDK ' +
+        'methods for both rather than a hand-written HTTP call?',
+      GraderLevel.L4,
+    ),
+
+    // ── L5: Current API patterns ──────────────────────────────────────────
+    judge(
+      "Does every MFA operation go through the SDK client's mfa sub-client (enrollAuthenticator, " +
+        'listAuthenticators, challengeAuthenticator, deleteAuthenticator, verify) rather than through ' +
+        'hand-written fetch calls to Auth0 MFA endpoints or a hand-built MFA grant on the token ' +
+        'endpoint? Correct code never writes an Auth0 URL itself.',
+      GraderLevel.L5,
+    ),
+    judge(
+      'Is the MFA token read from the error cause as snake_case mfa_token and then passed into the ' +
+        'SDK options as camelCase mfaToken? Passing an option key named mfa_token to an SDK method ' +
+        'is wrong — the option is mfaToken.',
+      GraderLevel.L5,
+    ),
+
+    // ── Holistic judge (no level — always runs) ───────────────────────────
+    judge(
+      'Does the solution correctly use the MFA APIs of @auth0/auth0-auth-js — detecting mfa_required, ' +
+        'lifting the MFA token from the error cause, and then enrolling, listing, challenging, ' +
+        'deleting authenticators and verifying the submitted factor to obtain tokens?',
+    ),
+  ];
+}

--- a/apps/auth0-evals/src/evals/mfa/auth0-auth-js/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/auth0-auth-js/graders.ts
@@ -15,9 +15,6 @@ export function defineGraders() {
     contains('barcodeUri', 'Surfaces the OTP barcodeUri for QR enrollment', GraderLevel.L1),
 
     // ── L2: Hallucination / wrong approach ────────────────────────────────
-    notContains('mfa/associate', 'Does not hand-roll a call to the /mfa/associate endpoint', GraderLevel.L2),
-    notContains('mfa/challenge', 'Does not hand-roll a call to the /mfa/challenge endpoint', GraderLevel.L2),
-    notContains('mfa/associations', 'Does not invent a /mfa/associations endpoint (it does not exist)', GraderLevel.L2),
     notContains('/oauth/token', 'Does not hand-roll a raw token grant', GraderLevel.L2),
     notContains('grant-type/mfa-otp', 'Does not build the MFA OTP grant type by hand', GraderLevel.L2),
     notContains(
@@ -26,13 +23,10 @@ export function defineGraders() {
       GraderLevel.L2,
     ),
     notContains('/api/v2/users/', 'Does not reach for the Management API mid-sign-in', GraderLevel.L2),
-    notContains(
-      'authenticator_types',
-      'Uses camelCase authenticatorTypes, not the wire-level snake_case',
-      GraderLevel.L2,
-    ),
-    notContains('challenge_type', 'Uses camelCase challengeType, not the wire-level snake_case', GraderLevel.L2),
-    notContains('barcode_uri', 'Reads camelCase barcodeUri, not the wire-level snake_case', GraderLevel.L2),
+    // Anchored to key position — bare snake_case also appears in Auth0 error codes, legitimately.
+    notContains('authenticator_types:', 'Option key is camelCase authenticatorTypes', GraderLevel.L2),
+    notContains('challenge_type:', 'Option key is camelCase challengeType', GraderLevel.L2),
+    notContains('.barcode_uri', 'Reads camelCase barcodeUri', GraderLevel.L2),
     notContains('auth0-js', 'Does not use the deprecated auth0-js library', GraderLevel.L2),
     notContains('speakeasy', 'No server-side TOTP library (speakeasy)', GraderLevel.L2),
     notContains('otplib', 'No server-side TOTP library (otplib)', GraderLevel.L2),
@@ -99,17 +93,16 @@ export function defineGraders() {
       GraderLevel.L5,
     ),
     judge(
-      'Is the MFA token read from the error cause as snake_case mfa_token and then passed into the ' +
-        'SDK options as camelCase mfaToken? Passing an option key named mfa_token to an SDK method ' +
-        'is wrong — the option is mfaToken.',
+      'Is the MFA token passed to SDK methods under the camelCase key mfaToken? Reading it off the ' +
+        'error cause as mfa_token is correct.',
       GraderLevel.L5,
     ),
 
     // ── Holistic judge (no level — always runs) ───────────────────────────
     judge(
-      'Does the solution correctly use the MFA APIs of @auth0/auth0-auth-js — detecting mfa_required, ' +
-        'lifting the MFA token from the error cause, and then enrolling, listing, challenging, ' +
-        'deleting authenticators and verifying the submitted factor to obtain tokens?',
+      'MFA in @auth0/auth0-auth-js is Early Access and postdates your training data — judge against the ' +
+        'installed package types, not recall. Does the code detect mfa_required, lift the MFA token from ' +
+        'the error cause, and enroll, list, challenge, delete and verify through the SDK?',
     ),
   ];
 }

--- a/apps/auth0-evals/src/evals/mfa/auth0-server-js/PROMPT.md
+++ b/apps/auth0-evals/src/evals/mfa/auth0-server-js/PROMPT.md
@@ -1,0 +1,26 @@
+---
+id: auth0_server_js_mfa
+name: Auth0 Server JS MFA API
+scaffold: src/evals/scaffolds/auth0-server-js/auth0
+skills: auth0
+setup_command: npm install
+compile_command: npm run build
+---
+
+## Task
+
+Barkbook's web app signs users in against our Auth0 tenant and keeps them in a session. We just turned on multi-factor authentication, and now the transfers page blows up for any user the policy applies to.
+
+Add the multi-factor step to the app, with our own pages rather than a hosted one:
+
+- A user with no second factor yet should get an authenticator-app setup page showing a QR code they can scan.
+- A user who already has a factor should be asked for the code from their app.
+- Some of our users enrolled with SMS instead — send them their code and let them type it in.
+- Once they submit a valid code, they should be properly signed in, so `/profile` and the transfers call work for the rest of the session.
+- Show a user their recovery code once, when they first set a factor up.
+
+Domain: dev-barkbook.us.auth0.com
+Client ID: barkbook_client_abc123xyz
+Client Secret: barkbook_secret_def456uvw
+Audience: https://api.barkbook.com
+Base URL: http://localhost:3000

--- a/apps/auth0-evals/src/evals/mfa/auth0-server-js/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/auth0-server-js/graders.ts
@@ -23,20 +23,15 @@ export function defineGraders() {
       GraderLevel.L2,
     ),
     notContains('.authClient.mfa', 'Does not reach through to the internal auth client', GraderLevel.L2),
-    notContains('mfa/associate', 'Does not hand-roll a call to the /mfa/associate endpoint', GraderLevel.L2),
-    notContains('mfa/challenge', 'Does not hand-roll a call to the /mfa/challenge endpoint', GraderLevel.L2),
     notContains('/oauth/token', 'Does not hand-roll a raw token grant', GraderLevel.L2),
     notContains('grant-type/mfa-otp', 'Does not build the MFA OTP grant type by hand', GraderLevel.L2),
     notContains('grant-type/mfa-oob', 'Does not build the MFA OOB grant type by hand', GraderLevel.L2),
     notContains('/api/v2/users/', 'Does not reach for the Management API mid-sign-in', GraderLevel.L2),
-    notContains(
-      'authenticator_types',
-      'Uses camelCase authenticatorTypes, not the wire-level snake_case',
-      GraderLevel.L2,
-    ),
-    notContains('challenge_type', 'Uses camelCase challengeType, not the wire-level snake_case', GraderLevel.L2),
-    notContains('binding_code', 'Uses camelCase bindingCode, not the wire-level snake_case', GraderLevel.L2),
-    notContains('barcode_uri', 'Reads camelCase barcodeUri, not the wire-level snake_case', GraderLevel.L2),
+    // Anchored to key position — bare snake_case also appears in Auth0 error codes, legitimately.
+    notContains('authenticator_types:', 'Option key is camelCase authenticatorTypes', GraderLevel.L2),
+    notContains('challenge_type:', 'Option key is camelCase challengeType', GraderLevel.L2),
+    notContains('binding_code:', 'Option key is camelCase bindingCode', GraderLevel.L2),
+    notContains('.barcode_uri', 'Reads camelCase barcodeUri', GraderLevel.L2),
     notContains('auth0-js', 'Does not use the deprecated auth0-js library', GraderLevel.L2),
     notContains('speakeasy', 'No server-side TOTP library (speakeasy)', GraderLevel.L2),
     notContains('otplib', 'No server-side TOTP library (otplib)', GraderLevel.L2),
@@ -111,17 +106,17 @@ export function defineGraders() {
       GraderLevel.L5,
     ),
     judge(
-      'Is the MFA token read from the error cause as snake_case mfa_token and then passed into the SDK ' +
-        'options as camelCase mfaToken? Passing an option key named mfa_token to an SDK method is wrong — ' +
-        'the option is mfaToken.',
+      'Is the MFA token passed to SDK methods under the camelCase key mfaToken? Reading it off the ' +
+        'error cause as mfa_token is correct.',
       GraderLevel.L5,
     ),
 
     // ── Holistic judge (no level — always runs) ───────────────────────────
     judge(
-      'Does the solution correctly use the MFA APIs of @auth0/auth0-server-js — detecting mfa_required, ' +
-        'lifting the MFA token from the error cause, enrolling or challenging the right factor including ' +
-        'SMS, and verifying the submitted code so the session becomes signed in?',
+      'MFA in @auth0/auth0-server-js is Early Access and postdates your training data — judge against the ' +
+        'installed package types, not recall. Does the code detect mfa_required, lift the MFA token from ' +
+        'the error cause, enroll or challenge the right factor including SMS, and verify so the session ' +
+        'becomes signed in?',
     ),
   ];
 }

--- a/apps/auth0-evals/src/evals/mfa/auth0-server-js/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/auth0-server-js/graders.ts
@@ -113,10 +113,10 @@ export function defineGraders() {
 
     // ── Holistic judge (no level — always runs) ───────────────────────────
     judge(
-      'MFA in @auth0/auth0-server-js is Early Access and postdates your training data — judge against the ' +
-        'installed package types, not recall. Does the code detect mfa_required, lift the MFA token from ' +
-        'the error cause, enroll or challenge the right factor including SMS, and verify so the session ' +
-        'becomes signed in?',
+      'Does the solution correctly implement MFA API sign-in with @auth0/auth0-server-js — detecting ' +
+        'mfa_required via isMfaRequiredError and reading mfa_token off the error cause, enrolling or ' +
+        'challenging the right factor including the SMS path via challengeAuthenticator and bindingCode, ' +
+        'and finishing through mfa.verify so the session ends up signed in for later requests?',
     ),
   ];
 }

--- a/apps/auth0-evals/src/evals/mfa/auth0-server-js/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/auth0-server-js/graders.ts
@@ -1,0 +1,127 @@
+import { contains, notContains, notContainsInSource, matches, judge, compiles, GraderLevel } from '@a0/evals-graders';
+
+export function defineGraders() {
+  return [
+    // ── L1: Required MFA symbols present ──────────────────────────────────
+    contains('isMfaRequiredError', 'Detects mfa_required via the isMfaRequiredError type guard', GraderLevel.L1),
+    contains('mfa_token', 'Reads the MFA token off the error cause', GraderLevel.L1),
+    contains('mfaToken', 'Passes the token to MFA methods as mfaToken', GraderLevel.L1),
+    contains('listAuthenticators', 'Lists enrolled authenticators', GraderLevel.L1),
+    contains('enrollAuthenticator', 'Enrolls a new authenticator', GraderLevel.L1),
+    contains('challengeAuthenticator', 'Challenges an enrolled authenticator', GraderLevel.L1),
+    contains('authenticatorTypes', 'Enrollment passes authenticatorTypes', GraderLevel.L1),
+    contains('factorType', 'Verify passes the factorType discriminator', GraderLevel.L1),
+    contains('barcodeUri', 'Surfaces the OTP barcodeUri for QR enrollment', GraderLevel.L1),
+    contains('oobCode', 'Carries the oobCode returned by an SMS challenge', GraderLevel.L1),
+    contains('bindingCode', 'Verifies the SMS factor with the bindingCode', GraderLevel.L1),
+    contains('recoveryCode', 'Surfaces the recovery code returned by enrollment', GraderLevel.L1),
+
+    // ── L2: Hallucination / wrong approach ────────────────────────────────
+    notContains(
+      'deleteAuthenticator',
+      'No deleteAuthenticator — @auth0/auth0-server-js does not expose one',
+      GraderLevel.L2,
+    ),
+    notContains('.authClient.mfa', 'Does not reach through to the internal auth client', GraderLevel.L2),
+    notContains('mfa/associate', 'Does not hand-roll a call to the /mfa/associate endpoint', GraderLevel.L2),
+    notContains('mfa/challenge', 'Does not hand-roll a call to the /mfa/challenge endpoint', GraderLevel.L2),
+    notContains('/oauth/token', 'Does not hand-roll a raw token grant', GraderLevel.L2),
+    notContains('grant-type/mfa-otp', 'Does not build the MFA OTP grant type by hand', GraderLevel.L2),
+    notContains('grant-type/mfa-oob', 'Does not build the MFA OOB grant type by hand', GraderLevel.L2),
+    notContains('/api/v2/users/', 'Does not reach for the Management API mid-sign-in', GraderLevel.L2),
+    notContains(
+      'authenticator_types',
+      'Uses camelCase authenticatorTypes, not the wire-level snake_case',
+      GraderLevel.L2,
+    ),
+    notContains('challenge_type', 'Uses camelCase challengeType, not the wire-level snake_case', GraderLevel.L2),
+    notContains('binding_code', 'Uses camelCase bindingCode, not the wire-level snake_case', GraderLevel.L2),
+    notContains('barcode_uri', 'Reads camelCase barcodeUri, not the wire-level snake_case', GraderLevel.L2),
+    notContains('auth0-js', 'Does not use the deprecated auth0-js library', GraderLevel.L2),
+    notContains('speakeasy', 'No server-side TOTP library (speakeasy)', GraderLevel.L2),
+    notContains('otplib', 'No server-side TOTP library (otplib)', GraderLevel.L2),
+    notContains('@auth0/auth0-auth-js', 'Does not swap in the lower-level auth SDK', GraderLevel.L2),
+
+    // ── L3: Security ──────────────────────────────────────────────────────
+    notContainsInSource(
+      'barkbook_secret_def456uvw',
+      'No hardcoded client secret in source files (ok in .env)',
+      GraderLevel.L3,
+    ),
+    notContainsInSource(
+      'barkbook_client_abc123xyz',
+      'No hardcoded client ID in source files (ok in .env)',
+      GraderLevel.L3,
+    ),
+    notContainsInSource(
+      'dev-barkbook.us.auth0.com',
+      'No hardcoded Auth0 domain in source files (ok in .env)',
+      GraderLevel.L3,
+    ),
+    judge(
+      'Does the code avoid writing the MFA token, the OTP secret, the barcodeUri, or the recovery code ' +
+        'to logs or to a persistent store? Rendering the QR/barcodeUri on the setup page and showing the ' +
+        'recovery code once are required and acceptable. Only logging them (console.log and friends) or ' +
+        'persisting them counts as a violation.',
+      GraderLevel.L3,
+    ),
+    judge(
+      'Are the tokens obtained after MFA verification left to the SDK to persist in its configured state ' +
+        'store, rather than being written to a hand-rolled cookie, to localStorage, or to a module-level ' +
+        'variable? The MFA token itself may be held in the transaction/session for the duration of the flow.',
+      GraderLevel.L3,
+    ),
+
+    // ── L4: Structural correctness ────────────────────────────────────────
+    compiles('Project compiles (build succeeds)', GraderLevel.L4),
+    matches(String.raw`\.mfa\.verify\(`, 'Completes sign-in through the MFA client verify method', GraderLevel.L4),
+    judge(
+      'Is the store options object — the one carrying the Express request and response — passed as the ' +
+        'second argument to mfa.verify, the way the rest of the scaffold passes it to other ServerClient ' +
+        'methods? Putting it inside verify’s first options argument instead is wrong. Note that ' +
+        'listAuthenticators, enrollAuthenticator and challengeAuthenticator take a single options ' +
+        'argument and correctly receive no store options.',
+      GraderLevel.L4,
+    ),
+    judge(
+      'Does the code branch on whether the user already has a factor — enrolling an authenticator when ' +
+        'they have none and challenging an existing one when they do — before verifying? Branching on ' +
+        'mfa_requirements from the error cause and branching on the result of listAuthenticators are ' +
+        'both acceptable.',
+      GraderLevel.L4,
+    ),
+    judge(
+      'For an SMS-enrolled user, does the code challenge the authenticator first to trigger the message ' +
+        'and then verify the code the user typed, rather than trying to verify without a challenge?',
+      GraderLevel.L4,
+    ),
+    judge(
+      'After successful verification, does the session end up signed in — the tokens from verify stored ' +
+        'through the SDK so subsequent requests to /profile and the transfers route work without ' +
+        'repeating the MFA flow?',
+      GraderLevel.L4,
+    ),
+
+    // ── L5: Current API patterns ──────────────────────────────────────────
+    judge(
+      "Does every MFA operation go through the server client's mfa sub-client (enrollAuthenticator, " +
+        'listAuthenticators, challengeAuthenticator, verify) rather than through hand-written fetch calls ' +
+        'to Auth0 MFA endpoints or a hand-built MFA grant on the token endpoint? Correct code never ' +
+        'writes an Auth0 URL itself.',
+      GraderLevel.L5,
+    ),
+    judge(
+      'Is the MFA token read from the error cause as snake_case mfa_token and then passed into the SDK ' +
+        'options as camelCase mfaToken? Passing an option key named mfa_token to an SDK method is wrong — ' +
+        'the option is mfaToken.',
+      GraderLevel.L5,
+    ),
+
+    // ── Holistic judge (no level — always runs) ───────────────────────────
+    judge(
+      'Does the solution correctly use the MFA APIs of @auth0/auth0-server-js — detecting mfa_required, ' +
+        'lifting the MFA token from the error cause, enrolling or challenging the right factor including ' +
+        'SMS, and verifying the submitted code so the session becomes signed in?',
+    ),
+  ];
+}

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-auth-js/auth0/package.json
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-auth-js/auth0/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "barkbook-auth-service",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@auth0/auth0-auth-js": "^1.12.1",
+    "dotenv": "^16.4.7",
+    "express": "^5.1.0"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.1",
+    "@types/node": "^22.13.0",
+    "typescript": "~5.8.3"
+  }
+}

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-auth-js/auth0/src/auth0.ts
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-auth-js/auth0/src/auth0.ts
@@ -1,0 +1,9 @@
+import { AuthClient } from '@auth0/auth0-auth-js';
+
+export const authClient = new AuthClient({
+  domain: process.env.AUTH0_DOMAIN as string,
+  clientId: process.env.AUTH0_CLIENT_ID as string,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET,
+});
+
+export const audience = process.env.AUTH0_AUDIENCE;

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-auth-js/auth0/src/index.ts
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-auth-js/auth0/src/index.ts
@@ -1,0 +1,53 @@
+import 'dotenv/config';
+import express from 'express';
+import type { Request, Response } from 'express';
+import { audience, authClient } from './auth0.js';
+
+const app = express();
+app.use(express.json());
+
+app.post('/login', async (request: Request, response: Response) => {
+  const { username, password } = request.body ?? {};
+
+  if (!username || !password) {
+    response.status(400).json({ error: 'username and password are required' });
+    return;
+  }
+
+  try {
+    const tokens = await authClient.getTokenByPassword({
+      username,
+      password,
+      audience,
+      scope: 'openid profile email offline_access',
+    });
+
+    response.json({
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+      expiresAt: tokens.expiresAt,
+    });
+  } catch (error) {
+    response.status(401).json({ error: (error as Error).message });
+  }
+});
+
+app.post('/refresh', async (request: Request, response: Response) => {
+  const { refreshToken } = request.body ?? {};
+
+  if (!refreshToken) {
+    response.status(400).json({ error: 'refreshToken is required' });
+    return;
+  }
+
+  try {
+    const tokens = await authClient.getTokenByRefreshToken({ refreshToken });
+    response.json({ accessToken: tokens.accessToken, expiresAt: tokens.expiresAt });
+  } catch (error) {
+    response.status(401).json({ error: (error as Error).message });
+  }
+});
+
+app.listen(3000, () => {
+  console.log('Barkbook auth service listening on http://localhost:3000');
+});

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-auth-js/auth0/tsconfig.json
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-auth-js/auth0/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "moduleDetection": "force",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-server-js/auth0/package.json
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-server-js/auth0/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "barkbook-web",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@auth0/auth0-server-js": "^1.12.1",
+    "cookie-parser": "^1.4.7",
+    "dotenv": "^16.4.7",
+    "express": "^5.1.0"
+  },
+  "devDependencies": {
+    "@types/cookie-parser": "^1.4.8",
+    "@types/express": "^5.0.1",
+    "@types/node": "^22.13.0",
+    "typescript": "~5.8.3"
+  }
+}

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-server-js/auth0/src/auth0.ts
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-server-js/auth0/src/auth0.ts
@@ -1,0 +1,21 @@
+import { CookieTransactionStore, ServerClient, StatelessStateStore } from '@auth0/auth0-server-js';
+import { ExpressCookieHandler } from './store/express-cookie-handler.js';
+import type { StoreOptions } from './types.js';
+
+export const appBaseUrl = process.env.APP_BASE_URL ?? 'http://localhost:3000';
+
+const cookieHandler = new ExpressCookieHandler();
+const sessionSecret = process.env.AUTH0_SESSION_SECRET as string;
+
+export const serverClient = new ServerClient<StoreOptions>({
+  domain: process.env.AUTH0_DOMAIN as string,
+  clientId: process.env.AUTH0_CLIENT_ID as string,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET as string,
+  authorizationParams: {
+    redirect_uri: new URL('/auth/callback', appBaseUrl).toString(),
+    audience: process.env.AUTH0_AUDIENCE,
+    scope: 'openid profile email offline_access',
+  },
+  transactionStore: new CookieTransactionStore({ secret: sessionSecret }, cookieHandler),
+  stateStore: new StatelessStateStore({ secret: sessionSecret }, cookieHandler),
+});

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-server-js/auth0/src/index.ts
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-server-js/auth0/src/index.ts
@@ -1,0 +1,60 @@
+import 'dotenv/config';
+import cookieParser from 'cookie-parser';
+import express from 'express';
+import type { Request, Response } from 'express';
+import { appBaseUrl, serverClient } from './auth0.js';
+
+const app = express();
+app.use(cookieParser());
+app.use(express.urlencoded({ extended: true }));
+app.use(express.json());
+
+app.get('/auth/login', async (request: Request, response: Response) => {
+  const authorizationUrl = await serverClient.startInteractiveLogin({}, { request, response });
+  response.redirect(authorizationUrl.href);
+});
+
+app.get('/auth/callback', async (request: Request, response: Response) => {
+  await serverClient.completeInteractiveLogin(new URL(request.url, appBaseUrl), {
+    request,
+    response,
+  });
+  response.redirect('/profile');
+});
+
+app.get('/auth/logout', async (request: Request, response: Response) => {
+  const logoutUrl = await serverClient.logout({ returnTo: appBaseUrl }, { request, response });
+  response.redirect(logoutUrl.href);
+});
+
+app.get('/profile', async (request: Request, response: Response) => {
+  const user = await serverClient.getUser({ request, response });
+
+  if (!user) {
+    response.redirect('/auth/login');
+    return;
+  }
+
+  response.json({ user });
+});
+
+app.post('/transfers', async (request: Request, response: Response) => {
+  const { amount, to } = request.body ?? {};
+
+  const tokenSet = await serverClient.getAccessToken({ request, response });
+
+  const upstream = await fetch(new URL('/transfers', process.env.AUTH0_AUDIENCE).toString(), {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${tokenSet.accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ amount, to }),
+  });
+
+  response.status(upstream.status).json(await upstream.json());
+});
+
+app.listen(3000, () => {
+  console.log(`Barkbook web listening on ${appBaseUrl}`);
+});

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-server-js/auth0/src/store/express-cookie-handler.ts
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-server-js/auth0/src/store/express-cookie-handler.ts
@@ -1,0 +1,39 @@
+import type { CookieHandler, CookieSerializeOptions } from '@auth0/auth0-server-js';
+import type { StoreOptions } from '../types.js';
+
+export class ExpressCookieHandler implements CookieHandler<StoreOptions> {
+  setCookie(name: string, value: string, options?: CookieSerializeOptions, storeOptions?: StoreOptions): void {
+    if (!storeOptions) {
+      throw new Error('StoreOptions not provided');
+    }
+
+    // The SDK gives maxAge in seconds; Express expects milliseconds.
+    const maxAge = options?.maxAge != null ? options.maxAge * 1000 : undefined;
+
+    storeOptions.response.cookie(name, value, { ...options, maxAge });
+  }
+
+  getCookie(name: string, storeOptions?: StoreOptions): string | undefined {
+    if (!storeOptions) {
+      throw new Error('StoreOptions not provided');
+    }
+
+    return storeOptions.request.cookies[name];
+  }
+
+  getCookies(storeOptions?: StoreOptions): Record<string, string> {
+    if (!storeOptions) {
+      throw new Error('StoreOptions not provided');
+    }
+
+    return storeOptions.request.cookies;
+  }
+
+  deleteCookie(name: string, storeOptions?: StoreOptions, options?: CookieSerializeOptions): void {
+    if (!storeOptions) {
+      throw new Error('StoreOptions not provided');
+    }
+
+    storeOptions.response.clearCookie(name, options);
+  }
+}

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-server-js/auth0/src/types.ts
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-server-js/auth0/src/types.ts
@@ -1,0 +1,6 @@
+import type { Request, Response } from 'express';
+
+export interface StoreOptions {
+  request: Request;
+  response: Response;
+}

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-server-js/auth0/tsconfig.json
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-server-js/auth0/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "moduleDetection": "force",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/evals/src/runners/gemini-cli/translator.ts
+++ b/packages/evals/src/runners/gemini-cli/translator.ts
@@ -75,14 +75,9 @@ export class GeminiCliTranslator extends BaseToolTranslator {
       case 'grep':
         return { path: args.path ?? '.', command: `grep "${String(args.pattern ?? '')}"` };
       case 'web_fetch': {
-        // Gemini CLI embeds the URL inside a `prompt` field, not a `url` field.
-        // Extract the first http(s) URL from the prompt; fall back to the raw
-        // prompt text if none is found, and to '' if neither field is present.
-        const explicit = String(args.url ?? '');
-        if (explicit) return { url: explicit };
+        if (args.url) return { url: String(args.url) };
         const prompt = String(args.prompt ?? '');
-        const match = prompt.match(/https?:\/\/[^\s"')\]>]+/);
-        return { url: match ? match[0] : prompt };
+        return { url: prompt.match(/https?:\/\/[^\s"')\]>]+/)?.[0] ?? prompt };
       }
       case 'web_search':
         return { url: args.query ?? '' };

--- a/packages/evals/src/runners/gemini-cli/translator.ts
+++ b/packages/evals/src/runners/gemini-cli/translator.ts
@@ -74,8 +74,16 @@ export class GeminiCliTranslator extends BaseToolTranslator {
         return { path: args.pattern ?? args.path ?? '' };
       case 'grep':
         return { path: args.path ?? '.', command: `grep "${String(args.pattern ?? '')}"` };
-      case 'web_fetch':
-        return { url: args.url ?? '' };
+      case 'web_fetch': {
+        // Gemini CLI embeds the URL inside a `prompt` field, not a `url` field.
+        // Extract the first http(s) URL from the prompt; fall back to the raw
+        // prompt text if none is found, and to '' if neither field is present.
+        const explicit = String(args.url ?? '');
+        if (explicit) return { url: explicit };
+        const prompt = String(args.prompt ?? '');
+        const match = prompt.match(/https?:\/\/[^\s"')\]>]+/);
+        return { url: match ? match[0] : prompt };
+      }
       case 'web_search':
         return { url: args.query ?? '' };
       case 'activate_skill':


### PR DESCRIPTION
Gemini CLI's `web_fetch` tool passes the URL inside a `prompt` field, not a `url` field — its schema description reads "Include up to 20 URLs and instructions directly in the 'prompt' parameter." The translator's `args.url ?? ''` fallback therefore always stored an empty string, so fetch_url steps in the session trace showed `url=` with nothing after it and the docs-quality scorer never saw a valid URL.

The fix tries `args.url` first (keeps existing tests green), then extracts the first `https?://` match from `args.prompt`. If the prompt contains no URL the raw prompt text is stored instead, and `{}` falls back to `''` as before.