### PR TITLE
feat(evals): add llama-4-maverick-17b as a baseline-only model

### DIFF
--- a/apps/auth0-evals/eval.config.js
+++ b/apps/auth0-evals/eval.config.js
@@ -139,7 +139,7 @@ export default {
     // `known` is the set `--model all` expands to. Opus 4.5 is intentionally excluded
     // here so `--model all` runs only Opus 5 among the Opus variants; the framework
     // and `modelIds` map below still support it for explicit `--model` runs.
-    known: ['gpt-5.6-sol', 'gpt-5.6-luna', 'gpt-5.6-terra', 'claude-sonnet-5', 'claude-opus-5', 'claude-haiku-4-5', 'gemini-3.1-pro-preview', 'gemini-3.5-flash'],
+    known: ['gpt-5.6-sol', 'gpt-5.6-luna', 'gpt-5.6-terra', 'claude-sonnet-5', 'claude-opus-5', 'claude-haiku-4-5', 'gemini-3.1-pro-preview', 'gemini-3.5-flash', 'llama-4-maverick-17b'],
     default: 'gpt-5.6-sol',
     // Maps short model aliases to the IDs the active proxy expects.
     // Bedrock proxy needs full `global.anthropic.*` IDs; LiteLLM proxy serves

--- a/packages/evals-core/src/config/costs.ts
+++ b/packages/evals-core/src/config/costs.ts
@@ -9,6 +9,8 @@ export const COST_TABLE: Record<string, [number, number]> = {
   'claude-haiku-4-5': [1.0, 5.0],
   'gemini-3.1-pro-preview': [2.0, 12.0],
   'gemini-3.5-flash': [1.5, 9.0],
+  // Placeholder prices — correct these later with real Llama-4-Maverick rates.
+  'llama-4-maverick-17b': [0.2, 0.6],
 };
 
 /** [input, output] USD per million tokens applied to models absent from COST_TABLE. */

--- a/packages/evals-core/src/config/model-detect.ts
+++ b/packages/evals-core/src/config/model-detect.ts
@@ -4,7 +4,7 @@
  * Determines which provider/routing a model belongs to based on known prefixes.
  */
 
-import { BEDROCK_MODELS, GEMINI_MODELS, GPT_MODELS } from './settings.js';
+import { BEDROCK_MODELS, GEMINI_MODELS, GPT_MODELS, LLAMA_MODELS } from './settings.js';
 
 /**
  * Checks if the given model name corresponds to a Bedrock model by looking for known Bedrock model name prefixes.
@@ -33,4 +33,12 @@ export function isGeminiModel(model: string): boolean {
  */
 export function isGptModel(model: string): boolean {
   return GPT_MODELS.some((prefix) => model.startsWith(prefix));
+}
+
+/**
+ * Checks if the given model name corresponds to a Llama model.
+ * Llama models are baseline-only — there is no agent runner for them.
+ */
+export function isLlamaModel(model: string): boolean {
+  return LLAMA_MODELS.some((prefix) => model.startsWith(prefix));
 }

--- a/packages/evals-core/src/config/settings.ts
+++ b/packages/evals-core/src/config/settings.ts
@@ -17,6 +17,10 @@ export const GEMINI_MODELS = ['gemini-'];
 // Model name prefixes for GPT models routed through the Codex runner.
 export const GPT_MODELS = ['gpt-'];
 
+// Llama models are baseline-only — no agent runner. Present here purely so
+// model-detect can flag them and buildJobList can skip agent-mode jobs.
+export const LLAMA_MODELS = ['llama-'];
+
 /**
  * Maps friendly model aliases to the model IDs the active proxy expects.
  *

--- a/packages/evals-core/src/index.ts
+++ b/packages/evals-core/src/index.ts
@@ -143,7 +143,7 @@ export { makeSessionId } from './utils/session.js';
 export { filteredEnv } from './utils/env.js';
 
 // Model detection
-export { isBedrockModel, isClaudeModel, isGeminiModel, isGptModel } from './config/model-detect.js';
+export { isBedrockModel, isClaudeModel, isGeminiModel, isGptModel, isLlamaModel } from './config/model-detect.js';
 
 // Grader engine
 export {

--- a/packages/evals-core/tests/model-detect.test.ts
+++ b/packages/evals-core/tests/model-detect.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isBedrockModel, isClaudeModel, isGeminiModel, isGptModel } from '../src/config/model-detect.js';
+import { isBedrockModel, isClaudeModel, isGeminiModel, isGptModel, isLlamaModel } from '../src/config/model-detect.js';
 
 describe('model detection', () => {
   it('isBedrockModel matches claude- prefix', () => {
@@ -20,5 +20,13 @@ describe('model detection', () => {
   it('isGptModel matches gpt- prefix', () => {
     expect(isGptModel('gpt-5.6-sol')).toBe(true);
     expect(isGptModel('claude-opus-5')).toBe(false);
+  });
+
+  it('isLlamaModel matches llama- prefix', () => {
+    expect(isLlamaModel('llama-4-maverick-17b')).toBe(true);
+    expect(isLlamaModel('claude-opus-5')).toBe(false);
+    expect(isLlamaModel('gpt-5.6-sol')).toBe(false);
+    expect(isLlamaModel('gemini-3.1-pro-preview')).toBe(false);
+    expect(isLlamaModel('')).toBe(false);
   });
 });

--- a/packages/evals/README.md
+++ b/packages/evals/README.md
@@ -188,6 +188,8 @@ The framework auto-selects a runner based on model prefix, or you can override w
 | GitHub Copilot | `copilot` | `gpt-*` models (and default fallback) |
 | Gemini CLI | `gemini-cli` | `gemini-*` models |
 
+`llama-4-maverick-17b` (and `llama-*` models generally) are baseline-only — they have no agent runner and run only baseline mode (L1–L3 graders).
+
 ### Claude Code runner
 
 The Claude Code runner uses `@anthropic-ai/claude-agent-sdk` and routes through the configured LLM proxy like all other runners. Set `CLAUDE_CODE_USE_BEDROCK=1` to opt in to the Bedrock pass-through endpoint instead.

--- a/packages/evals/src/cli/constants.ts
+++ b/packages/evals/src/cli/constants.ts
@@ -18,6 +18,7 @@ export const KNOWN_WORKING_MODELS = [
   'claude-haiku-4-5',
   'gemini-3.1-pro-preview',
   'gemini-3.5-flash',
+  'llama-4-maverick-17b',
 ];
 
 /** Model used when no `--model` flag is provided. */

--- a/packages/evals/src/cli/run.ts
+++ b/packages/evals/src/cli/run.ts
@@ -43,6 +43,7 @@ import {
   isClaudeModel,
   isGeminiModel,
   isGptModel,
+  isLlamaModel,
   registerRunner,
   getRunner,
   logger,
@@ -305,6 +306,13 @@ export function buildJobList(
       for (const mode of modes) {
         if (mode !== 'agent') {
           jobs.push([evalCfg, model, mode, [], agentType ?? DEFAULT_AGENT_TYPE]);
+          continue;
+        }
+        // Llama models are baseline-only: no agent runner exists, and the
+        // default copilot runner would silently coerce them to a GPT model
+        // (see copilot/runner.ts), producing misleading scores. Skip agent jobs.
+        if (isLlamaModel(model)) {
+          logger.info(`${model} is baseline-only; skipping agent mode`);
           continue;
         }
         const effectiveAgentType: AgentType =

--- a/packages/evals/tests/run.test.ts
+++ b/packages/evals/tests/run.test.ts
@@ -121,6 +121,21 @@ describe('buildJobList — mixed modes', () => {
     // 2 evals × 2 models × 2 modes = 8 jobs
     expect(jobs).toHaveLength(8);
   });
+
+  it('Llama model with baseline+agent modes → only baseline job produced', () => {
+    const jobs = buildJobList([EVAL], ['llama-4-maverick-17b'], ['baseline', 'agent'], [], undefined);
+    expect(jobs).toHaveLength(1);
+    const modes = jobs.map((j) => j[2]);
+    expect(modes).toEqual(['baseline']);
+  });
+
+  it('non-Llama model with baseline+agent modes → both jobs produced', () => {
+    const jobs = buildJobList([EVAL], ['gpt-5.2'], ['baseline', 'agent'], [], undefined);
+    expect(jobs).toHaveLength(2);
+    const modes = jobs.map((j) => j[2]);
+    expect(modes).toContain('baseline');
+    expect(modes).toContain('agent');
+  });
 });
 
 // ── buildSubprocessArgs ───────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Registers \`llama-4-maverick-17b\` for benchmarking as a **baseline-only** model.

Llama has no native agentic CLI runner. Without a guard, an unrouted model falls back to \`DEFAULT_AGENT_TYPE=copilot\`, and the Copilot runner silently coerces any non-GPT model to a default GPT model (\`copilot/runner.ts:23-24\`) — so Llama's "agent" scores would secretly be GPT scores. To avoid that, \`buildJobList\` skips agent-mode jobs for \`llama-*\` models. Baseline mode is provider-agnostic (hits the OpenAI-compatible proxy directly) and works with config alone.

## Changes

- \`LLAMA_MODELS\` prefix + \`isLlamaModel()\` detection (evals-core)
- added to \`models.known\` (eval.config.js) and \`KNOWN_WORKING_MODELS\` (constants.ts); alias passes through, no \`modelIds\` entry
- placeholder \`COST_TABLE\` entry \`[0.2, 0.6]\` (commented — replace with real rates)
- \`buildJobList\` guard: skip agent-mode jobs for Llama, log an info notice
- README note: \`llama-*\` is baseline-only (L1–L3 graders)
- tests: \`isLlamaModel\` happy/negative cases; \`buildJobList\` produces baseline-only for Llama, both modes for a non-Llama control

## Verification

\`npm run build\`, \`npm test\` (719 + 527 pass), and \`npm run lint\` all green in \`evals\` and \`evals-core\`. \`evals-axis\` has a pre-existing build failure (missing \`@netlify/axis\` dep) unrelated to this change.

## Follow-ups

- Replace placeholder pricing with real per-1M-token rates
- Agent-mode support for Llama would need a generic OpenAI-compatible agent runner (deferred)