### PR TITLE
feat(evals): add SMS/email MFA CLI graders and notRanCommand primitive

### DIFF
--- a/apps/auth0-evals/src/evals/mfa/cli/PROMPT.md
+++ b/apps/auth0-evals/src/evals/mfa/cli/PROMPT.md
@@ -8,6 +8,17 @@ provision: auth0-tenant
 
 ## Task
 
-Our Auth0 tenant needs multi-factor authentication required for step-up flows — a factor merely being available is not enough; MFA must actually be enforced.
+Our Auth0 tenant needs two MFA channels configured and enforced using the Auth0 CLI:
 
-Using the Auth0 CLI, enable the required MFA factor on the tenant and then enforce MFA so it is required for users.
+**1. Phone (SMS) factor**
+- Enable the SMS factor on the tenant.
+- Set the message type to SMS (not voice).
+- Configure the phone provider. Use Auth0's built-in provider (suitable for testing).
+
+**2. Email factor**
+- Enable the email factor on the tenant.
+- Note: Auth0 requires at least one other factor to be enabled before email can be enabled.
+
+Finally, enforce MFA across all applications so it is required for every user — a factor merely being available is not enough.
+
+Do not use the Auth0 dashboard or Terraform. Use only the Auth0 CLI (`auth0 api` commands).

--- a/apps/auth0-evals/src/evals/mfa/cli/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/cli/graders.ts
@@ -1,4 +1,4 @@
-import { ranCommand, ranCommandOneOf, ranCommandsInOrder, notRanCommand, judge, GraderLevel } from '@a0/evals-graders';
+import { ranCommand, ranCommandsInOrder, notRanCommand, judge, GraderLevel } from '@a0/evals-graders';
 
 // A goal-only CLI eval run against a live, throwaway tenant the `auth0` CLI is
 // already logged into. The agent writes nothing to disk — grading leans entirely
@@ -13,13 +13,6 @@ export function defineGraders() {
       'guardian/factors/otp',
       'Did not enable OTP factor instead of SMS',
       GraderLevel.L2,
-    ),
-
-    // ── L4: Enable the SMS factor ─────────────────────────────────────────
-    ranCommandOneOf(
-      ['guardian/factors/otp', 'guardian/factors/push', 'guardian/factors/sms'],
-      'Enabled MFA factor via Auth0 CLI',
-      GraderLevel.L4,
     ),
 
     // ── L4: Set phone message type to SMS (not voice) ────────────────────

--- a/apps/auth0-evals/src/evals/mfa/cli/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/cli/graders.ts
@@ -1,43 +1,68 @@
-import { ranCommand, ranCommandOneOf, ranCommandsInOrder, judge, GraderLevel } from '@a0/evals-graders';
+import { ranCommand, ranCommandOneOf, ranCommandsInOrder, notRanCommand, judge, GraderLevel } from '@a0/evals-graders';
 
 // A goal-only CLI eval run against a live, throwaway tenant the `auth0` CLI is
