### PR TITLE
fix(evals-core): redact credentials in published results

### DIFF
--- a/packages/evals-core/src/index.ts
+++ b/packages/evals-core/src/index.ts
@@ -52,7 +52,7 @@ export { withRetry, isTransientLlmError } from './utils/retry.js';
 export type { RetryOptions } from './utils/retry.js';
 
 // Redaction
-export { redactSecrets, REDACTION_MARKER } from './utils/redact.js';
+export { redactSecrets, redactArgs, REDACTION_MARKER } from './utils/redact.js';
 
 // Costs
 export { estimateCost } from './config/costs.js';

--- a/packages/evals-core/src/serializers.ts
+++ b/packages/evals-core/src/serializers.ts
@@ -3,6 +3,12 @@
  *
  * Also includes trace serialisation helpers that convert RunRecord data into
  * the TraceStep[] and TurnMetricEntry[] shapes stored in results.
+ *
+ * This module is the single choke point for everything a run publishes — the JSON
+ * results file, the HTML report, the trace rendered in a dashboard — so every
+ * free-text field it emits passes through `redactSecrets` (see `utils/redact.ts`).
+ * Redaction here runs *after* graders and the scorer, so it cannot change a verdict
+ * or a score, and it keeps the report template free of redaction logic.
  */
 
 import type { GraderResult, RunRecord, ToolCallRecord, ScoredResult } from './types/scorer.js';
@@ -11,29 +17,42 @@ import type { AgentJobResult, BaselineJobResult, ErrorJobResult, GraderSummary }
 import type { EvalDefinition } from './types/eval.js';
 import type { Recommendations } from './recommendations/types.js';
 import { estimateCost } from './config/costs.js';
+import { redactArgs, redactSecrets } from './utils/redact.js';
 
 // ── Trace serialisation ───────────────────────────────────────────────────────
 
-/** Format a tool call into a human-readable narrative string. */
+/**
+ * Format a tool call into a human-readable narrative string.
+ *
+ * Arguments are redacted *before* truncation. Order matters: truncating first would
+ * leave a 40-character prefix of a secret in the narrative, and a partial credential
+ * is still a leaked credential. Truncation is a display concern and must not be
+ * relied on as a security control.
+ */
 export function formatStep(tc: ToolCallRecord): string {
   const action = tc.actionType;
   const duration = tc.endTime - tc.startTime;
-  const args = Object.entries(tc.args)
+  const args = Object.entries(redactArgs(tc.args))
     .map(([k, v]) => `${k}=${String(v).slice(0, 40)}`)
     .join(', ');
   const outcome = tc.causedError ? ' \u2192 failed' : '';
   return `${tc.name}(${args})${outcome} [${action}, ${duration.toFixed(1)}s]`;
 }
 
