### PR TITLE
fix(models): correct gemini-3-7-flash to gemini-3.7-flash

### DIFF
--- a/packages/evals-core/src/config/costs.ts
+++ b/packages/evals-core/src/config/costs.ts
@@ -8,7 +8,7 @@ export const COST_TABLE: Record<string, [number, number]> = {
   'claude-opus-5': [5.0, 25.0],
   'claude-haiku-4-5': [1.0, 5.0],
   'gemini-3.1-pro-preview': [2.0, 12.0],
-  'gemini-3-7-flash': [0.75, 3.75],
+  'gemini-3.7-flash': [0.75, 3.75],
 };
 
 /** [input, output] USD per million tokens applied to models absent from COST_TABLE. */

--- a/packages/evals/README.md
+++ b/packages/evals/README.md
@@ -78,7 +78,7 @@ export default {
     known: [
       'gpt-5.4', 'gpt-5.4-mini',
       'claude-sonnet-4-6', 'claude-opus-4-6', 'claude-opus-4-7', 'claude-haiku-4-5',
-      'gemini-3.1-pro-preview', 'gemini-3-7-flash',
+      'gemini-3.1-pro-preview', 'gemini-3.7-flash',
     ],
     default: 'gpt-5.4',
   },

--- a/packages/evals/src/cli/constants.ts
+++ b/packages/evals/src/cli/constants.ts
@@ -17,7 +17,7 @@ export const KNOWN_WORKING_MODELS = [
   'claude-opus-5',
   'claude-haiku-4-5',
   'gemini-3.1-pro-preview',
-  'gemini-3-7-flash',
+  'gemini-3.7-flash',
 ];
 
 /** Model used when no `--model` flag is provided. */


### PR DESCRIPTION
## Changes

Corrects the model name from `gemini-3-7-flash` (hyphen) to `gemini-3.7-flash` (dot) to match the actual model ID.

Files changed:
- `packages/evals-core/src/config/costs.ts`
- `packages/evals/src/cli/constants.ts`
- `packages/evals/README.md`

## References

- Follows up on #243 which introduced the typo