-// already logged into (requested via `provision: auth0-tenant` in PROMPT.md
-// frontmatter, which the eval runner reads to provision the tenant; the
-// framework loader ignores the field). It runs the MFA tenant-config scenario
-// against a real tenant rather than a mocked Guardian surface. The agent writes
-// nothing to disk, so grading leans entirely on event graders (which inspect the
-// agent's successful shell calls) plus a trace-aware judge
-// (`includeCommandTrace: true`). Baseline mode runs no tools, so every grader
-// fails there — this eval is meant for agent mode.
+// already logged into. The agent writes nothing to disk — grading leans entirely
+// on event graders (command trace) plus a trace-aware judge.
+// Tests SMS phone factor setup (enable + message-types) and email factor setup,
+// then enforcement via guardian/policies.
 export function defineGraders() {
   return [
-    // ── L4: Enable an MFA factor via the Auth0 CLI (event-based) ──────────
-    // Reads the tool-call trace, not file contents — the whole task is CLI
-    // invocations, so there is no artifact to inspect with contains/matches.
+    // ── L2: Hallucination — agent must NOT substitute OTP for the requested ──
+    // SMS phone factor. notRanCommand checks the command trace.
+    notRanCommand(
+      'guardian/factors/otp',
+      'Did not enable OTP factor instead of SMS',
+      GraderLevel.L2,
+    ),
+
+    // ── L4: Enable the SMS factor ─────────────────────────────────────────
     ranCommandOneOf(
       ['guardian/factors/otp', 'guardian/factors/push', 'guardian/factors/sms'],
       'Enabled MFA factor via Auth0 CLI',
       GraderLevel.L4,
     ),
-    // ── L4: Enforce MFA — the step agents skip, leaving an enabled-but- ────
-    // unenforced tenant. Arg-precise so a wrong payload (e.g. an empty policy
-    // list) fails.
+
+    // ── L4: Set phone message type to SMS (not voice) ────────────────────
+    ranCommand(
+      'guardian/factors/phone/message-types',
+      ['sms'],
+      'Set phone message type to SMS',
+      GraderLevel.L4,
+    ),
+
+    // ── L4: Enable the email factor ───────────────────────────────────────
+    ranCommand(
+      'guardian/factors/email',
+      ['enabled'],
+      'Enabled email MFA factor',
+      GraderLevel.L4,
+    ),
+
+    // ── L4: Enforce MFA policy ────────────────────────────────────────────
     ranCommand('guardian/policies', ['all-applications'], 'Enforced MFA via guardian/policies', GraderLevel.L4),
-    // ── L4: Sequence — factor must be enabled BEFORE the enforcement policy ─
-    // that relies on it.
+
+    // ── L4: SMS factor must be enabled BEFORE the enforcement policy ──────
     ranCommandsInOrder(
-      [['guardian/factors/otp', 'guardian/factors/push', 'guardian/factors/sms'], 'guardian/policies'],
-      'Enabled factor before setting enforcement policy',
+      ['guardian/factors/sms', 'guardian/policies'],
+      'SMS factor enabled before enforcing MFA policy',
+      GraderLevel.L4,
+    ),
+
+    // ── L4: Email factor must be enabled BEFORE the enforcement policy ────
+    ranCommandsInOrder(
+      ['guardian/factors/email', 'guardian/policies'],
+      'Email factor enabled before enforcing MFA policy',
       GraderLevel.L4,
     ),
 
     // ── Holistic judge (no level — always runs) ───────────────────────────
-    // includeCommandTrace: this eval writes no files — the artifact is the CLI
-    // trace, so the judge must see the commands the agent ran to evaluate it.
     judge(
-      'Based on the command trace, does the solution enable an MFA factor on the Auth0 tenant via ' +
-        'the Auth0 CLI (auth0 api put guardian/factors/...) AND enforce MFA via the guardian/policies ' +
-        'endpoint with the all-applications policy — WITHOUT configuring MFA through the dashboard or Terraform?',
+      'Based on the command trace, does the solution: ' +
+        '(1) enable the SMS phone factor (guardian/factors/sms), set message-types to SMS ' +
+        '(guardian/factors/phone/message-types), and configure the phone provider; ' +
+        '(2) enable the email factor (guardian/factors/email) — with another factor already enabled first; ' +
+        '(3) enforce MFA via guardian/policies with all-applications — ' +
+        'using only the Auth0 CLI, not the dashboard or Terraform?',
       undefined,
       { includeCommandTrace: true },
     ),

--- a/packages/evals-graders/src/index.ts
+++ b/packages/evals-graders/src/index.ts
@@ -9,6 +9,7 @@ export type {
   GraderSource,
   EventToolCall,
   EventGraderLevel,
+  NotRanCommandLevel,
   CompileResult,
 } from './types.js';
 
@@ -20,6 +21,7 @@ export {
   matches,
   judge,
   ranCommand,
+  notRanCommand,
   ranCommandOneOf,
   ranCommandsInOrder,
   wroteFile,

--- a/packages/evals-graders/src/primitives.ts
+++ b/packages/evals-graders/src/primitives.ts
@@ -5,7 +5,7 @@
  * logic lives in runner.ts (runGraders).
  */
 
-import type { GraderDef, GraderOptions, GraderSource, EventToolCall, EventGraderLevel } from './types.js';
+import type { GraderDef, GraderOptions, GraderSource, EventToolCall, EventGraderLevel, NotRanCommandLevel } from './types.js';
 import { GraderLevel } from './types.js';
 
 export function contains(
@@ -143,6 +143,26 @@ export function ranCommand(
     level,
     predicate: (toolCalls: EventToolCall[]) =>
       getRunCommands(toolCalls).some((cmd) => cmd.includes(command) && argList.every((arg) => cmd.includes(arg))),
+  };
+}
+
+/**
+ * Asserts that the agent did NOT run any shell command containing the given command substring.
+ * This is a hallucination (L2) grader — it checks the command trace for wrong/forbidden commands.
+ *
+ * @param command - Substring that must NOT appear in any executed command
+ */
+export function notRanCommand(
+  command: string,
+  description: string | undefined,
+  level: NotRanCommandLevel,
+): GraderDef {
+  return {
+    kind: 'event',
+    name: description ?? `did not run command '${command}'`,
+    level,
+    predicate: (toolCalls: EventToolCall[]) =>
+      !getRunCommands(toolCalls).some((cmd) => cmd.includes(command)),
   };
 }
 

--- a/packages/evals-graders/src/types.ts
+++ b/packages/evals-graders/src/types.ts
@@ -88,6 +88,9 @@ export interface GraderOptions {
 /** Levels valid for event-based graders (agent-only — no tool calls exist in baseline). */
 export type EventGraderLevel = GraderLevel.L4 | GraderLevel.L5;
 
+/** Level valid for notRanCommand — a hallucination (L2) check on the command trace. */
+export type NotRanCommandLevel = GraderLevel.L2;
+
 /**
  * Where a text-search or judge grader looks for its content.
  * - `'files'` (default) — workspace files only.

--- a/packages/evals-graders/tests/primitives.test.ts
+++ b/packages/evals-graders/tests/primitives.test.ts
@@ -7,6 +7,7 @@ import {
   judge,
   compiles,
   ranCommand,
+  notRanCommand,
   ranCommandOneOf,
   ranCommandsInOrder,
   wroteFile,
@@ -257,6 +258,44 @@ describe('ranCommand predicate', () => {
     expect(() => ranCommand('npm install', undefined, undefined, GraderLevel.L1)).toThrow(
       'event-based graders only support',
     );
+  });
+});
+
+// ── notRanCommand (predicate) ────────────────────────────────────────────────
+
+describe('notRanCommand predicate', () => {
+  const run = (def: ReturnType<typeof notRanCommand>, calls: EventToolCall[]) => def.predicate!(calls);
+
+  it('passes when the forbidden command was not run', () => {
+    const def = notRanCommand('guardian/factors/otp', undefined, GraderLevel.L2);
+    expect(run(def, [evt({ name: 'run_command', args: { command: 'auth0 api put guardian/factors/sms' } })])).toBe(true);
+  });
+
+  it('fails when the forbidden command was run', () => {
+    const def = notRanCommand('guardian/factors/otp', undefined, GraderLevel.L2);
+    expect(run(def, [evt({ name: 'run_command', args: { command: 'auth0 api put guardian/factors/otp' } })])).toBe(false);
+  });
+
+  it('passes when the forbidden command errored (errored calls are excluded)', () => {
+    const def = notRanCommand('guardian/factors/otp', undefined, GraderLevel.L2);
+    expect(
+      run(def, [evt({ name: 'run_command', args: { command: 'auth0 api put guardian/factors/otp' }, causedError: true })]),
+    ).toBe(true);
+  });
+
+  it('passes when no commands were run', () => {
+    const def = notRanCommand('guardian/factors/otp', undefined, GraderLevel.L2);
+    expect(run(def, [])).toBe(true);
+  });
+
+  it('uses the description as the grader name', () => {
+    const def = notRanCommand('guardian/factors/otp', 'Did not use OTP', GraderLevel.L2);
+    expect(def.name).toBe('Did not use OTP');
+  });
+
+  it('falls back to a generated name when description is undefined', () => {
+    const def = notRanCommand('guardian/factors/otp', undefined, GraderLevel.L2);
+    expect(def.name).toContain('guardian/factors/otp');
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `notRanCommand` grader primitive (L2/hallucination) to `@a0/evals-graders` — the inverse of `ranCommand`, typed with `NotRanCommandLevel = GraderLevel.L2` so it cannot be misused for structural grading
- Extends `mfa_cli` PROMPT.md to explicitly ask agents to set up both the SMS phone factor and the email factor via the Auth0 CLI
- Replaces the old broad `ranCommandsInOrder` (any-factor → policies) with per-factor ordering checks (SMS → policies, email → policies) and adds graders for `guardian/factors/phone/message-types` and `guardian/factors/email`
- Fixes the Hallucination scoring gap for CLI evals: previously no L2 graders existed so `scoreFromGraders` always returned 100; now `notRanCommand` produces a real signal

## Test plan

- [ ] `npm run build` passes (evals-graders + evals packages)
- [ ] `npm test` passes — 721 tests across 17 test files in `packages/evals`, 70 tests in `packages/evals-graders`
- [ ] `notRanCommand('guardian/factors/otp', ...)` fails a run where the agent calls OTP instead of SMS
- [ ] Hallucination dimension shows a real score (not 100 fallback) for `mfa_cli` runs