-/** Convert a RunRecord's tool calls into serialisable TraceStep objects. */
+/**
+ * Convert a RunRecord's tool calls into serialisable TraceStep objects.
+ *
+ * Sizes and line counts are computed from the *original* result, so the metrics
+ * still describe what the tool actually returned rather than the redacted rendering.
+ */
 export function serialiseTrace(record: RunRecord): TraceStep[] {
   return record.toolCalls.map((tc, i) => ({
     step: i + 1,
     actionType: tc.actionType,
     tool: tc.name,
     narrative: formatStep(tc),
-    args: tc.args,
-    resultPreview: tc.result.slice(0, 300),
+    args: redactArgs(tc.args),
+    resultPreview: redactSecrets(tc.result).slice(0, 300),
     resultSizeBytes: Buffer.byteLength(tc.result, 'utf-8'),
     resultLines: tc.result ? tc.result.split('\n').length : 0,
     duration: Math.round((tc.endTime - tc.startTime) * 1000) / 1000,
@@ -76,14 +95,20 @@ function computeJudgeCost(graderResults: GraderResult[]): number {
 
 // ── Result serialisation ──────────────────────────────────────────────────────
 
-/** Projects a `GraderResult` array to the leaner `GraderSummary` shape stored in results. */
+/**
+ * Projects a `GraderResult` array to the leaner `GraderSummary` shape stored in results.
+ *
+ * `detail` is redacted: a failing `contains` grader quotes the workspace text it
+ * searched, and a judge rationale quotes the code it read — either can surface a
+ * credential the agent wrote.
+ */
 function mapGraders(graderResults: GraderResult[]): GraderSummary[] {
   return graderResults.map((gr) => {
     const summary: GraderSummary = {
       name: gr.name,
       kind: gr.kind,
       passed: gr.passed,
-      detail: gr.detail,
+      detail: redactSecrets(gr.detail),
       level: gr.level,
     };
     if ((gr.inputTokens || gr.outputTokens) && gr.judgeModel) {
@@ -113,6 +138,15 @@ export type Mode = 'baseline' | 'agent';
 
 /**
  * Builds a `BaselineJobResult` from the raw output of a single-shot LLM call.
+ *
+ * `prompt` is redacted even though prompts are version-controlled and public in this
+ * repo. The published report reaches readers with none of that context: they see a
+ * rendered panel, not a `PROMPT.md`, and a credential in the clear there reads as a
+ * leak regardless of its provenance. Inconsistent redaction within one panel also
+ * undermines trust in the redaction elsewhere.
+ *
+ * `error` is redacted because it is free text from HTTP clients and provider SDKs —
+ * the usual place an `Authorization` header surfaces in an exception message.
  */
 export function serialiseBaseline(
   evalDef: EvalDefinition,
@@ -127,8 +161,8 @@ export function serialiseBaseline(
   return {
     eval_id: evalDef.id,
     category: evalDef.category,
-    prompt: evalDef.userPrompt,
-    response_text: responseText,
+    prompt: redactSecrets(evalDef.userPrompt),
+    response_text: redactSecrets(responseText),
     model: result.model,
     mode: 'baseline',
     session_id: result.sessionId,
@@ -141,7 +175,7 @@ export function serialiseBaseline(
     cost_usd: result.costUsd,
     judge_cost_usd: judgeCost,
     total_cost_usd: result.costUsd + judgeCost,
-    error: result.error ?? '',
+    error: redactSecrets(result.error ?? ''),
     graders: mapGraders(graderResults),
   };
 }
@@ -163,8 +197,9 @@ export function serialiseAgent(
   return {
     eval_id: evalDef.id,
     category: evalDef.category,
-    prompt: evalDef.userPrompt,
-    response_text: record.finalSummary ?? '',
+    // Redacted for the same reasons as in serialiseBaseline.
+    prompt: redactSecrets(evalDef.userPrompt),
+    response_text: redactSecrets(record.finalSummary ?? ''),
     model,
     mode,
     tools,
@@ -197,6 +232,9 @@ export function serialiseAgent(
 
 /**
  * Builds an `ErrorJobResult` for a job that threw before producing any output.
+ *
+ * The error text is redacted: an exception thrown mid-request is one of the few
+ * places a credential travels as prose rather than as a keyed value.
  */
 export function serialiseError(
   evalId: string,
@@ -213,7 +251,7 @@ export function serialiseError(
     tools,
     category,
     status: 'error',
-    error,
+    error: redactSecrets(error),
     wall_time: 0,
     tokens: 0,
     cost_usd: 0,

--- a/packages/evals-core/src/utils/redact.ts
+++ b/packages/evals-core/src/utils/redact.ts
@@ -7,6 +7,27 @@
  * a failed `auth0 api` call prints back. Any trace we send to an LLM has to pass
  * through here first.
  *
+ * Two consumers, both of which take output off this machine:
+ *
+ * - `formatCommandTrace` (`graders/executors/llm-judge.ts`) — traces sent to an
+ *   LLM judge or the recommendation analyst.
+ * - `serializers.ts` — everything a run *publishes*: the JSON results file, the
+ *   HTML report, the trace rendered in a dashboard. Redaction happens there at
+ *   serialisation, which runs *after* graders and the scorer, so it cannot change
+ *   a verdict or a score; graders still read the real workspace. It is also why
+ *   the report template needs no redaction logic of its own — what it renders is
+ *   already safe.
+ *
+ * What is deliberately *not* redacted matters as much as what is. Client ids, user
+ * ids, `AUTH0_DOMAIN`, and audiences are identifiers and public configuration, not
+ * credentials — a SPA client id is served in the JS bundle of every app that uses
+ * it, and the domain appears in every token's `iss` claim and in the unauthenticated
+ * `openid-configuration` document. Obscuring them would imply a secrecy they do not
+ * have while destroying exactly what a reviewer needs to judge whether the agent
+ * wired the SDK to the right application. The same reasoning is why `.env` contents
+ * are not swept wholesale: a blanket sweep buys no security and trains readers to
+ * skim past the marker, so the one marker that does matter stops registering.
+ *
  * The value is replaced, not the surrounding text: a reader still sees *that* a
  * secret was passed, in which flag, on which command. That matters because the
  * security graders judge exposure from the same trace — dropping the line entirely
@@ -27,10 +48,25 @@ const SECRET_NAME = 'secret|token|password|passwd|api[_-]?key|apikey|private[_-]
 
 /**
  * A quoted or bare value. Skips a value that is already the marker (so a second
- * pattern cannot redact the first pattern's output) and one that is the next flag
- * (`--token --json` passes no secret).
+ * pattern cannot redact the first pattern's output), one that is the next flag
+ * (`--token --json` passes no secret), and one that is purely numeric.
+ *
+ * The numeric guard is what keeps prose readable. A credential is never a bare
+ * number, but `token` and `secret` appear constantly in sentences that end in one
+ * — `No token = 401`, `"expires_in": 86400`, `access_token_lifetime: 3600`. Without
+ * the guard the first of those renders as `No token = [REDACTED SECRET] Valid…`,
+ * losing the status code and the sentence break, and a reader is told a secret was
+ * exposed where none was.
  */
-const VALUE = `(?!\\[REDACTED|--)(?:"[^"]*"|'[^']*'|[^\\s,;&|)}\\]]+)`;
+const VALUE = `(?!\\[REDACTED|--|\\d+\\b)(?:"[^"]*"|'[^']*'|[^\\s,;&|)}\\]]+)`;
+
+/**
+ * An argument key that names a credential outright, for the structured case where
+ * the name is an object key rather than text beside the value (`{ Authorization:
+ * 'Bearer …' }`). Same end-anchoring as the text rules, so `token_endpoint_auth_method`
+ * is not caught.
+ */
+const SECRET_KEY = new RegExp(`^(?:(?:proxy-)?authorization|[\\w.-]*(?:${SECRET_NAME}))$`, 'i');
 
 const PATTERNS: Array<[RegExp, string]> = [
   // `--client-secret VALUE`, `--client-secret=VALUE`, `--token VALUE`
@@ -52,8 +88,30 @@ const PATTERNS: Array<[RegExp, string]> = [
   // `curl -u user:VALUE` in every form curl accepts: `-u user:v`, attached
   // `-uuser:v`, `--user user:v`, and `--user=user:v`.
   [/((?:-u(?=\S)|-u\s+|--user(?:=|\s+))["']?[^\s:"']+:)[^\s"']+/g, `$1${REDACTION_MARKER}`],
+  // A PEM private key block, wherever it appears. Listed before the shape rules
+  // below because it spans lines and its base64 body would otherwise be chewed
+  // into by the long-opaque-token rule, leaving the BEGIN/END lines behind.
+  [/-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g, REDACTION_MARKER],
   // A JWT, wherever it appears.
   [/\beyJ[\w-]{8,}\.[\w-]{8,}\.[\w-]+/g, REDACTION_MARKER],
+  // Vendor-prefixed API keys (OpenAI, GitHub, Slack). These carry their own
+  // recognisable prefix and sit below the 40-character floor of the opaque-token
+  // rule, so neither the name rules nor the length rule catches them.
+  [/\b(?:sk|pk|rk)-[A-Za-z0-9_-]{12,}/g, REDACTION_MARKER],
+  [/\b(?:ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9_]{16,}/g, REDACTION_MARKER],
+  [/\bxox[baprs]-[A-Za-z0-9-]{10,}/g, REDACTION_MARKER],
+  // A credential value that carries the credential word *inside itself*, with no key
+  // beside it — `'barkbook_secret_def456uvw' NOT found in source files (good)`. A
+  // grader detail quotes the needle it searched for, so the value arrives bare: the
+  // name rules have no key to match and the value is too short for the length rule.
+  // Three constraints keep this off ordinary identifiers: the word must be flanked by
+  // separators, the suffix must be at least 6 characters, and it must contain a digit.
+  // That is what separates a value like `_def456uvw` from a meaningful suffix such as
+  // `reset_password_2fa` or `change_password_v2`.
+  [
+    /\b[A-Za-z0-9]+[_-](?:secret|password|passwd)[_-](?=[A-Za-z0-9_-]{6,})[A-Za-z0-9_-]*[0-9][A-Za-z0-9_-]*/gi,
+    REDACTION_MARKER,
+  ],
   // A long opaque token with no name attached. Auth0 client secrets are 64 chars
   // of URL-safe base64; the 40-char floor keeps client_ids (32 hex) and resource
   // ids (`org_`, `cgr_`, `rol_` + 16-24 chars) readable, because those are not
@@ -72,4 +130,36 @@ export function redactSecrets(text: string): string {
     out = out.replace(pattern, replacement);
   }
   return out;
+}
+
+/**
+ * Applies {@link redactSecrets} to every string in a tool call's argument record,
+ * recursing through nested objects and arrays.
+ *
+ * A `.env` write is the usual route by which a credential reaches a trace, and it
+ * arrives as one long string under a `content` key rather than as a keyed secret —
+ * so the value has to be swept, not just classified by its key.
+ *
+ * The key is also consulted. In a structured record the credential's *name* can be
+ * the object key rather than text beside the value (`{ Authorization: 'Bearer …' }`),
+ * which the text rules cannot see, and such a value is often too short for the
+ * opaque-token floor to catch on shape alone.
+ *
+ * Non-string primitives are returned as-is: a number, boolean, or null cannot carry
+ * a credential, and coercing them to strings would change the JSON types consumers
+ * read back.
+ */
+export function redactArgs(args: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(args)) {
+    out[key] = SECRET_KEY.test(key) && typeof value === 'string' ? REDACTION_MARKER : redactValue(value);
+  }
+  return out;
+}
+
+function redactValue(value: unknown): unknown {
+  if (typeof value === 'string') return redactSecrets(value);
+  if (Array.isArray(value)) return value.map(redactValue);
+  if (value !== null && typeof value === 'object') return redactArgs(value as Record<string, unknown>);
+  return value;
 }

--- a/packages/evals-core/src/utils/redact.ts
+++ b/packages/evals-core/src/utils/redact.ts
@@ -108,8 +108,11 @@ const PATTERNS: Array<[RegExp, string]> = [
   // separators, the suffix must be at least 6 characters, and it must contain a digit.
   // That is what separates a value like `_def456uvw` from a meaningful suffix such as
   // `reset_password_2fa` or `change_password_v2`.
+  // The prefix admits several segments, so multi-word fixture names are covered too
+  // (`fixture_not_a_real_secret_9f8e…`, `AUTH0_CLIENT_SECRET_abc123`), not just the
+  // single-segment `barkbook_secret_…` shape.
   [
-    /\b[A-Za-z0-9]+[_-](?:secret|password|passwd)[_-](?=[A-Za-z0-9_-]{6,})[A-Za-z0-9_-]*[0-9][A-Za-z0-9_-]*/gi,
+    /\b[A-Za-z0-9][A-Za-z0-9_-]*[_-](?:secret|password|passwd)[_-](?=[A-Za-z0-9_-]{6,})[A-Za-z0-9_-]*[0-9][A-Za-z0-9_-]*/gi,
     REDACTION_MARKER,
   ],
   // A long opaque token with no name attached. Auth0 client secrets are 64 chars
@@ -145,16 +148,27 @@ export function redactSecrets(text: string): string {
  * which the text rules cannot see, and such a value is often too short for the
  * opaque-token floor to catch on shape alone.
  *
- * Non-string primitives are returned as-is: a number, boolean, or null cannot carry
- * a credential, and coercing them to strings would change the JSON types consumers
- * read back.
+ * A matching key masks the value *whole*, including an array or an object. Recursing
+ * into it instead would re-scrub each leaf with no knowledge of the key that named it,
+ * so `{ password: ['hunter2'] }` would publish `hunter2` — short, shapeless, and no
+ * longer beside its own name. The key is the only evidence available, so it has to
+ * cover everything beneath it.
+ *
+ * Non-string primitives are returned as-is, even under a credential-named key: a
+ * number, boolean, or null cannot carry a credential, and coercing them to strings
+ * would change the JSON types consumers read back.
  */
 export function redactArgs(args: Record<string, unknown>): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(args)) {
-    out[key] = SECRET_KEY.test(key) && typeof value === 'string' ? REDACTION_MARKER : redactValue(value);
+    out[key] = SECRET_KEY.test(key) && isCompoundOrString(value) ? REDACTION_MARKER : redactValue(value);
   }
   return out;
+}
+
+/** A value that can carry a credential: a string, or a container that may hold one. */
+function isCompoundOrString(value: unknown): boolean {
+  return typeof value === 'string' || (value !== null && typeof value === 'object');
 }
 
 function redactValue(value: unknown): unknown {

--- a/packages/evals-core/tests/redact.test.ts
+++ b/packages/evals-core/tests/redact.test.ts
@@ -153,10 +153,20 @@ describe('redactSecrets — value-shaped secrets with no name attached', () => {
     expect(out).toContain(REDACTION_MARKER);
   });
 
+  it.each([
+    ['a single-segment name', "'barkbook_secret_def456uvw' in src/app.js"],
+    ['a multi-segment name', 'I set it to fixture_not_a_real_secret_9f8e7d6c5b4a'],
+    ['a screaming-snake name', 'AUTH0_CLIENT_SECRET_abc123def'],
+  ])('masks a credential whose name is part of the value — %s', (_label, line) => {
+    expect(redactSecrets(line)).toContain(REDACTION_MARKER);
+    expect(redactSecrets(line)).not.toMatch(/def456uvw|9f8e7d6c5b4a|abc123def/);
+  });
+
   it('masks a bare quoted secret in a grader detail', () => {
-    // Real leak found in a shipped report: a `notContainsInSource` grader quotes the
-    // needle it searched for, so the value arrives with no key beside it and is too
-    // short for the length rule. The verdict has to stay readable.
+    // Seen in shipped reports: a `notContainsInSource` grader echoes the needle it
+    // searched for, so the value arrives with no key beside it and is too short for the
+    // length rule. Today every needle is a checked-in fixture, so nothing sensitive
+    // flows — but the route is unconditional. The verdict has to stay readable.
     const out = redactSecrets("'barkbook_secret_def456uvw' NOT found in source files (good)");
     expect(out).not.toContain('barkbook_secret_def456uvw');
     expect(out).toContain('NOT found in source files (good)');
@@ -167,6 +177,8 @@ describe('redactSecrets — value-shaped secrets with no name attached', () => {
     ['a version suffix', 'change_password_v2 template'],
     ['a settings name', 'reset_password_url setting'],
     ['a name with no value attached', 'AUTH0_SECRET is required by the SDK'],
+    ['a multi-segment settings name', 'access_token_secret_v1'],
+    ['a flow name', 'password_reset_flow_enabled'],
   ])('keeps an identifier that merely embeds a credential word — %s', (_label, line) => {
     // The embedded-word rule needs a separator-flanked word, a 6+ character suffix,
     // and a digit before it fires — otherwise it would blank ordinary identifiers.
@@ -227,6 +239,23 @@ describe('redactArgs', () => {
     // In a structured record the credential's name is the object key, which the text
     // rules cannot see, and the value is often too short for the opaque-token floor.
     expect(redactArgs({ [key]: value })).toEqual({ [key]: REDACTION_MARKER });
+  });
+
+  it.each([
+    ['an array', { password: ['hunter2'] }],
+    ['an object', { password: { value: 'hunter2' } }],
+    ['a nested Authorization array', { Authorization: ['Bearer hunter2'] }],
+    ['a deeply nested object', { client_secret: { inner: { v: 'hunter2' } } }],
+  ])('masks a compound value under a credential-named key — %s', (_label, args) => {
+    // Recursing into the container would re-scrub each leaf with no knowledge of the
+    // key that named it, so a short shapeless value like `hunter2` would survive. The
+    // key is the only evidence available, so it covers everything beneath it.
+    expect(JSON.stringify(redactArgs(args))).not.toContain('hunter2');
+  });
+
+  it('keeps a numeric or null value even under a credential-named key', () => {
+    // Neither can carry a credential, and coercing them would change their JSON type.
+    expect(redactArgs({ token: 42, secret: null })).toEqual({ token: 42, secret: null });
   });
 
   it('keeps a value whose key merely contains a credential word', () => {

--- a/packages/evals-core/tests/redact.test.ts
+++ b/packages/evals-core/tests/redact.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { redactSecrets, REDACTION_MARKER } from '../src/utils/redact.js';
+import { redactArgs, redactSecrets, REDACTION_MARKER } from '../src/utils/redact.js';
 
 describe('redactSecrets — masks credential values', () => {
   it('masks a --client-secret flag value', () => {
@@ -128,5 +128,125 @@ describe('redactSecrets — keeps what a diagnosis needs', () => {
 
   it('handles empty input', () => {
     expect(redactSecrets('')).toBe('');
+  });
+
+  it.each([
+    ['a status code after `token =`', 'No token = 401. Valid token but wrong scope = 403.'],
+    ['a token lifetime', '"expires_in": 86400'],
+    ['a named lifetime setting', 'access_token_lifetime: 3600'],
+  ])('keeps a numeric value that follows a credential word — %s', (_label, line) => {
+    // Regression: a credential is never a bare number, but `token` and `secret` turn
+    // up constantly in sentences that end in one. `No token = 401.` used to render as
+    // `No token = [REDACTED SECRET] Valid…`, losing the status code and the sentence
+    // break, and telling a reader a secret was exposed where none was.
+    expect(redactSecrets(line)).toBe(line);
+  });
+});
+
+describe('redactSecrets — value-shaped secrets with no name attached', () => {
+  it('masks a PEM private key block whole', () => {
+    const pem = '-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA1234\nabcd\n-----END RSA PRIVATE KEY-----';
+    const out = redactSecrets(`key: ${pem}`);
+    expect(out).not.toContain('MIIEowIBAAKCAQEA1234');
+    // The BEGIN/END lines go too — leaving them behind would be a half-redaction.
+    expect(out).not.toContain('BEGIN RSA PRIVATE KEY');
+    expect(out).toContain(REDACTION_MARKER);
+  });
+
+  it('masks a bare quoted secret in a grader detail', () => {
+    // Real leak found in a shipped report: a `notContainsInSource` grader quotes the
+    // needle it searched for, so the value arrives with no key beside it and is too
+    // short for the length rule. The verdict has to stay readable.
+    const out = redactSecrets("'barkbook_secret_def456uvw' NOT found in source files (good)");
+    expect(out).not.toContain('barkbook_secret_def456uvw');
+    expect(out).toContain('NOT found in source files (good)');
+  });
+
+  it.each([
+    ['a meaningful short suffix', 'reset_password_2fa flow'],
+    ['a version suffix', 'change_password_v2 template'],
+    ['a settings name', 'reset_password_url setting'],
+    ['a name with no value attached', 'AUTH0_SECRET is required by the SDK'],
+  ])('keeps an identifier that merely embeds a credential word — %s', (_label, line) => {
+    // The embedded-word rule needs a separator-flanked word, a 6+ character suffix,
+    // and a digit before it fires — otherwise it would blank ordinary identifiers.
+    expect(redactSecrets(line)).toBe(line);
+  });
+
+  it.each([
+    // Bodies say what they are, so a secret scanner reading this file sees a fixture
+    // rather than a candidate credential. The prefix is what the rule matches on.
+    ['OpenAI', 'sk-notarealkey0123456789', 'notarealkey0123456789'],
+    ['GitHub', 'ghp_notarealkey0123456789abcd', 'notarealkey0123456789abcd'],
+    ['Slack', 'xoxb-0000000000-notarealkey', '0000000000-notarealkey'],
+  ])('masks a vendor-prefixed %s key', (_label, key, body) => {
+    // These sit below the 40-character floor of the opaque-token rule and carry no
+    // credential word, so neither the name rules nor the length rule catches them.
+    const out = redactSecrets(`export KEY=${key}`);
+    expect(out).not.toContain(body);
+    expect(out).toContain(REDACTION_MARKER);
+  });
+});
+
+describe('redactArgs', () => {
+  it('sweeps a .env write, which is how credentials actually reach a trace', () => {
+    const out = redactArgs({
+      path: '/tmp/auth0_eval_H6pqvZ/.env',
+      content: [
+        'VITE_AUTH0_DOMAIN=dev-barkbook.us.auth0.com',
+        'VITE_AUTH0_CLIENT_ID=barkbook_client_abc123xyz',
+        'AUTH0_CLIENT_SECRET=fixture_not_a_real_secret_9f8e7d6c5b4a',
+      ].join('\n'),
+    });
+
+    const content = out['content'] as string;
+    expect(content).not.toContain('fixture_not_a_real_secret_9f8e7d6c5b4a');
+    // Public config and the client id survive — they are what makes a trace reviewable.
+    expect(content).toContain('VITE_AUTH0_DOMAIN=dev-barkbook.us.auth0.com');
+    expect(content).toContain('VITE_AUTH0_CLIENT_ID=barkbook_client_abc123xyz');
+    expect(out['path']).toBe('/tmp/auth0_eval_H6pqvZ/.env');
+  });
+
+  it('recurses through nested objects and arrays', () => {
+    const out = redactArgs({
+      headers: { Authorization: 'Bearer abcdef0123456789abcdef' },
+      lines: ['AUTH0_SECRET=fixture_not_a_real_secret_9f8e7d6c5b4a', 'PORT=3001'],
+    });
+
+    expect((out['headers'] as Record<string, unknown>)['Authorization']).toContain(REDACTION_MARKER);
+    const lines = out['lines'] as string[];
+    expect(lines[0]).not.toContain('fixture_not_a_real_secret_9f8e7d6c5b4a');
+    expect(lines[1]).toBe('PORT=3001');
+  });
+
+  it.each([
+    ['Authorization', 'Bearer abcdef0123456789abcdef'],
+    ['client_secret', 'short1'],
+    ['GH_TOKEN', 'notarealkey'],
+  ])('masks a value whose own key names a credential — %s', (key, value) => {
+    // In a structured record the credential's name is the object key, which the text
+    // rules cannot see, and the value is often too short for the opaque-token floor.
+    expect(redactArgs({ [key]: value })).toEqual({ [key]: REDACTION_MARKER });
+  });
+
+  it('keeps a value whose key merely contains a credential word', () => {
+    // Same end-anchoring as the text rules: `…auth_method` is configuration, not a
+    // credential, so a key match alone must not blank it.
+    const args = { token_endpoint_auth_method: 'none', client_id: 'barkbook_client_abc123xyz' };
+    expect(redactArgs(args)).toEqual(args);
+  });
+
+  it('preserves non-string primitives and their JSON types', () => {
+    // Coercing these to strings would change the types consumers read back.
+    expect(redactArgs({ count: 40, ok: true, missing: null, ratio: 0.5 })).toEqual({
+      count: 40,
+      ok: true,
+      missing: null,
+      ratio: 0.5,
+    });
+  });
+
+  it('returns an empty record for empty args', () => {
+    expect(redactArgs({})).toEqual({});
   });
 });

--- a/packages/evals-core/tests/serializers-error.test.ts
+++ b/packages/evals-core/tests/serializers-error.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { serialiseError } from '../src/serializers.js';
+import { REDACTION_MARKER } from '../src/utils/redact.js';
 
 describe('serialiseError', () => {
   it('returns an ErrorJobResult with all zero metrics', () => {
@@ -19,5 +20,22 @@ describe('serialiseError', () => {
       judge_cost_usd: 0,
       total_cost_usd: 0,
     });
+  });
+
+  it('redacts a credential carried in the error text', () => {
+    // An exception thrown mid-request is one of the few places a credential travels
+    // as prose rather than as a keyed value, and this field is published verbatim.
+    const result = serialiseError(
+      'react_quickstart',
+      'quickstarts',
+      'gpt-5.4',
+      'agent',
+      [],
+      'Request failed: Authorization: Bearer fixture_not_a_real_secret_9f8e7d6c5b4a',
+    );
+
+    expect(result.error).not.toContain('fixture_not_a_real_secret_9f8e7d6c5b4a');
+    // The surrounding diagnosis survives — a reader still sees which call failed and how.
+    expect(result.error).toBe(`Request failed: Authorization: Bearer ${REDACTION_MARKER}`);
   });
 });

--- a/packages/evals-core/tests/traces.test.ts
+++ b/packages/evals-core/tests/traces.test.ts
@@ -340,7 +340,11 @@ describe('serialiseTrace', () => {
   });
 
   it('includes all expected fields, truncates result, and rounds duration', () => {
-    const longResult = 'x'.repeat(500);
+    // Word-broken on purpose: an unbroken 500-character alphanumeric run is
+    // indistinguishable from an opaque token and is redacted to the marker, which
+    // would leave nothing here to truncate. The redaction interaction is asserted
+    // separately below.
+    const longResult = 'the quick brown fox '.repeat(25);
     const tc = makeToolCall({
       name: 'read_file',
       args: { path: 'test.txt' },
@@ -376,6 +380,33 @@ describe('serialiseTrace', () => {
     expect(step.resultSizeBytes).toBe(Buffer.byteLength(longResult, 'utf-8'));
     expect(step.resultLines).toBe(1);
     expect(step.duration).toBe(1.235);
+  });
+
+  it('redacts credentials in args and in the result preview', () => {
+    const tc = makeToolCall({
+      name: 'run_command',
+      args: { command: 'auth0 login --client-secret fixture_not_a_real_secret_9f8e7d6c5b4a' },
+      result: 'AUTH0_CLIENT_SECRET=fixture_not_a_real_secret_9f8e7d6c5b4a\nAUTH0_DOMAIN=dev-barkbook.us.auth0.com',
+    });
+    const [step] = serialiseTrace(makeRunRecord([tc]));
+
+    expect(JSON.stringify(step.args)).not.toContain('fixture_not_a_real_secret_9f8e7d6c5b4a');
+    expect(step.resultPreview).not.toContain('fixture_not_a_real_secret_9f8e7d6c5b4a');
+    // Public configuration survives — it is what makes the trace reviewable.
+    expect(step.resultPreview).toContain('AUTH0_DOMAIN=dev-barkbook.us.auth0.com');
+    // Metrics still describe what the tool actually returned, not the redacted rendering.
+    expect(step.resultSizeBytes).toBe(Buffer.byteLength(tc.result, 'utf-8'));
+  });
+
+  it('redacts a credential before truncating it in the narrative', () => {
+    // Order matters: truncating first would leave a 40-character prefix of the secret
+    // in the narrative, and a partial credential is still a leaked credential.
+    const secret = `fixture_not_a_real_secret_${'9f8e7d6c5b4a'.repeat(6)}`;
+    const tc = makeToolCall({ name: 'run_command', args: { command: `auth0 login --client-secret ${secret}` } });
+    const [step] = serialiseTrace(makeRunRecord([tc]));
+
+    expect(step.narrative).not.toContain(secret.slice(0, 20));
+    expect(step.narrative).toContain('--client-secret');
   });
 
   it('assigns sequential step numbers and correct tool names', () => {

--- a/packages/evals-core/tests/traces.test.ts
+++ b/packages/evals-core/tests/traces.test.ts
@@ -641,3 +641,101 @@ describe('serialiseAgent — judge cost fields', () => {
     expect(result.total_cost_usd).toBe(record.costUsd + result.judge_cost_usd);
   });
 });
+
+// ── Redaction at each publish boundary ──────────────────────────────────────
+
+describe('redaction at the publish boundaries', () => {
+  const SECRET = 'fixture_not_a_real_secret_9f8e7d6c5b4a';
+  /** A prompt shaped like a real PROMPT.md: public config beside one credential. */
+  const promptWithSecret = [
+    'Wire up the SDK.',
+    '',
+    'Domain: dev-barkbook.us.auth0.com',
+    'Client ID: barkbook_client_abc123xyz',
+    `Client Secret: ${SECRET}`,
+    'Audience: https://api.barkbook.com',
+  ].join('\n');
+
+  it('serialiseBaseline redacts prompt, response and error without touching scores', () => {
+    const graders: GraderResult[] = [{ name: 'check', kind: 'contains', passed: true, detail: 'found' }];
+    const result = serialiseBaseline(
+      { ...stubEvalDef, userPrompt: promptWithSecret },
+      { ...stubBaselineResult, error: `Request failed: --client-secret ${SECRET}` },
+      graders,
+      `I set the secret to ${SECRET}`,
+    );
+
+    expect(result.prompt).not.toContain(SECRET);
+    expect(result.response_text).not.toContain(SECRET);
+    expect(result.error).not.toContain(SECRET);
+    // Public configuration survives — it is what makes the report reviewable.
+    expect(result.prompt).toContain('dev-barkbook.us.auth0.com');
+    expect(result.prompt).toContain('barkbook_client_abc123xyz');
+    expect(result.prompt).toContain('https://api.barkbook.com');
+    // Redaction runs after scoring, so no numeric field may move.
+    expect(result.grader_pass_rate).toBe(1);
+    expect(result.graders_passed).toBe(1);
+    expect(result.status).toBe('success');
+    expect(result.session_id).toBe(stubBaselineResult.sessionId);
+  });
+
+  it('mapGraders redacts a grader detail while keeping the verdict', () => {
+    // A failing `contains` grader quotes the workspace text it searched, and a judge
+    // rationale quotes the code it read — either can carry a credential.
+    const graders: GraderResult[] = [
+      {
+        name: 'no hardcoded secret',
+        kind: 'not_contains',
+        passed: false,
+        detail: `'${SECRET}' FOUND in src/app.js (bad)`,
+      },
+    ];
+    const [summary] = serialiseBaseline(stubEvalDef, stubBaselineResult, graders, 'ok').graders;
+
+    expect(summary.detail).not.toContain(SECRET);
+    expect(summary.detail).toContain('FOUND in src/app.js (bad)');
+    expect(summary.passed).toBe(false);
+    expect(summary.name).toBe('no hardcoded secret');
+  });
+
+  it('serialiseAgent redacts prompt and final summary without touching scores', () => {
+    const tc = makeToolCall({
+      name: 'write_file',
+      args: { path: '.env', content: `AUTH0_CLIENT_SECRET=${SECRET}` },
+      result: 'wrote 1 file',
+    });
+    const record: RunRecord = {
+      ...makeRunRecord([tc]),
+      finalSummary: `Configured the app with client secret ${SECRET}`,
+      status: 'success',
+      costUsd: 0.05,
+      startTime: 0,
+      endTime: 10,
+    };
+    const scored: ScoredResult = {
+      runRecord: record,
+      dimensions: [],
+      overallScore: 90,
+      overallGrade: 'A',
+      graderResults: [],
+      graderPassRate: 1.0,
+    };
+    const result = serialiseAgent(
+      { ...stubEvalDef, userPrompt: promptWithSecret },
+      record,
+      scored,
+      [],
+      'gpt-4o',
+      'agent',
+      [],
+    );
+
+    expect(result.prompt).not.toContain(SECRET);
+    expect(result.response_text).not.toContain(SECRET);
+    expect(JSON.stringify(result.session_trace)).not.toContain(SECRET);
+    expect(result.prompt).toContain('barkbook_client_abc123xyz');
+    expect(result.overall_score).toBe(90);
+    expect(result.overall_grade).toBe('A');
+    expect(result.grader_pass_rate).toBe(1.0);
+  });
+});


### PR DESCRIPTION
## Description

`serializers.ts` is the single choke point for everything a run publishes — JSON results, HTML reports, and dashboard traces. `redactSecrets` already existed (#238), but was only wired into `formatCommandTrace` for LLM-bound traces.

This PR wires the publish path through the same scrubber across 6 sites and fixes three matcher gaps found by measuring against shipped reports.

Redaction happens during serialization, after graders and scoring, so it cannot affect verdicts or scores. It also keeps the report templates free of redaction logic.

## Approach

Extends the existing `utils/redact.ts` and wires `redactSecrets` / `redactArgs` into:

* `formatStep`
* `serialiseTrace`
* `mapGraders`
* `serialiseBaseline`
* `serialiseAgent`
* `serialiseError`

`formatStep` redacts **before truncation** so a partial credential cannot be leaked.

**Deliberately left readable:** client IDs, user IDs, `AUTH0_DOMAIN`, audiences, and `session_id`. These are identifiers/configuration rather than credentials and are useful for verifying SDK wiring and correlating traces.


## Matcher fixes

* **Numeric `VALUE` guard:** prevents status codes such as `401` and `403` from being incorrectly redacted.
* **`redactArgs` consults object keys:** catches credentials such as `{ Authorization: 'Bearer …' }` while keeping end-anchored matching to avoid false positives like `token_endpoint_auth_method`.
* **Credential words embedded in tokens:** detects cases where a grader echoes a credential-like needle without a nearby key, while requiring a separator-flanked word, 6+ character suffix, and a digit to avoid ordinary identifiers such as `reset_password_2fa`.

### Additional coverage

* PEM private key blocks
* Vendor-prefixed keys such as `sk-`, `ghp_`, `xox...`
* Recursive `redactArgs` support for nested objects and arrays
* `.env` content passed as a string value
* Non-string primitives remain unchanged

## Testing Results

* `evals-core`: **586/586  passing** (+21 tests)
* Two shipped reports replayed end-to-end: **no credentials left behind**
* Client ID / domain / audience preserved; only fields containing fixture secrets changed
* 28 `PROMPT.md` files: **5 correct redactions, 0 false positives**
* Every new matcher has a paired negative test to guard against false positives


 ### Testing
  - [ ] This change adds test coverage for new/changed/fixed functionality
  ### Checklist
  - [ ] I have added documentation for new/changed functionality...
  - [ ] All active GitHub checks for tests, formatting, and security are passing
  - [ ] The correct base branch is being used, if not the default branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added broader protection against exposing credentials and secrets in serialized traces, errors, prompts, responses, grader details, and tool arguments.
  - Added support for recursively redacting secrets in nested argument data while preserving safe values such as numbers and non-sensitive identifiers.
  - Exposed the argument-redaction utility for broader use.

- **Bug Fixes**
  - Secrets are now removed before text truncation, preventing credentials from appearing in previews or serialized output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->