### PR TITLE
chore(models): replace gemini-3.5-flash with gemini-3-7-flash

### DIFF
--- a/packages/evals-core/src/config/costs.ts
+++ b/packages/evals-core/src/config/costs.ts
@@ -8,7 +8,7 @@ export const COST_TABLE: Record<string, [number, number]> = {
   'claude-opus-5': [5.0, 25.0],
   'claude-haiku-4-5': [1.0, 5.0],
   'gemini-3.1-pro-preview': [2.0, 12.0],
-  'gemini-3.5-flash': [1.5, 9.0],
+  'gemini-3-7-flash': [0.75, 3.75],
 };
 
 /** [input, output] USD per million tokens applied to models absent from COST_TABLE. */

--- a/packages/evals/README.md
+++ b/packages/evals/README.md
@@ -78,7 +78,7 @@ export default {
     known: [
       'gpt-5.4', 'gpt-5.4-mini',
       'claude-sonnet-4-6', 'claude-opus-4-6', 'claude-opus-4-7', 'claude-haiku-4-5',
-      'gemini-3.1-pro-preview', 'gemini-3.5-flash',
+      'gemini-3.1-pro-preview', 'gemini-3-7-flash',
     ],
     default: 'gpt-5.4',
   },

--- a/packages/evals/src/cli/constants.ts
+++ b/packages/evals/src/cli/constants.ts
@@ -17,7 +17,7 @@ export const KNOWN_WORKING_MODELS = [
   'claude-opus-5',
   'claude-haiku-4-5',
   'gemini-3.1-pro-preview',
-  'gemini-3.5-flash',
+  'gemini-3-7-flash',
 ];
 
 /** Model used when no `--model` flag is provided. */


### PR DESCRIPTION
### Description

Swaps `gemini-3.5-flash` for `gemini-3-7-flash` across the model registry. Gemini 3.7 Flash is Google's latest coding-focused Flash model, scoring 65.3% on DeepSWE v1.1 vs 49.0% for its predecessor. Pricing is also updated to reflect current rates.

Changes:
- `packages/evals/src/cli/constants.ts`: updated `KNOWN_WORKING_MODELS` array
- `packages/evals-core/src/config/costs.ts`: updated `COST_TABLE` entry from `[1.5, 9.0]` to `[0.75, 3.75]` (USD per 1M tokens, input/output)
- `packages/evals/README.md`: updated model list in docs

### References

- https://blog.google/innovation-and-ai/models-and-research/gemini-models/introducing-gemini-3-7-flash/

### Testing

Registry-only change - no logic modified. Existing tests pass unchanged.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch