### PR TITLE
feat(evals): add opencode agent runner for llama models

### DIFF
--- a/apps/auth0-evals/eval.config.js
+++ b/apps/auth0-evals/eval.config.js
@@ -139,7 +139,7 @@ export default {
     // `known` is the set `--model all` expands to. Opus 4.5 is intentionally excluded
     // here so `--model all` runs only Opus 5 among the Opus variants; the framework
     // and `modelIds` map below still support it for explicit `--model` runs.
-    known: ['gpt-5.6-sol', 'gpt-5.6-luna', 'gpt-5.6-terra', 'claude-sonnet-5', 'claude-opus-5', 'claude-haiku-4-5', 'gemini-3.1-pro-preview', 'gemini-3.5-flash'],
+    known: ['gpt-5.6-sol', 'gpt-5.6-luna', 'gpt-5.6-terra', 'claude-sonnet-5', 'claude-opus-5', 'claude-haiku-4-5', 'gemini-3.1-pro-preview', 'gemini-3.5-flash', 'llama-4-maverick-17b'],
     default: 'gpt-5.6-sol',
     // Maps short model aliases to the IDs the active proxy expects.
     // Bedrock proxy needs full `global.anthropic.*` IDs; LiteLLM proxy serves

--- a/apps/auth0-evals/eval.config.js
+++ b/apps/auth0-evals/eval.config.js
@@ -12,6 +12,7 @@ const CLAUDE_PROXY_BASE_URL = process.env.CLAUDE_PROXY_BASE_URL ?? PROXY_BASE_UR
 const GEMINI_PROXY_BASE_URL = process.env.GEMINI_PROXY_BASE_URL ?? PROXY_BASE_URL;
 const CODEX_PROXY_BASE_URL = process.env.CODEX_PROXY_BASE_URL ?? PROXY_BASE_URL;
 const COPILOT_PROXY_BASE_URL = process.env.COPILOT_PROXY_BASE_URL ?? PROXY_BASE_URL;
+const OPENCODE_PROXY_BASE_URL = process.env.OPENCODE_PROXY_BASE_URL ?? PROXY_BASE_URL;
 
 // When set, route Claude models through the Bedrock proxy, which needs full
 // `global.anthropic.*` model IDs instead of the short aliases.
@@ -39,6 +40,9 @@ export default {
     },
     'copilot': {
       proxy: { baseUrl: COPILOT_PROXY_BASE_URL },
+    },
+    'opencode': {
+      proxy: { baseUrl: OPENCODE_PROXY_BASE_URL },
     },
   },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5050,6 +5050,179 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/opencode-ai": {
+      "version": "1.18.25",
+      "integrity": "sha512-pS4RKJ9eKwU7Dp5G5pdj1rhMnpG5APixXzfTKNoFqv9aFVI36Rnza2jESvKifxyPZlsA65MQB03WCArY0EK6mg==",
+      "cpu": [
+        "arm64",
+        "x64"
+      ],
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "bin": {
+        "opencode": "bin/opencode.exe"
+      },
+      "optionalDependencies": {
+        "opencode-darwin-arm64": "1.18.25",
+        "opencode-darwin-x64": "1.18.25",
+        "opencode-darwin-x64-baseline": "1.18.25",
+        "opencode-linux-arm64": "1.18.25",
+        "opencode-linux-arm64-musl": "1.18.25",
+        "opencode-linux-x64": "1.18.25",
+        "opencode-linux-x64-baseline": "1.18.25",
+        "opencode-linux-x64-baseline-musl": "1.18.25",
+        "opencode-linux-x64-musl": "1.18.25",
+        "opencode-windows-arm64": "1.18.25",
+        "opencode-windows-x64": "1.18.25",
+        "opencode-windows-x64-baseline": "1.18.25"
+      }
+    },
+    "node_modules/opencode-darwin-arm64": {
+      "version": "1.18.25",
+      "integrity": "sha512-W4dyMFtHBglWZ1SEooh3Ke9v1M9lv945Y58atb8e1yKII8YykJ8LknOFyKipYC028oPDO4IZc3GYGKbg9PCg2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/opencode-darwin-x64": {
+      "version": "1.18.25",
+      "integrity": "sha512-YYKrfeUSJhD7hZl+yNmayS51sDwxiE9o5XwrfgYSSie6sOyHFc9Ei13VBkVU6T+IJHhFhTahOFAwSDxggrAnGA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/opencode-darwin-x64-baseline": {
+      "version": "1.18.25",
+      "integrity": "sha512-rRgTaoTeIN2diL1e1HGZ48Zh4ynMDEB1jYjD76LaFUVzMwakEY1i7NvG8e/rbjRMDkgXIr6TwzCtIMcMOpLQMA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/opencode-linux-arm64": {
+      "version": "1.18.25",
+      "integrity": "sha512-PMvcpFpha3yAhaVCC0QbegHPxsEZ0FuQf+52PXvqQut1r3w1l1Pilor9tUA7TyCRa4UokACI90nTmKmtMnQBag==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-arm64-musl": {
+      "version": "1.18.25",
+      "integrity": "sha512-IwIPKmNwIjLshlSgjoRLKFwxxiLpZ5Y0zjv6r456RQtJKK62IbYGXkCm3AiSZ/lqGsu3XF+xn/Xza29ivgpgcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64": {
+      "version": "1.18.25",
+      "integrity": "sha512-bdRSJ6gbK/EnLNWxROOQYXFXiUeqeFxGz8DIO8LCqnii99A2OWFAyZ3Da5gpvfT1Yrp9/lYL55n/tM3ale5smg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64-baseline": {
+      "version": "1.18.25",
+      "integrity": "sha512-+b0w7XyHx0XPQWHBk2JymXbXnyZQ2PjIPuu4a4QJgSUqGuGz1L2flA3wgpZVAWFUhrEIr9DFhBk3AkKKNgMuRw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64-baseline-musl": {
+      "version": "1.18.25",
+      "integrity": "sha512-E2JUeOOSXPbG1cNOzxnqjqkd0a3+oFmwkbJe6bZ308CFgLWBFfVh0fF42HTCEqfK+yYbidpEkQuEkUgxq/11IA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64-musl": {
+      "version": "1.18.25",
+      "integrity": "sha512-W15qTNDz1fsTzs1SkE6bB/gpIDBF3rwDbewUKdbyXD3dVs6umyugOql1T4u9n/gqWa/Z/VDURbn39VsejeSdbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-windows-arm64": {
+      "version": "1.18.25",
+      "integrity": "sha512-GFp74pProoPwqktHMf+9wQ8fza1RvFt0RG0iRtTQnJ4VWVY62qEeVuJkH6ki9QXS270HXyqtxvF8AuHQzuVZlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/opencode-windows-x64": {
+      "version": "1.18.25",
+      "integrity": "sha512-xW5wtSxWYbI7DcmQWMlNWIiDBdMJON1vDiEmVWo88R9tT/PaahOhWKgp7FoWDqJKf89jS3ZIzkqnkU3F2dio7A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/opencode-windows-x64-baseline": {
+      "version": "1.18.25",
+      "integrity": "sha512-/28bGRQwT+2JdGbtGaNr95tstgysiULEXtcvgNg7yLDxitqmSVgd8V8XRGS0UWDdfiWWMND9A9T5EAsbF1/xDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
@@ -6300,6 +6473,7 @@
         "braintrust": "^3.25.0",
         "commander": "^15.0.0",
         "dotenv": "^17.4.2",
+        "opencode-ai": "^1.18.0",
         "p-limit": "^7.3.1"
       },
       "bin": {

--- a/packages/evals-core/src/config/costs.ts
+++ b/packages/evals-core/src/config/costs.ts
@@ -9,6 +9,8 @@ export const COST_TABLE: Record<string, [number, number]> = {
   'claude-haiku-4-5': [1.0, 5.0],
   'gemini-3.1-pro-preview': [2.0, 12.0],
   'gemini-3.5-flash': [1.5, 9.0],
+  // Placeholder prices — correct these later with real Llama-4-Maverick rates.
+  'llama-4-maverick-17b': [0.2, 0.6],
 };
 
 /** [input, output] USD per million tokens applied to models absent from COST_TABLE. */

--- a/packages/evals-core/src/config/model-detect.ts
+++ b/packages/evals-core/src/config/model-detect.ts
@@ -37,7 +37,7 @@ export function isGptModel(model: string): boolean {
 
 /**
  * Checks if the given model name corresponds to a Llama model.
- * Llama models are baseline-only — there is no agent runner for them.
+ * Llama models route to the opencode agent runner in agent mode.
  */
 export function isLlamaModel(model: string): boolean {
   return LLAMA_MODELS.some((prefix) => model.startsWith(prefix));

--- a/packages/evals-core/src/config/model-detect.ts
+++ b/packages/evals-core/src/config/model-detect.ts
@@ -4,7 +4,7 @@
  * Determines which provider/routing a model belongs to based on known prefixes.
  */
 
-import { BEDROCK_MODELS, GEMINI_MODELS, GPT_MODELS } from './settings.js';
+import { BEDROCK_MODELS, GEMINI_MODELS, GPT_MODELS, LLAMA_MODELS } from './settings.js';
 
 /**
  * Checks if the given model name corresponds to a Bedrock model by looking for known Bedrock model name prefixes.
@@ -33,4 +33,12 @@ export function isGeminiModel(model: string): boolean {
  */
 export function isGptModel(model: string): boolean {
   return GPT_MODELS.some((prefix) => model.startsWith(prefix));
+}
+
+/**
+ * Checks if the given model name corresponds to a Llama model.
+ * Llama models are baseline-only — there is no agent runner for them.
+ */
+export function isLlamaModel(model: string): boolean {
+  return LLAMA_MODELS.some((prefix) => model.startsWith(prefix));
 }

--- a/packages/evals-core/src/config/settings.ts
+++ b/packages/evals-core/src/config/settings.ts
@@ -17,8 +17,8 @@ export const GEMINI_MODELS = ['gemini-'];
 // Model name prefixes for GPT models routed through the Codex runner.
 export const GPT_MODELS = ['gpt-'];
 
-// Llama models are baseline-only — no agent runner. Present here purely so
-// model-detect can flag them and buildJobList can skip agent-mode jobs.
+// Llama models route to the opencode agent runner in agent mode. Present here
+// so model-detect can flag them and route them correctly.
 export const LLAMA_MODELS = ['llama-'];
 
 /**
@@ -52,3 +52,8 @@ export const CODEX_TASK_TIMEOUT_MS = 30 * 60_000;
 
 /** Maximum wall-clock time for a single baseline LLM call (2 minutes). */
 export const BASELINE_TASK_TIMEOUT_MS = 2 * 60_000;
+
+/** Maximum wall-clock time for a single opencode CLI task (30 minutes).
+ * This fires first as a graceful abort. The host-side 35-min Docker deadline
+ * is a hard-kill backstop for unresponsive containers. */
+export const OPENCODE_TASK_TIMEOUT_MS = 30 * 60_000;

--- a/packages/evals-core/src/config/settings.ts
+++ b/packages/evals-core/src/config/settings.ts
@@ -17,6 +17,10 @@ export const GEMINI_MODELS = ['gemini-'];
 // Model name prefixes for GPT models routed through the Codex runner.
 export const GPT_MODELS = ['gpt-'];
 
+// Llama models are baseline-only — no agent runner. Present here purely so
+// model-detect can flag them and buildJobList can skip agent-mode jobs.
+export const LLAMA_MODELS = ['llama-'];
+
 /**
  * Maps friendly model aliases to the model IDs the active proxy expects.
  *

--- a/packages/evals-core/src/index.ts
+++ b/packages/evals-core/src/index.ts
@@ -143,7 +143,7 @@ export { makeSessionId } from './utils/session.js';
 export { filteredEnv } from './utils/env.js';
 
 // Model detection
-export { isBedrockModel, isClaudeModel, isGeminiModel, isGptModel } from './config/model-detect.js';
+export { isBedrockModel, isClaudeModel, isGeminiModel, isGptModel, isLlamaModel } from './config/model-detect.js';
 
 // Grader engine
 export {

--- a/packages/evals-core/src/index.ts
+++ b/packages/evals-core/src/index.ts
@@ -134,6 +134,7 @@ export {
   COPILOT_TASK_TIMEOUT_MS,
   BASELINE_TASK_TIMEOUT_MS,
   CODEX_TASK_TIMEOUT_MS,
+  OPENCODE_TASK_TIMEOUT_MS,
 } from './config/settings.js';
 
 // Session

--- a/packages/evals-core/src/types/agents.ts
+++ b/packages/evals-core/src/types/agents.ts
@@ -3,7 +3,7 @@
  */
 
 /** Agent runner types accepted by the `--agent-type` flag. */
-export const KNOWN_AGENT_TYPES = ['claude-code', 'copilot', 'gemini-cli', 'codex'] as const;
+export const KNOWN_AGENT_TYPES = ['claude-code', 'copilot', 'gemini-cli', 'codex', 'opencode'] as const;
 
 /** Union of valid agent runner identifiers. */
 export type AgentType = (typeof KNOWN_AGENT_TYPES)[number];

--- a/packages/evals-core/src/workspace/workspace.ts
+++ b/packages/evals-core/src/workspace/workspace.ts
@@ -52,12 +52,14 @@ export function compileGuidance(compileCommand: string): string {
  *   - Codex reads AGENTS.md (official agents.md standard supporter).
  *   - Copilot reads .github/copilot-instructions.md reliably; AGENTS.md is
  *     "not supported by all Copilot features" per GitHub's docs.
+ *   - opencode auto-loads AGENTS.md from the project root.
  */
 export const AGENT_CONTEXT_FILENAMES: Record<AgentType, string> = {
   'claude-code': 'CLAUDE.md',
   'gemini-cli': 'GEMINI.md',
   codex: 'AGENTS.md',
   copilot: '.github/copilot-instructions.md',
+  opencode: 'AGENTS.md',
 };
 
 /**

--- a/packages/evals-core/tests/model-detect.test.ts
+++ b/packages/evals-core/tests/model-detect.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isBedrockModel, isClaudeModel, isGeminiModel, isGptModel } from '../src/config/model-detect.js';
+import { isBedrockModel, isClaudeModel, isGeminiModel, isGptModel, isLlamaModel } from '../src/config/model-detect.js';
 
 describe('model detection', () => {
   it('isBedrockModel matches claude- prefix', () => {
@@ -20,5 +20,13 @@ describe('model detection', () => {
   it('isGptModel matches gpt- prefix', () => {
     expect(isGptModel('gpt-5.6-sol')).toBe(true);
     expect(isGptModel('claude-opus-5')).toBe(false);
+  });
+
+  it('isLlamaModel matches llama- prefix', () => {
+    expect(isLlamaModel('llama-4-maverick-17b')).toBe(true);
+    expect(isLlamaModel('claude-opus-5')).toBe(false);
+    expect(isLlamaModel('gpt-5.6-sol')).toBe(false);
+    expect(isLlamaModel('gemini-3.1-pro-preview')).toBe(false);
+    expect(isLlamaModel('')).toBe(false);
   });
 });

--- a/packages/evals/README.md
+++ b/packages/evals/README.md
@@ -187,8 +187,9 @@ The framework auto-selects a runner based on model prefix, or you can override w
 | Claude Code | `claude-code` | `claude-*` models |
 | GitHub Copilot | `copilot` | `gpt-*` models (and default fallback) |
 | Gemini CLI | `gemini-cli` | `gemini-*` models |
+| opencode | `opencode` | `llama-*` models |
 
-`llama-4-maverick-17b` (and `llama-*` models generally) are baseline-only — they have no agent runner and run only baseline mode (L1–L3 graders).
+`llama-*` models auto-route to the `opencode` agent runner in agent mode (and still run baseline).
 
 ### Claude Code runner
 

--- a/packages/evals/README.md
+++ b/packages/evals/README.md
@@ -188,6 +188,8 @@ The framework auto-selects a runner based on model prefix, or you can override w
 | GitHub Copilot | `copilot` | `gpt-*` models (and default fallback) |
 | Gemini CLI | `gemini-cli` | `gemini-*` models |
 
+`llama-4-maverick-17b` (and `llama-*` models generally) are baseline-only — they have no agent runner and run only baseline mode (L1–L3 graders).
+
 ### Claude Code runner
 
 The Claude Code runner uses `@anthropic-ai/claude-agent-sdk` and routes through the configured LLM proxy like all other runners. Set `CLAUDE_CODE_USE_BEDROCK=1` to opt in to the Bedrock pass-through endpoint instead.

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -30,6 +30,7 @@
     "braintrust": "^3.25.0",
     "commander": "^15.0.0",
     "dotenv": "^17.4.2",
+    "opencode-ai": "^1.18.0",
     "p-limit": "^7.3.1"
   },
   "scripts": {

--- a/packages/evals/src/cli/constants.ts
+++ b/packages/evals/src/cli/constants.ts
@@ -18,6 +18,7 @@ export const KNOWN_WORKING_MODELS = [
   'claude-haiku-4-5',
   'gemini-3.1-pro-preview',
   'gemini-3.5-flash',
+  'llama-4-maverick-17b',
 ];
 
 /** Model used when no `--model` flag is provided. */

--- a/packages/evals/src/cli/run.ts
+++ b/packages/evals/src/cli/run.ts
@@ -43,6 +43,7 @@ import {
   isClaudeModel,
   isGeminiModel,
   isGptModel,
+  isLlamaModel,
   registerRunner,
   getRunner,
   logger,
@@ -305,6 +306,13 @@ export function buildJobList(
       for (const mode of modes) {
         if (mode !== 'agent') {
           jobs.push([evalCfg, model, mode, [], agentType ?? DEFAULT_AGENT_TYPE]);
+          continue;
+        }
+        // Llama models are baseline-only: no agent runner exists, and the
+        // default copilot runner would silently coerce them to a GPT model
+        // (see copilot/runner.ts), producing misleading scores. Skip agent jobs.
+        if (isLlamaModel(model)) {
+          logger.info(`${model} is baseline-only; skipping agent mode`);
           continue;
         }
         const effectiveAgentType: AgentType =

--- a/packages/evals/src/cli/run.ts
+++ b/packages/evals/src/cli/run.ts
@@ -10,9 +10,9 @@
  *   --model       Model(s) to run (default: gpt-5.6-sol). Can be repeated.
  *                 Use 'all' to run all known working models.
  *   --mode        Execution mode: baseline | agent | all (default: baseline)
- *   --agent-type  Agent runner: claude-code | copilot | gemini-cli | codex
+ *   --agent-type  Agent runner: claude-code | copilot | gemini-cli | codex | opencode
  *                 Auto-routed by model prefix when omitted (claude-* → claude-code,
- *                 gemini-* → gemini-cli, gpt-* → codex, else copilot).
+ *                 gemini-* → gemini-cli, gpt-* → codex, llama-* → opencode, else copilot).
  *   --tools       Tools to inject for agent mode: skills, mcp (default: none). Case-insensitive.
  *   --workers     Parallel workers (default: 4)
  *   --output      JSON output path (default: scores-<mode>.json)
@@ -60,6 +60,7 @@ import { ClaudeCodeRunner } from '../runners/claude-code/runner.js';
 import { CopilotCliRunner } from '../runners/copilot/runner.js';
 import { GeminiCliRunner } from '../runners/gemini-cli/runner.js';
 import { CodexRunner } from '../runners/codex/runner.js';
+import { OpencodeRunner } from '../runners/opencode/runner.js';
 import { createBraintrustReporter } from '../reporters/braintrust.js';
 import { syncDataset, toEvalSummaries } from '../reporters/braintrust-dataset.js';
 
@@ -78,6 +79,7 @@ async function initRunners(): Promise<void> {
   registerRunner('copilot', new CopilotCliRunner());
   registerRunner('gemini-cli', new GeminiCliRunner());
   registerRunner('codex', new CodexRunner());
+  registerRunner('opencode', new OpencodeRunner());
 }
 
 // ── Per-job execution ─────────────────────────────────────────────────────────
@@ -308,13 +310,6 @@ export function buildJobList(
           jobs.push([evalCfg, model, mode, [], agentType ?? DEFAULT_AGENT_TYPE]);
           continue;
         }
-        // Llama models are baseline-only: no agent runner exists, and the
-        // default copilot runner would silently coerce them to a GPT model
-        // (see copilot/runner.ts), producing misleading scores. Skip agent jobs.
-        if (isLlamaModel(model)) {
-          logger.info(`${model} is baseline-only; skipping agent mode`);
-          continue;
-        }
         const effectiveAgentType: AgentType =
           !agentType && isClaudeModel(model)
             ? 'claude-code'
@@ -322,7 +317,9 @@ export function buildJobList(
               ? 'gemini-cli'
               : !agentType && isGptModel(model)
                 ? 'codex'
-                : (agentType ?? DEFAULT_AGENT_TYPE);
+                : !agentType && isLlamaModel(model)
+                  ? 'opencode'
+                  : (agentType ?? DEFAULT_AGENT_TYPE);
         for (const jobTools of agentToolSets) {
           if (effectiveAgentType === 'claude-code') {
             if (isClaudeModel(model)) {

--- a/packages/evals/src/cli/sandbox-runner.ts
+++ b/packages/evals/src/cli/sandbox-runner.ts
@@ -39,6 +39,7 @@ import { ClaudeCodeRunner } from '../runners/claude-code/runner.js';
 import { CopilotCliRunner } from '../runners/copilot/runner.js';
 import { GeminiCliRunner } from '../runners/gemini-cli/runner.js';
 import { CodexRunner } from '../runners/codex/runner.js';
+import { OpencodeRunner } from '../runners/opencode/runner.js';
 import { SANDBOX_RESULTS_FILE } from './constants.js';
 
 // ── Runner registration ──────────────────────────────────────────────────────
@@ -53,6 +54,7 @@ async function initRunners(): Promise<void> {
   registerRunner('copilot', new CopilotCliRunner());
   registerRunner('gemini-cli', new GeminiCliRunner());
   registerRunner('codex', new CodexRunner());
+  registerRunner('opencode', new OpencodeRunner());
 }
 
 // ── Main ─────────────────────────────────────────────────────────────────────

--- a/packages/evals/src/runners/opencode/agent.ts
+++ b/packages/evals/src/runners/opencode/agent.ts
@@ -1,0 +1,549 @@
+/**
+ * opencode agent runner.
+ *
+ * Spawns `opencode run <prompt> --dir <workspace> --model <provider/model>
+ * --auto --format json` as a subprocess and parses the JSONL event stream
+ * into a RunRecord.
+ *
+ * Authentication: routed through the LiteLLM proxy using the LLM API key —
+ * the same token used by all other runners.
+ *
+ * Event format (--format json):
+ *   NOTE: the exact event shape should be confirmed against a live
+ *   `opencode run --format json` capture. Field names like `type`, `part`,
+ *   and event type spellings (`tool_use`/`tool-use`, `step_finish`/`step-finish`)
+ *   are assumed based on common JSONL agent patterns and may need adjustment.
+ *
+ * Config: written to <workspace>/opencode.jsonc so opencode auto-discovers it.
+ */
+
+import { spawn } from 'node:child_process';
+import { createInterface } from 'node:readline';
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createRequire } from 'node:module';
+import type { RunRecord, ToolCallRecord, TurnMetric, EvalDefinition } from '@a0/evals-core';
+import {
+  OPENCODE_TASK_TIMEOUT_MS,
+  MAX_TURNS,
+  getFrameworkConfig,
+  getAgentProxyBaseUrl,
+  estimateCost,
+  logger,
+  filteredEnv,
+  makeSessionId,
+  mintMcpToken,
+  mcpBearerTokenEnvVar,
+} from '@a0/evals-core';
+import { classifyActionType, classifyErrorCategory, detectRetry } from '@a0/evals-core';
+import { OpencodeCliTranslator } from './translator.js';
+
+const translator = new OpencodeCliTranslator();
+
+/** Model identifier written to RunRecord when the opencode runner is used. */
+export const OPENCODE_MODEL_ID = 'opencode';
+
+/** Default model for the opencode runner. */
+export const OPENCODE_DEFAULT_MODEL = 'llama-4-maverick-17b';
+
+/**
+ * Provider name used in opencode.jsonc and as the model prefix.
+ * opencode `model` field uses `<provider>/<model>` syntax.
+ */
+export const OPENCODE_PROVIDER_NAME = 'llmproxy';
+
+// ── Binary resolution ─────────────────────────────────────────────────────────
+
+/**
+ * Resolves the opencode binary path from node_modules (NOT PATH) using
+ * createRequire so the binary is always the installed package version,
+ * independent of $PATH.
+ *
+ * Throws a clear error if the binary cannot be located. The `opencode-ai`
+ * package is a runtime dependency; if it is not installed this is a
+ * configuration error rather than a code error.
+ */
+export function resolveOpencodeBin(): string {
+  const require = createRequire(import.meta.url);
+  let pkgJsonPath: string;
+  try {
+    pkgJsonPath = require.resolve('opencode-ai/package.json');
+  } catch {
+    throw new Error(
+      '[opencode] Cannot resolve opencode-ai/package.json — is the opencode-ai package installed? ' +
+        'Run: npm install opencode-ai',
+    );
+  }
+
+  // package.json is at <pkgDir>/package.json; bin is typically at <pkgDir>/bin/opencode
+  // or referenced in the package.json "bin" field.
+  const pkgDir = pkgJsonPath.replace(/[/\\]package\.json$/, '');
+
+  // Try common binary locations: node_modules/.bin/opencode, pkgDir/bin/opencode, pkgDir/opencode
+  const candidates = [
+    join(pkgDir, '..', '.bin', 'opencode'),
+    join(pkgDir, 'bin', 'opencode'),
+    join(pkgDir, 'opencode'),
+  ];
+
+  for (const candidate of candidates) {
+    // Dynamic require handles existence check — spawn will error if wrong.
+    // We rely on the fact that if the package is installed, at least one of
+    // these will exist. Return the first that looks plausible.
+    try {
+      // Attempt to read the file to verify it exists.
+      require.resolve(candidate);
+      return candidate;
+    } catch {
+      // Not found at this path — try next.
+    }
+  }
+
+  // Fall back to the node_modules/.bin symlink resolution via the package's bin field.
+  // If none of the candidates resolve, the first candidate is still the most likely
+  // location and spawn will give a clear OS error.
+  return candidates[0]!;
+}
+
+// ── Config writer ─────────────────────────────────────────────────────────────
+
+export interface OpencodeConfigResult {
+  mcpServerNames: string[];
+  /** Minted Bearer tokens keyed by the env var name each `{env:VAR}` reference resolves to. */
+  bearerTokens: Record<string, string>;
+}
+
+/**
+ * Writes <workspace>/opencode.jsonc with the provider, model, MCP, and
+ * skills configuration for one eval run.
+ *
+ * IMPORTANT: never writes the raw LLM_API_KEY or raw bearer tokens into the
+ * file — only `{env:VAR}` placeholders. Tokens are returned in `bearerTokens`
+ * so the caller can inject them into the subprocess env.
+ *
+ * small_model MUST be pinned to the same model — opencode's title/summary/
+ * compaction calls otherwise default to a built-in model id the proxy will
+ * 400 on. This is the #1 correctness trap for this runner.
+ */
+export async function writeOpencodeConfig(
+  workspace: string,
+  model: string,
+  opts: { tools: string[] },
+): Promise<OpencodeConfigResult> {
+  const { tools } = opts;
+
+  const proxyBaseUrl = getAgentProxyBaseUrl('opencode');
+  const normalizedBaseUrl = proxyBaseUrl.replace(/\/+$/, '');
+  const baseURL = normalizedBaseUrl.endsWith('/v1') ? normalizedBaseUrl : `${normalizedBaseUrl}/v1`;
+
+  const modelRef = `${OPENCODE_PROVIDER_NAME}/${model}`;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const config: Record<string, any> = {
+    $schema: 'https://opencode.ai/config.json',
+    provider: {
+      [OPENCODE_PROVIDER_NAME]: {
+        npm: '@ai-sdk/openai-compatible',
+        name: 'LLM Proxy',
+        options: {
+          baseURL,
+          // {env:LLM_API_KEY} is an opencode env-var placeholder — the raw key
+          // is NEVER written to this file. It is injected into the subprocess env.
+          apiKey: '{env:LLM_API_KEY}',
+        },
+        models: {
+          [model]: { name: model },
+        },
+      },
+    },
+    model: modelRef,
+    // small_model MUST be pinned to the same model — opencode's title/summary/
+    // compaction calls otherwise default to a built-in model id the proxy will
+    // 400 on. #1 correctness trap.
+    small_model: modelRef,
+  };
+
+  const mcpServerNames: string[] = [];
+  const bearerTokens: Record<string, string> = {};
+
+  if (tools.includes('mcp')) {
+    const mcpServers: Record<string, unknown> = {};
+    const configServers = getFrameworkConfig().mcp.servers;
+
+    for (const [name, server] of Object.entries(configServers)) {
+      if (server.type !== 'http') continue;
+
+      if (server.auth) {
+        const token = await mintMcpToken(server.auth);
+        if (!token) {
+          logger.warn(`[opencode] MCP server '${name}' skipped — token mint failed or creds missing`);
+          continue;
+        }
+        const envVar = mcpBearerTokenEnvVar(name);
+        if (bearerTokens[envVar] !== undefined) {
+          logger.warn(
+            `[opencode] MCP server '${name}' skipped — env var ${envVar} already used by another server (name collision)`,
+          );
+          continue;
+        }
+        bearerTokens[envVar] = token;
+        mcpServers[name] = {
+          type: 'remote',
+          url: server.url,
+          enabled: true,
+          // {env:VAR} placeholder — raw token is injected via subprocess env, never written here.
+          headers: { Authorization: `Bearer {env:${envVar}}` },
+        };
+      } else {
+        mcpServers[name] = { type: 'remote', url: server.url, enabled: true };
+      }
+      mcpServerNames.push(name);
+    }
+
+    if (Object.keys(mcpServers).length > 0) {
+      config.mcp = mcpServers;
+    }
+  }
+
+  writeFileSync(join(workspace, 'opencode.jsonc'), JSON.stringify(config, null, 2), 'utf-8');
+  return { mcpServerNames, bearerTokens };
+}
+
+// ── Event type normalisation ──────────────────────────────────────────────────
+
+/**
+ * Normalises opencode event type strings to a canonical form.
+ * opencode may emit `tool_use`, `tool-use`, `step_finish`, `step-finish`, etc.
+ * Accept both underscore and hyphen spellings.
+ *
+ * NOTE: confirm these type values against a live `--format json` capture.
+ */
+function normaliseEventType(raw: string): string {
+  return raw.replace(/-/g, '_');
+}
+
+// ── Runner ────────────────────────────────────────────────────────────────────
+
+export interface OpencodeRunOptions {
+  /** Tool flags (e.g. ['mcp', 'skills']). */
+  tools?: string[];
+  /** opencode model to use. Defaults to OPENCODE_DEFAULT_MODEL. */
+  model?: string;
+}
+
+/**
+ * Runs an opencode agent against an eval and returns a RunRecord compatible
+ * with the scorer and serialisers used by the standard agent pipeline.
+ */
+export async function runOpencodeAgent(
+  evalDef: Pick<EvalDefinition, 'id' | 'userPrompt'>,
+  workspace: string,
+  opts: OpencodeRunOptions = {},
+): Promise<RunRecord> {
+  const { tools = [], model = OPENCODE_DEFAULT_MODEL } = opts;
+
+  const record: RunRecord = {
+    taskName: evalDef.id,
+    model,
+    sessionId: makeSessionId(),
+    startTime: Date.now() / 1000,
+    endTime: 0,
+    toolCalls: [],
+    turnMetrics: [],
+    providerErrors: [],
+    inputTokens: 0,
+    outputTokens: 0,
+    costUsd: 0,
+    status: 'running',
+    finalSummary: '',
+    workspace,
+  };
+
+  logger.info(`\n[opencode] Starting task: ${evalDef.id}`);
+  logger.info(`[opencode] Workspace: ${workspace}`);
+  logger.info(`[opencode] Model: ${model}`);
+
+  const { mcpServerNames, bearerTokens } = await writeOpencodeConfig(workspace, model, { tools });
+
+  if (mcpServerNames.length > 0) {
+    logger.info(`[opencode] MCP: ${mcpServerNames.join(', ')}`);
+  } else if (tools.includes('mcp')) {
+    logger.warn(`[opencode] --tools mcp requested but no MCP servers are available`);
+  }
+
+  let bin: string;
+  try {
+    bin = resolveOpencodeBin();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    record.providerErrors.push(`binary resolution error: ${msg}`);
+    record.status = 'failure';
+    record.endTime = Date.now() / 1000;
+    logger.error(`[opencode] ✗ ${msg}`);
+    return record;
+  }
+
+  const opencodeEnv: Record<string, string> = {
+    ...filteredEnv(),
+  };
+  if (process.env.LLM_API_KEY) {
+    opencodeEnv.LLM_API_KEY = process.env.LLM_API_KEY;
+  } else {
+    logger.warn(`[opencode] LLM_API_KEY not set — requests will fail.`);
+  }
+  if (process.env.GH_TOKEN) {
+    opencodeEnv.GH_TOKEN = process.env.GH_TOKEN;
+  }
+  // Inject minted Bearer tokens so opencode can resolve each authed server's
+  // `{env:MCP_BEARER_*}` header reference from the opencode.jsonc config.
+  for (const [key, value] of Object.entries(bearerTokens)) {
+    opencodeEnv[key] = value;
+  }
+
+  // Pending tool calls: tool_id → { name, args, startTime }
+  const pending = new Map<string, { name: string; args: Record<string, unknown>; startTime: number }>();
+
+  // Turn tracking — one TurnMetric per step_finish event.
+  let turnLimitReached = false;
+  let turnNum = 0;
+  let turnToolCount = 0;
+  let turnStartTime = record.startTime;
+
+  const args: string[] = [
+    'run',
+    evalDef.userPrompt,
+    '--dir',
+    workspace,
+    '--model',
+    `${OPENCODE_PROVIDER_NAME}/${model}`,
+    '--auto',
+    '--format',
+    'json',
+  ];
+
+  return new Promise<RunRecord>((resolve) => {
+    const child = spawn(bin, args, { cwd: workspace, env: opencodeEnv });
+
+    const taskTimeout = setTimeout(() => {
+      record.providerErrors.push(`task timeout after ${OPENCODE_TASK_TIMEOUT_MS / 1000}s`);
+      record.status = 'failure';
+      logger.info(`[opencode] ✗ Task timeout — killing`);
+      child.kill('SIGTERM');
+    }, OPENCODE_TASK_TIMEOUT_MS);
+
+    const stderrChunks: Buffer[] = [];
+    if (child.stderr) {
+      child.stderr.on('data', (c: Buffer) => stderrChunks.push(c));
+    }
+
+    if (child.stdout) {
+      const rl = createInterface({ input: child.stdout, crlfDelay: Infinity });
+
+      rl.on('line', (line: string) => {
+        const trimmed = line.trim();
+        if (!trimmed) return;
+
+        let event: Record<string, unknown>;
+        try {
+          event = JSON.parse(trimmed) as Record<string, unknown>;
+        } catch {
+          logger.warn(`[opencode] Non-JSON stdout: ${trimmed.slice(0, 120)}`);
+          return;
+        }
+
+        // NOTE: opencode's exact event type field and values should be confirmed
+        // against a live `--format json` capture. We accept both `type` at the
+        // top level and a `part.type` nesting (some JSONL agents wrap events).
+        const rawType = (event.type ?? (event.part as Record<string, unknown> | undefined)?.type ?? '') as string;
+        const type = normaliseEventType(rawType);
+
+        switch (type) {
+          case 'tool_use': {
+            // NOTE: field names `tool_name`/`name`, `tool_id`/`id`, `parameters`/`input`
+            // should be confirmed against a live capture.
+            const toolName = (event.tool_name ?? event.name ?? 'unknown') as string;
+            const toolId = (event.tool_id ?? event.id ?? String(Date.now())) as string;
+            const params = (event.parameters ?? event.input ?? {}) as Record<string, unknown>;
+
+            if (translator.isInternalTool(toolName)) break;
+
+            pending.set(toolId, { name: toolName, args: params, startTime: Date.now() / 1000 });
+            turnToolCount++;
+            break;
+          }
+
+          case 'tool_result': {
+            // NOTE: field names should be confirmed against a live capture.
+            const toolId = (event.tool_id ?? event.id ?? '') as string;
+            const pend = pending.get(toolId);
+            if (pend) pending.delete(toolId);
+
+            const output = (event.output ?? event.content ?? '') as string;
+            const isError = event.status === 'error' || event.is_error === true;
+            const rawName = pend?.name ?? 'unknown';
+            const mappedName = translator.mapName(rawName);
+            const toolArgs = translator.normalizeArgs(rawName, pend?.args ?? {});
+            const startTime = pend?.startTime ?? Date.now() / 1000;
+            const endTime = Date.now() / 1000;
+            const elapsed = ((endTime - startTime) * 1000).toFixed(0);
+            const preview = output.slice(0, 80).replace(/\n/g, ' ');
+
+            if (isError) {
+              logger.error(`  [opencode] ${mappedName} ✗ (${elapsed}ms) ${preview}`);
+            } else {
+              logger.info(`  [opencode] ${mappedName} ✓ (${elapsed}ms)${preview ? ` → ${preview}` : ''}`);
+            }
+
+            const isRetry = detectRetry(record.toolCalls, mappedName, toolArgs);
+            const tc: ToolCallRecord = {
+              name: mappedName,
+              args: toolArgs,
+              result: output,
+              startTime,
+              endTime,
+              isDocLookup: translator.isDocLookup(rawName),
+              isInterruption: translator.isInterruption(rawName),
+              causedError: isError,
+              actionType: classifyActionType(mappedName, isError),
+              isRetry,
+              recoveredFromError: isRetry && !isError,
+            };
+            if (isError) tc.errorCategory = classifyErrorCategory(output);
+            record.toolCalls.push(tc);
+            break;
+          }
+
+          case 'step_finish': {
+            // NOTE: token field names (`tokens.input`, `tokens.output`, `tokens.reasoning`,
+            // `tokens.cache.read`, `tokens.cache.write`, `cost`) should be confirmed
+            // against a live capture.
+            const tokens = (event.tokens ?? {}) as Record<string, unknown>;
+            const cache = (tokens.cache ?? {}) as Record<string, unknown>;
+            const inputTokens = ((tokens.input as number) ?? 0) + ((cache.read as number) ?? 0);
+            const outputTokens =
+              ((tokens.output as number) ?? 0) + ((tokens.reasoning as number) ?? 0) + ((cache.write as number) ?? 0);
+            const reportedCost = event.cost as number | undefined;
+
+            record.inputTokens += inputTokens;
+            record.outputTokens += outputTokens;
+
+            const turnCost =
+              typeof reportedCost === 'number' && reportedCost > 0
+                ? reportedCost
+                : estimateCost(model, inputTokens, outputTokens);
+            record.costUsd += turnCost;
+
+            turnNum++;
+            const turnEndTime = Date.now() / 1000;
+            const tm: TurnMetric = {
+              turn: turnNum,
+              inputTokens,
+              outputTokens,
+              llmLatency: Math.max(0, turnEndTime - turnStartTime),
+              finishReason: turnToolCount > 0 ? 'tool_calls' : 'stop',
+              toolCallCount: turnToolCount,
+              costUsd: turnCost,
+            };
+            record.turnMetrics.push(tm);
+            turnStartTime = turnEndTime;
+
+            logger.info(
+              `[opencode] Turn ${turnNum}: ${inputTokens}in/${outputTokens}out tokens, ` +
+                `${turnToolCount} tool(s), cost=$${turnCost.toFixed(4)}`,
+            );
+            turnToolCount = 0;
+
+            if (!turnLimitReached && turnNum >= MAX_TURNS) {
+              turnLimitReached = true;
+              record.providerErrors.push(`turn limit: stopped after ${MAX_TURNS} turns`);
+              record.status = 'failure';
+              logger.info(`[opencode] ✗ Turn limit reached (${MAX_TURNS}) — killing`);
+              child.kill('SIGTERM');
+            }
+            break;
+          }
+
+          case 'text':
+          case 'assistant_message':
+          case 'message': {
+            // Capture the final assistant text output as the summary.
+            const content = (event.content ?? event.text ?? '') as string;
+            if (content) record.finalSummary = content;
+            break;
+          }
+
+          case 'error': {
+            const msg = (event.message ?? event.error ?? String(event)) as string;
+            record.providerErrors.push(msg);
+            logger.error(`[opencode] Event error: ${msg}`);
+            break;
+          }
+
+          default:
+            // Unknown event types are silently ignored to be forward-compatible.
+            break;
+        }
+      });
+    }
+
+    child.on('close', (code) => {
+      clearTimeout(taskTimeout);
+
+      // Drain tool_use events that never received a tool_result (e.g. on timeout
+      // or unexpected exit) so we don't silently lose tool-call metrics.
+      for (const [, pend] of pending) {
+        const mappedName = translator.mapName(pend.name);
+        const tc: ToolCallRecord = {
+          name: mappedName,
+          args: translator.normalizeArgs(pend.name, pend.args),
+          result: '',
+          startTime: pend.startTime,
+          endTime: Date.now() / 1000,
+          isDocLookup: translator.isDocLookup(pend.name),
+          isInterruption: translator.isInterruption(pend.name),
+          causedError: true,
+          actionType: classifyActionType(mappedName, true),
+          isRetry: false,
+          recoveredFromError: false,
+          errorCategory: 'unknown',
+        };
+        record.toolCalls.push(tc);
+        record.providerErrors.push(`orphaned tool call: ${pend.name}`);
+      }
+      pending.clear();
+
+      if (code !== 0 && record.status !== 'failure') {
+        const stderr = Buffer.concat(stderrChunks).toString('utf-8').trim();
+        if (record.toolCalls.length === 0 && !record.finalSummary) {
+          const msg = `opencode exited with code ${code ?? 1}${stderr ? `: ${stderr.slice(0, 200)}` : ''}`;
+          record.providerErrors.push(msg);
+          record.status = 'failure';
+          logger.error(`[opencode] ✗ ${msg}`);
+        }
+      }
+
+      record.endTime = Date.now() / 1000;
+      if (record.status === 'running') {
+        record.status = record.toolCalls.length > 0 || record.finalSummary ? 'success' : 'failure';
+        if (record.status === 'failure') {
+          record.providerErrors.push('no output received');
+        }
+      }
+
+      logger.info(
+        `[opencode] Done — status=${record.status} turns=${turnNum} ` +
+          `tools=${record.toolCalls.length} cost=$${record.costUsd.toFixed(4)}`,
+      );
+      resolve(record);
+    });
+
+    child.on('error', (err) => {
+      clearTimeout(taskTimeout);
+      record.providerErrors.push(`spawn error: ${err.message}`);
+      record.status = 'failure';
+      record.endTime = Date.now() / 1000;
+      logger.error(`[opencode] ✗ Spawn error: ${err.message}`);
+      resolve(record);
+    });
+  });
+}

--- a/packages/evals/src/runners/opencode/runner.ts
+++ b/packages/evals/src/runners/opencode/runner.ts
@@ -1,0 +1,30 @@
+/**
+ * AgentRunner implementation for the opencode agent.
+ *
+ * Skills are placed in `.claude/skills/` so opencode's native discovery
+ * (`.claude/skills/**\/SKILL.md`) picks them up automatically.
+ */
+
+import type { AgentRunner, RunParams, RunResult, EvalDefinition } from '@a0/evals-core';
+import { CopySkillsStrategy, isLlamaModel } from '@a0/evals-core';
+import type { SkillsStrategy } from '@a0/evals-core';
+import { runOpencodeAgent, OPENCODE_MODEL_ID, OPENCODE_DEFAULT_MODEL } from './agent.js';
+
+export class OpencodeRunner implements AgentRunner {
+  private readonly skillsStrategy: SkillsStrategy = new CopySkillsStrategy('.claude/skills');
+
+  async prepareSkills(evalDef: EvalDefinition, workspace: string): Promise<EvalDefinition> {
+    return this.skillsStrategy.apply(evalDef, workspace);
+  }
+
+  async run({ evalDef, workspace, model, tools }: RunParams): Promise<RunResult> {
+    // Accept the sentinel 'opencode' or any Llama model (isLlamaModel check).
+    // Anything else (e.g. 'claude-...', 'gemini-...', 'gpt-...') is not a valid
+    // opencode/llama model — fall back to the default Llama model.
+    const resolvedModel = model === OPENCODE_MODEL_ID || isLlamaModel(model) ? model : OPENCODE_DEFAULT_MODEL;
+    const effectiveModel = resolvedModel === OPENCODE_MODEL_ID ? OPENCODE_DEFAULT_MODEL : resolvedModel;
+
+    const record = await runOpencodeAgent(evalDef, workspace, { tools, model: effectiveModel });
+    return { record, resolvedModel: record.model ?? OPENCODE_MODEL_ID };
+  }
+}

--- a/packages/evals/src/runners/opencode/translator.ts
+++ b/packages/evals/src/runners/opencode/translator.ts
@@ -1,0 +1,100 @@
+import { BaseToolTranslator } from '../base-translator.js';
+
+const OPENCODE_TOOL_MAP: Record<string, string> = {
+  bash: 'run_command',
+  read: 'read_file',
+  write: 'write_file',
+  edit: 'write_file',
+  list: 'list_files',
+  glob: 'list_files',
+  grep: 'list_files',
+  webfetch: 'fetch_url',
+  todowrite: 'plan',
+  todoread: 'plan',
+};
+
+export class OpencodeCliTranslator extends BaseToolTranslator {
+  protected readonly toolMap = OPENCODE_TOOL_MAP;
+  protected readonly docLookupSet = new Set(['webfetch']);
+  protected readonly interruptionSet = new Set<string>();
+  // todowrite/todoread are agent-internal planning/bookkeeping tools;
+  // task is a sub-agent orchestration tool. Excluded from scoring.
+  protected readonly internalToolSet = new Set(['todowrite', 'todoread', 'task']);
+  protected readonly logTag = 'OpencodeCliTranslator';
+
+  /**
+   * Detects opencode MCP tool names.
+   *
+   * NOTE: the exact format emitted by opencode --format json should be
+   * confirmed against a live capture. opencode likely emits MCP tools as
+   * `<server>_<tool>` or `<server>.<tool>`. This heuristic matches names
+   * that contain a separator AND are not in the native toolMap, which is a
+   * reasonable default. Also matches the framework's own `mcp__` prefix (idempotent).
+   */
+  protected override isMcpTool(name: string): boolean {
+    if (name.startsWith('mcp__')) return true;
+    // Treat names with dots or double-underscores as MCP tools (server.tool or mcp__s__t).
+    if (name.includes('.') || name.includes('__')) return true;
+    // Names not in the native tool map that contain a hyphen+underscore combo
+    // (e.g. "auth0-docs_search_auth0_docs") — same heuristic as copilot.
+    if (!Object.hasOwn(OPENCODE_TOOL_MAP, name) && name.includes('-') && name.includes('_')) return true;
+    return false;
+  }
+
+  /**
+   * Normalizes opencode MCP tool names to the framework's `mcp__<server>__<tool>` convention.
+   *
+   * NOTE: opencode's exact emitted MCP name separator should be confirmed
+   * against a live `--format json` capture. This implementation handles:
+   *   - Already-normalized `mcp__server__tool` → unchanged
+   *   - `server.tool` → `mcp__server__tool`
+   *   - `server_tool` (single underscore prefix) → `mcp__server_tool` (prefixed)
+   * Adjust once the live format is confirmed.
+   */
+  protected override mapMcpName(name: string): string {
+    if (name.startsWith('mcp__')) return name;
+    // `server.tool` → replace first `.` separator with `__` and prefix with `mcp__`
+    if (name.includes('.')) {
+      return `mcp__${name.replace('.', '__')}`;
+    }
+    // Fallback: prefix with `mcp__`
+    return `mcp__${name}`;
+  }
+
+  override isDocLookup(name: string): boolean {
+    return super.isDocLookup(name) || name.includes('fetch') || name.includes('doc');
+  }
+
+  normalizeArgs(opencodeName: string, args: Record<string, unknown>): Record<string, unknown> {
+    switch (opencodeName) {
+      case 'bash':
+        // opencode bash tool likely uses `command` — confirm against live capture.
+        return { command: args.command ?? args.cmd ?? '' };
+      case 'read':
+        // opencode read tool likely uses `filePath` — confirm against live capture.
+        return { path: args.filePath ?? args.path ?? args.file_path ?? '' };
+      case 'write':
+        return {
+          path: args.filePath ?? args.path ?? args.file_path ?? '',
+          content: args.content ?? '',
+        };
+      case 'edit':
+        return {
+          path: args.filePath ?? args.path ?? args.file_path ?? '',
+          content: args.content ?? args.new_content ?? args.new_string ?? '',
+        };
+      case 'list':
+      case 'glob':
+        return { path: args.pattern ?? args.path ?? '' };
+      case 'grep':
+        return { path: args.path ?? '.', command: `grep "${String(args.pattern ?? '')}"` };
+      case 'webfetch':
+        return { url: args.url ?? '' };
+      case 'todowrite':
+      case 'todoread':
+        return args;
+      default:
+        return args;
+    }
+  }
+}

--- a/packages/evals/tests/run.test.ts
+++ b/packages/evals/tests/run.test.ts
@@ -121,6 +121,21 @@ describe('buildJobList — mixed modes', () => {
     // 2 evals × 2 models × 2 modes = 8 jobs
     expect(jobs).toHaveLength(8);
   });
+
+  it('Llama model with baseline+agent modes → only baseline job produced', () => {
+    const jobs = buildJobList([EVAL], ['llama-4-maverick-17b'], ['baseline', 'agent'], [], undefined);
+    expect(jobs).toHaveLength(1);
+    const modes = jobs.map((j) => j[2]);
+    expect(modes).toEqual(['baseline']);
+  });
+
+  it('non-Llama model with baseline+agent modes → both jobs produced', () => {
+    const jobs = buildJobList([EVAL], ['gpt-5.2'], ['baseline', 'agent'], [], undefined);
+    expect(jobs).toHaveLength(2);
+    const modes = jobs.map((j) => j[2]);
+    expect(modes).toContain('baseline');
+    expect(modes).toContain('agent');
+  });
 });
 
 // ── buildSubprocessArgs ───────────────────────────────────────────────────────

--- a/packages/evals/tests/run.test.ts
+++ b/packages/evals/tests/run.test.ts
@@ -122,11 +122,30 @@ describe('buildJobList — mixed modes', () => {
     expect(jobs).toHaveLength(8);
   });
 
-  it('Llama model with baseline+agent modes → only baseline job produced', () => {
+  it('Llama model with baseline+agent modes → two jobs: baseline and agent (opencode)', () => {
     const jobs = buildJobList([EVAL], ['llama-4-maverick-17b'], ['baseline', 'agent'], [], undefined);
-    expect(jobs).toHaveLength(1);
+    expect(jobs).toHaveLength(2);
     const modes = jobs.map((j) => j[2]);
-    expect(modes).toEqual(['baseline']);
+    expect(modes).toContain('baseline');
+    expect(modes).toContain('agent');
+    const agentJob = jobs.find((j) => j[2] === 'agent')!;
+    expect(agentJob[4]).toBe('opencode');
+    expect(agentJob[1]).toBe('llama-4-maverick-17b');
+  });
+
+  it('Llama model with only baseline mode → one baseline job', () => {
+    const jobs = buildJobList([EVAL], ['llama-4-maverick-17b'], ['baseline'], [], undefined);
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0][2]).toBe('baseline');
+  });
+
+  it('Llama model with agent mode and mcp+skills tools → agent job carries tools and agentType opencode', () => {
+    const jobs = buildJobList([EVAL], ['llama-4-maverick-17b'], ['agent'], ['mcp', 'skills'], undefined);
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0][2]).toBe('agent');
+    expect(jobs[0][4]).toBe('opencode');
+    expect(jobs[0][3]).toEqual(['mcp', 'skills']);
+    expect(jobs[0][1]).toBe('llama-4-maverick-17b');
   });
 
   it('non-Llama model with baseline+agent modes → both jobs produced', () => {

--- a/packages/evals/tests/runners/opencode-agent.test.ts
+++ b/packages/evals/tests/runners/opencode-agent.test.ts
@@ -1,0 +1,710 @@
+/**
+ * Unit tests for runOpencodeAgent in opencode/agent.ts.
+ *
+ * Mocks `node:child_process` spawn so the tests never touch the filesystem or
+ * spawn a real process.  Each test builds a fake child that emits JSONL events
+ * via a Readable stdout, then asserts on the returned RunRecord.
+ *
+ * Covered scenarios:
+ *   - tool_use + tool_result  → ToolCallRecord with translator-mapped name
+ *   - step_finish             → TurnMetric; token / cost accumulation
+ *   - text / message          → finalSummary
+ *   - error event             → providerErrors
+ *   - malformed (non-JSON) line → skipped; run still finalises as success
+ *   - MAX_TURNS enforcement   → status=failure; child.kill called
+ *   - orphaned tool_use       → drained on close with causedError=true
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { Readable } from 'node:stream';
+
+// ── Mock framework config ─────────────────────────────────────────────────────
+
+const mockGetFrameworkConfig = vi.hoisted(() =>
+  vi.fn().mockReturnValue({
+    proxy: { baseUrl: 'https://llm.example.com' },
+    mcp: {
+      servers: {
+        'auth0-docs': { type: 'http', url: 'https://auth0.com/docs/mcp' },
+      },
+    },
+  }),
+);
+
+const mintMcpTokenMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@a0/evals-core', async () => ({
+  ...(await vi.importActual('@a0/evals-core')),
+  getFrameworkConfig: mockGetFrameworkConfig,
+  mintMcpToken: mintMcpTokenMock,
+  getAgentProxyBaseUrl: vi.fn().mockReturnValue('https://llm.example.com'),
+  filteredEnv: vi.fn().mockReturnValue({}),
+  makeSessionId: vi.fn().mockReturnValue('test-session-id'),
+  estimateCost: vi.fn().mockReturnValue(0),
+}));
+
+// ── Mock spawn ────────────────────────────────────────────────────────────────
+
+const mockSpawn = vi.hoisted(() => vi.fn());
+vi.mock('node:child_process', () => ({ spawn: mockSpawn }));
+
+// ── Mock binary resolution so resolveOpencodeBin() doesn't throw ──────────────
+
+vi.mock('node:module', async () => {
+  const actual = await vi.importActual<typeof import('node:module')>('node:module');
+  return {
+    ...actual,
+    createRequire: vi.fn().mockReturnValue(
+      Object.assign(vi.fn().mockReturnValue(undefined), {
+        resolve: vi.fn().mockReturnValue('/mock/opencode-ai/package.json'),
+        extensions: {},
+        cache: {},
+        main: undefined,
+      }),
+    ),
+  };
+});
+
+// ── Mock fs so writeOpencodeConfig doesn't touch the real filesystem ───────────
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return { ...actual, writeFileSync: vi.fn() };
+});
+
+import { MAX_TURNS } from '@a0/evals-core';
+import { runOpencodeAgent } from '../../src/runners/opencode/agent.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+type JsonlEvent = Record<string, unknown>;
+
+/**
+ * Builds a fake child process.  `events` are pushed as JSONL lines then the
+ * stream ends; the `close` event fires with `exitCode`.  All of this happens
+ * inside a `setImmediate` so readline has time to attach before data arrives.
+ */
+function makeChild(events: JsonlEvent[], exitCode = 0, stderrText = '') {
+  const stdout = new Readable({ read() {} });
+  const stderr = new Readable({ read() {} });
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: Readable;
+    stderr: Readable;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  child.stdout = stdout;
+  child.stderr = stderr;
+  child.kill = vi.fn();
+
+  setImmediate(() => {
+    for (const ev of events) {
+      stdout.push(JSON.stringify(ev) + '\n');
+    }
+    stdout.push(null);
+    if (stderrText) stderr.push(Buffer.from(stderrText));
+    stderr.push(null);
+    child.emit('close', exitCode);
+  });
+
+  return child;
+}
+
+/**
+ * Build a child that pushes raw text lines (for testing malformed input).
+ */
+function makeChildWithRawLines(lines: string[], exitCode = 0) {
+  const stdout = new Readable({ read() {} });
+  const stderr = new Readable({ read() {} });
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: Readable;
+    stderr: Readable;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  child.stdout = stdout;
+  child.stderr = stderr;
+  child.kill = vi.fn();
+
+  setImmediate(() => {
+    for (const line of lines) {
+      stdout.push(line + '\n');
+    }
+    stdout.push(null);
+    stderr.push(null);
+    child.emit('close', exitCode);
+  });
+
+  return child;
+}
+
+const evalDef = { id: 'react_quickstart', userPrompt: 'Add Auth0 login.' };
+const workspace = '/tmp/test-workspace';
+
+beforeEach(() => {
+  mockSpawn.mockReset();
+  mintMcpTokenMock.mockReset();
+});
+
+// ── tool_use + tool_result ────────────────────────────────────────────────────
+
+describe('tool_use + tool_result', () => {
+  it('creates a ToolCallRecord with translator-mapped name, normalized args, and causedError=false', async () => {
+    mockSpawn.mockReturnValue(
+      makeChild([
+        {
+          type: 'tool_use',
+          tool_id: 't1',
+          tool_name: 'bash',
+          parameters: { command: 'npm install' },
+        },
+        {
+          type: 'tool_result',
+          tool_id: 't1',
+          output: 'added 10 packages',
+          status: 'success',
+        },
+        // Provide a step_finish so status resolves to success
+        {
+          type: 'step_finish',
+          tokens: { input: 10, output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
+          cost: 0.0001,
+        },
+        { type: 'text', content: 'Done.' },
+      ]),
+    );
+
+    const record = await runOpencodeAgent(evalDef, workspace);
+    expect(record.toolCalls).toHaveLength(1);
+    const tc = record.toolCalls[0];
+
+    // opencode 'bash' → canonical 'run_command'
+    expect(tc.name).toBe('run_command');
+    // args are normalised by the translator
+    expect(tc.args).toEqual({ command: 'npm install' });
+    expect(tc.result).toBe('added 10 packages');
+    expect(tc.causedError).toBe(false);
+    // actionType must be set (non-empty string)
+    expect(typeof tc.actionType).toBe('string');
+    expect(tc.actionType.length).toBeGreaterThan(0);
+  });
+
+  it('accepts the hyphenated spelling tool-use as equivalent to tool_use', async () => {
+    mockSpawn.mockReturnValue(
+      makeChild([
+        {
+          type: 'tool-use',
+          tool_id: 't2',
+          tool_name: 'bash',
+          parameters: { command: 'ls' },
+        },
+        {
+          type: 'tool_result',
+          tool_id: 't2',
+          output: 'src/',
+          status: 'success',
+        },
+        {
+          type: 'step_finish',
+          tokens: { input: 5, output: 2, reasoning: 0, cache: { read: 0, write: 0 } },
+        },
+        { type: 'text', content: 'Done.' },
+      ]),
+    );
+
+    const record = await runOpencodeAgent(evalDef, workspace);
+    expect(record.toolCalls).toHaveLength(1);
+    expect(record.toolCalls[0].name).toBe('run_command');
+  });
+
+  it('marks tool_result with status error as causedError=true', async () => {
+    mockSpawn.mockReturnValue(
+      makeChild([
+        {
+          type: 'tool_use',
+          tool_id: 't3',
+          tool_name: 'bash',
+          parameters: { command: 'npm test' },
+        },
+        {
+          type: 'tool_result',
+          tool_id: 't3',
+          output: 'Tests failed',
+          status: 'error',
+        },
+        {
+          type: 'step_finish',
+          tokens: { input: 5, output: 2, reasoning: 0, cache: { read: 0, write: 0 } },
+        },
+        { type: 'text', content: 'Failed.' },
+      ]),
+    );
+
+    const record = await runOpencodeAgent(evalDef, workspace);
+    expect(record.toolCalls[0].causedError).toBe(true);
+  });
+
+  it('marks tool_result with is_error=true as causedError=true', async () => {
+    mockSpawn.mockReturnValue(
+      makeChild([
+        {
+          type: 'tool_use',
+          tool_id: 't4',
+          tool_name: 'read',
+          parameters: { filePath: 'src/app.ts' },
+        },
+        {
+          type: 'tool_result',
+          tool_id: 't4',
+          output: 'ENOENT',
+          is_error: true,
+        },
+        {
+          type: 'step_finish',
+          tokens: { input: 5, output: 2, reasoning: 0, cache: { read: 0, write: 0 } },
+        },
+        { type: 'text', content: 'Failed.' },
+      ]),
+    );
+
+    const record = await runOpencodeAgent(evalDef, workspace);
+    expect(record.toolCalls[0].causedError).toBe(true);
+  });
+});
+
+// ── step_finish: token accumulation and TurnMetric ───────────────────────────
+
+describe('step_finish events', () => {
+  it('accumulates inputTokens/outputTokens and pushes a TurnMetric', async () => {
+    mockSpawn.mockReturnValue(
+      makeChild([
+        {
+          type: 'step_finish',
+          tokens: { input: 100, output: 40, reasoning: 10, cache: { read: 20, write: 5 } },
+          cost: 0.0025,
+        },
+        { type: 'text', content: 'All done.' },
+      ]),
+    );
+
+    const record = await runOpencodeAgent(evalDef, workspace);
+
+    // inputTokens = input(100) + cache.read(20) = 120
+    expect(record.inputTokens).toBe(120);
+    // outputTokens = output(40) + reasoning(10) + cache.write(5) = 55
+    expect(record.outputTokens).toBe(55);
+
+    // costUsd prefers the reported cost
+    expect(record.costUsd).toBeCloseTo(0.0025);
+
+    expect(record.turnMetrics).toHaveLength(1);
+    const tm = record.turnMetrics[0];
+    expect(tm.turn).toBe(1);
+    expect(tm.inputTokens).toBe(120);
+    expect(tm.outputTokens).toBe(55);
+    expect(tm.costUsd).toBeCloseTo(0.0025);
+    expect(typeof tm.llmLatency).toBe('number');
+    expect(tm.llmLatency).toBeGreaterThanOrEqual(0);
+  });
+
+  it('accepts the hyphenated spelling step-finish', async () => {
+    mockSpawn.mockReturnValue(
+      makeChild([
+        {
+          type: 'step-finish',
+          tokens: { input: 50, output: 20, reasoning: 0, cache: { read: 0, write: 0 } },
+          cost: 0.001,
+        },
+        { type: 'text', content: 'Done.' },
+      ]),
+    );
+
+    const record = await runOpencodeAgent(evalDef, workspace);
+    expect(record.turnMetrics).toHaveLength(1);
+    expect(record.inputTokens).toBe(50);
+  });
+
+  it('accumulates tokens across multiple step_finish events', async () => {
+    mockSpawn.mockReturnValue(
+      makeChild([
+        {
+          type: 'step_finish',
+          tokens: { input: 100, output: 30, reasoning: 0, cache: { read: 0, write: 0 } },
+          cost: 0.001,
+        },
+        {
+          type: 'step_finish',
+          tokens: { input: 200, output: 60, reasoning: 0, cache: { read: 0, write: 0 } },
+          cost: 0.002,
+        },
+        { type: 'text', content: 'Done.' },
+      ]),
+    );
+
+    const record = await runOpencodeAgent(evalDef, workspace);
+    expect(record.inputTokens).toBe(300);
+    expect(record.outputTokens).toBe(90);
+    expect(record.costUsd).toBeCloseTo(0.003);
+    expect(record.turnMetrics).toHaveLength(2);
+    expect(record.turnMetrics[0].turn).toBe(1);
+    expect(record.turnMetrics[1].turn).toBe(2);
+  });
+
+  it('uses estimated cost when reported cost is 0 or absent', async () => {
+    // estimateCost is mocked to return 0, so we just verify costUsd stays 0 in that path
+    mockSpawn.mockReturnValue(
+      makeChild([
+        {
+          type: 'step_finish',
+          tokens: { input: 100, output: 50, reasoning: 0, cache: { read: 0, write: 0 } },
+          // cost intentionally absent
+        },
+        { type: 'text', content: 'Done.' },
+      ]),
+    );
+
+    const record = await runOpencodeAgent(evalDef, workspace);
+    // estimateCost mock returns 0 → costUsd should be 0
+    expect(record.costUsd).toBe(0);
+  });
+
+  it('step_finish with no tool calls in the turn has finishReason stop', async () => {
+    mockSpawn.mockReturnValue(
+      makeChild([
+        {
+          type: 'step_finish',
+          tokens: { input: 10, output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
+        },
+        { type: 'text', content: 'No tools used.' },
+      ]),
+    );
+
+    const record = await runOpencodeAgent(evalDef, workspace);
+    expect(record.turnMetrics[0].finishReason).toBe('stop');
+    expect(record.turnMetrics[0].toolCallCount).toBe(0);
+  });
+
+  it('step_finish after tool calls has finishReason tool_calls', async () => {
+    mockSpawn.mockReturnValue(
+      makeChild([
+        {
+          type: 'tool_use',
+          tool_id: 'ta',
+          tool_name: 'bash',
+          parameters: { command: 'ls' },
+        },
+        {
+          type: 'tool_result',
+          tool_id: 'ta',
+          output: 'src/',
+          status: 'success',
+        },
+        {
+          type: 'step_finish',
+          tokens: { input: 10, output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
+        },
+        { type: 'text', content: 'Done.' },
+      ]),
+    );
+
+    const record = await runOpencodeAgent(evalDef, workspace);
+    expect(record.turnMetrics[0].finishReason).toBe('tool_calls');
+    expect(record.turnMetrics[0].toolCallCount).toBe(1);
+  });
+});
+
+// ── text / message events → finalSummary ─────────────────────────────────────
+
+describe('text / message events', () => {
+  it('text event sets finalSummary', async () => {
+    mockSpawn.mockReturnValue(
+      makeChild([
+        {
+          type: 'step_finish',
+          tokens: { input: 5, output: 2, reasoning: 0, cache: { read: 0, write: 0 } },
+        },
+        { type: 'text', content: 'Integration complete.' },
+      ]),
+    );
+
+    const record = await runOpencodeAgent(evalDef, workspace);
+    expect(record.finalSummary).toBe('Integration complete.');
+  });
+
+  it('last text event wins as finalSummary', async () => {
+    mockSpawn.mockReturnValue(
+      makeChild([
+        { type: 'text', content: 'First message.' },
+        {
+          type: 'step_finish',
+          tokens: { input: 5, output: 2, reasoning: 0, cache: { read: 0, write: 0 } },
+        },
+        { type: 'text', content: 'Final summary.' },
+      ]),
+    );
+
+    const record = await runOpencodeAgent(evalDef, workspace);
+    expect(record.finalSummary).toBe('Final summary.');
+  });
+
+  it('message event sets finalSummary via .content field', async () => {
+    mockSpawn.mockReturnValue(
+      makeChild([
+        {
+          type: 'step_finish',
+          tokens: { input: 5, output: 2, reasoning: 0, cache: { read: 0, write: 0 } },
+        },
+        { type: 'message', content: 'Message content.' },
+      ]),
+    );
+
+    const record = await runOpencodeAgent(evalDef, workspace);
+    expect(record.finalSummary).toBe('Message content.');
+  });
+
+  it('assistant_message event sets finalSummary', async () => {
+    mockSpawn.mockReturnValue(
+      makeChild([
+        {
+          type: 'step_finish',
+          tokens: { input: 5, output: 2, reasoning: 0, cache: { read: 0, write: 0 } },
+        },
+        { type: 'assistant_message', content: 'Assistant reply.' },
+      ]),
+    );
+
+    const record = await runOpencodeAgent(evalDef, workspace);
+    expect(record.finalSummary).toBe('Assistant reply.');
+  });
+});
+
+// ── error events ──────────────────────────────────────────────────────────────
+
+describe('error events', () => {
+  it('error event with message field is appended to providerErrors', async () => {
+    mockSpawn.mockReturnValue(
+      makeChild([
+        { type: 'error', message: 'rate limit exceeded' },
+        { type: 'text', content: 'Stopped.' },
+      ]),
+    );
+
+    const record = await runOpencodeAgent(evalDef, workspace);
+    expect(record.providerErrors.some((e) => e.includes('rate limit exceeded'))).toBe(true);
+  });
+
+  it('error event with error field is appended to providerErrors', async () => {
+    mockSpawn.mockReturnValue(
+      makeChild([
+        { type: 'error', error: 'connection reset' },
+        { type: 'text', content: 'Stopped.' },
+      ]),
+    );
+
+    const record = await runOpencodeAgent(evalDef, workspace);
+    expect(record.providerErrors.some((e) => e.includes('connection reset'))).toBe(true);
+  });
+});
+
+// ── malformed (non-JSON) lines ────────────────────────────────────────────────
+
+describe('malformed stdout lines', () => {
+  it('skips non-JSON lines without throwing; run finalizes as success when valid output exists', async () => {
+    // Interleave some garbage with a valid step_finish + text event
+    const lines = [
+      'not valid json at all',
+      JSON.stringify({
+        type: 'step_finish',
+        tokens: { input: 5, output: 2, reasoning: 0, cache: { read: 0, write: 0 } },
+      }),
+      '{ bad json',
+      JSON.stringify({ type: 'text', content: 'Done.' }),
+    ];
+
+    const child = makeChildWithRawLines(lines, 0);
+    mockSpawn.mockReturnValue(child);
+
+    const record = await runOpencodeAgent(evalDef, workspace);
+    // No throw; record is still valid
+    expect(record.status).toBe('success');
+    expect(record.finalSummary).toBe('Done.');
+    expect(record.turnMetrics).toHaveLength(1);
+  });
+
+  it('skips empty/whitespace lines without affecting the run', async () => {
+    const lines = [
+      '   ',
+      '',
+      JSON.stringify({ type: 'text', content: 'Hello.' }),
+      JSON.stringify({
+        type: 'step_finish',
+        tokens: { input: 2, output: 1, reasoning: 0, cache: { read: 0, write: 0 } },
+      }),
+    ];
+
+    mockSpawn.mockReturnValue(makeChildWithRawLines(lines, 0));
+    const record = await runOpencodeAgent(evalDef, workspace);
+    expect(record.status).toBe('success');
+  });
+});
+
+// ── MAX_TURNS enforcement ─────────────────────────────────────────────────────
+
+describe('MAX_TURNS enforcement', () => {
+  it('sets status=failure and calls child.kill after MAX_TURNS step_finish events', async () => {
+    const events: JsonlEvent[] = [];
+    for (let i = 0; i < MAX_TURNS + 3; i++) {
+      events.push({
+        type: 'tool_use',
+        tool_id: `t${i}`,
+        tool_name: 'bash',
+        parameters: { command: 'ls' },
+      });
+      events.push({
+        type: 'tool_result',
+        tool_id: `t${i}`,
+        output: 'ok',
+        status: 'success',
+      });
+      events.push({
+        type: 'step_finish',
+        tokens: { input: 10, output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
+        cost: 0.001,
+      });
+    }
+    events.push({ type: 'text', content: 'Went on too long.' });
+
+    const child = makeChild(events);
+    mockSpawn.mockReturnValue(child);
+
+    const record = await runOpencodeAgent(evalDef, workspace);
+
+    expect(record.status).toBe('failure');
+    expect(record.providerErrors.some((e) => e.includes('turn limit'))).toBe(true);
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    // At least MAX_TURNS turn metrics should exist
+    expect(record.turnMetrics.length).toBeGreaterThanOrEqual(MAX_TURNS);
+  });
+});
+
+// ── orphaned tool_use (no matching tool_result) ───────────────────────────────
+
+describe('orphaned tool_use events', () => {
+  it('drains orphaned tool_use into a ToolCallRecord with causedError=true before close', async () => {
+    // Emit a tool_use that never receives a tool_result, then close.
+    mockSpawn.mockReturnValue(
+      makeChild(
+        [
+          {
+            type: 'tool_use',
+            tool_id: 'orphan1',
+            tool_name: 'bash',
+            parameters: { command: 'rm -rf /' },
+          },
+        ],
+        1,
+      ),
+    );
+
+    const record = await runOpencodeAgent(evalDef, workspace);
+
+    const orphaned = record.toolCalls.find((tc) => tc.name === 'run_command');
+    expect(orphaned).toBeDefined();
+    expect(orphaned?.causedError).toBe(true);
+    expect(orphaned?.result).toBe('');
+    expect(record.providerErrors.some((e) => e.includes('orphaned tool call'))).toBe(true);
+  });
+
+  it('drains multiple orphaned tool_use events', async () => {
+    mockSpawn.mockReturnValue(
+      makeChild(
+        [
+          { type: 'tool_use', tool_id: 'o1', tool_name: 'bash', parameters: { command: 'ls' } },
+          { type: 'tool_use', tool_id: 'o2', tool_name: 'read', parameters: { filePath: 'app.ts' } },
+        ],
+        1,
+      ),
+    );
+
+    const record = await runOpencodeAgent(evalDef, workspace);
+    expect(record.toolCalls).toHaveLength(2);
+    expect(record.toolCalls.every((tc) => tc.causedError)).toBe(true);
+    expect(record.providerErrors.filter((e) => e.startsWith('orphaned tool call:'))).toHaveLength(2);
+  });
+});
+
+// ── status and final state ────────────────────────────────────────────────────
+
+describe('status and final state', () => {
+  it('clean close with finalSummary and tool calls sets status=success', async () => {
+    mockSpawn.mockReturnValue(
+      makeChild([
+        {
+          type: 'tool_use',
+          tool_id: 't1',
+          tool_name: 'bash',
+          parameters: { command: 'npm install' },
+        },
+        {
+          type: 'tool_result',
+          tool_id: 't1',
+          output: 'ok',
+          status: 'success',
+        },
+        {
+          type: 'step_finish',
+          tokens: { input: 10, output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
+        },
+        { type: 'text', content: 'Task complete.' },
+      ]),
+    );
+
+    const record = await runOpencodeAgent(evalDef, workspace);
+    expect(record.status).toBe('success');
+  });
+
+  it('non-zero exit with no output sets status=failure', async () => {
+    mockSpawn.mockReturnValue(makeChild([], 1, 'fatal error'));
+    const record = await runOpencodeAgent(evalDef, workspace);
+    expect(record.status).toBe('failure');
+  });
+
+  it('spawn error event sets status=failure', async () => {
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: Readable;
+      stderr: Readable;
+      kill: ReturnType<typeof vi.fn>;
+    };
+    child.stdout = new Readable({ read() {} });
+    child.stderr = new Readable({ read() {} });
+    child.kill = vi.fn();
+    setImmediate(() => child.emit('error', new Error('spawn ENOENT')));
+    mockSpawn.mockReturnValue(child);
+
+    const record = await runOpencodeAgent(evalDef, workspace);
+    expect(record.status).toBe('failure');
+    expect(record.providerErrors.some((e) => e.includes('spawn ENOENT'))).toBe(true);
+  });
+
+  it('endTime is always set after completion', async () => {
+    mockSpawn.mockReturnValue(makeChild([], 1));
+    const before = Date.now() / 1000;
+    const record = await runOpencodeAgent(evalDef, workspace);
+    const after = Date.now() / 1000;
+    expect(record.endTime).toBeGreaterThanOrEqual(before);
+    expect(record.endTime).toBeLessThanOrEqual(after + 0.1);
+  });
+
+  it('record taskName is the eval id', async () => {
+    mockSpawn.mockReturnValue(
+      makeChild([
+        {
+          type: 'step_finish',
+          tokens: { input: 5, output: 2, reasoning: 0, cache: { read: 0, write: 0 } },
+        },
+        { type: 'text', content: 'Done.' },
+      ]),
+    );
+    const record = await runOpencodeAgent(evalDef, workspace);
+    expect(record.taskName).toBe('react_quickstart');
+  });
+});

--- a/packages/evals/tests/runners/opencode-config.test.ts
+++ b/packages/evals/tests/runners/opencode-config.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Unit tests for writeOpencodeConfig in opencode/agent.ts.
+ *
+ * Writes to a real temp directory and reads the generated opencode.jsonc back
+ * to assert on its structure, matching the pattern used by other config-writer
+ * tests in this suite.
+ *
+ * Critical correctness assertions:
+ *   1. Provider uses @ai-sdk/openai-compatible; baseURL ends with /v1; apiKey is {env:LLM_API_KEY}
+ *   2. model AND small_model are BOTH '<OPENCODE_PROVIDER_NAME>/llama-4-maverick-17b'
+ *      (the #1 opencode correctness trap — small_model must be pinned to the same model)
+ *   3. Authed MCP server → type: 'remote', headers.Authorization with {env:VAR} placeholder,
+ *      bearerTokens map carries the minted token under that VAR
+ *   4. NO raw secret in the written file
+ *   5. Without tools:['mcp'], no mcp key in config
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// ── Mock framework config and token helpers ───────────────────────────────────
+
+const mockGetFrameworkConfig = vi.hoisted(() =>
+  vi.fn().mockReturnValue({
+    proxy: { baseUrl: 'https://llm.example.com' },
+    mcp: {
+      servers: {
+        'auth0-docs': { type: 'http', url: 'https://auth0.com/docs/mcp' },
+        'auth0-hosted-mcp': {
+          type: 'http',
+          url: 'https://tenant.auth0.com/v1/mcp',
+          auth: {
+            tokenUrl: 'https://tenant.auth0.com/oauth/token',
+            clientId: 'cid',
+            clientSecret: 'secret',
+            audience: 'https://tenant.auth0.com/api/v2/',
+          },
+        },
+      },
+    },
+  }),
+);
+
+const mintMcpTokenMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@a0/evals-core', async () => ({
+  ...(await vi.importActual('@a0/evals-core')),
+  getFrameworkConfig: mockGetFrameworkConfig,
+  mintMcpToken: mintMcpTokenMock,
+  getAgentProxyBaseUrl: vi.fn().mockReturnValue('https://llm.example.com'),
+  filteredEnv: vi.fn().mockReturnValue({}),
+  makeSessionId: vi.fn().mockReturnValue('test-session-id'),
+  estimateCost: vi.fn().mockReturnValue(0),
+}));
+
+import {
+  writeOpencodeConfig,
+  OPENCODE_PROVIDER_NAME,
+  OPENCODE_DEFAULT_MODEL,
+} from '../../src/runners/opencode/agent.js';
+
+// ── Temp workspace helpers ────────────────────────────────────────────────────
+
+let tmpWorkspace: string;
+
+beforeEach(() => {
+  mintMcpTokenMock.mockReset();
+  tmpWorkspace = mkdtempSync(join(tmpdir(), 'opencode-config-'));
+});
+
+afterEach(() => {
+  rmSync(tmpWorkspace, { recursive: true, force: true });
+});
+
+function readConfig(): Record<string, unknown> {
+  const raw = readFileSync(join(tmpWorkspace, 'opencode.jsonc'), 'utf-8');
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+function readConfigRaw(): string {
+  return readFileSync(join(tmpWorkspace, 'opencode.jsonc'), 'utf-8');
+}
+
+// ── provider block ────────────────────────────────────────────────────────────
+
+describe('provider block', () => {
+  it('uses @ai-sdk/openai-compatible as the npm package', async () => {
+    await writeOpencodeConfig(tmpWorkspace, OPENCODE_DEFAULT_MODEL, { tools: [] });
+    const config = readConfig();
+    const provider = (config.provider as Record<string, unknown>)[OPENCODE_PROVIDER_NAME] as Record<string, unknown>;
+    expect(provider.npm).toBe('@ai-sdk/openai-compatible');
+  });
+
+  it('options.baseURL ends with /v1', async () => {
+    await writeOpencodeConfig(tmpWorkspace, OPENCODE_DEFAULT_MODEL, { tools: [] });
+    const config = readConfig();
+    const provider = (config.provider as Record<string, unknown>)[OPENCODE_PROVIDER_NAME] as Record<string, unknown>;
+    const options = provider.options as Record<string, unknown>;
+    expect(typeof options.baseURL).toBe('string');
+    expect((options.baseURL as string).endsWith('/v1')).toBe(true);
+  });
+
+  it('options.apiKey is the {env:LLM_API_KEY} placeholder, never a raw key', async () => {
+    await writeOpencodeConfig(tmpWorkspace, OPENCODE_DEFAULT_MODEL, { tools: [] });
+    const config = readConfig();
+    const provider = (config.provider as Record<string, unknown>)[OPENCODE_PROVIDER_NAME] as Record<string, unknown>;
+    const options = provider.options as Record<string, unknown>;
+    expect(options.apiKey).toBe('{env:LLM_API_KEY}');
+  });
+
+  it('does not double-append /v1 when proxy URL already ends with /v1', async () => {
+    // The mock already returns 'https://llm.example.com' (no /v1).
+    // Test that a URL already containing /v1 doesn't become /v1/v1.
+    const { getAgentProxyBaseUrl } = await import('@a0/evals-core');
+    vi.mocked(getAgentProxyBaseUrl).mockReturnValueOnce('https://llm.example.com/v1');
+
+    await writeOpencodeConfig(tmpWorkspace, OPENCODE_DEFAULT_MODEL, { tools: [] });
+    const config = readConfig();
+    const provider = (config.provider as Record<string, unknown>)[OPENCODE_PROVIDER_NAME] as Record<string, unknown>;
+    const options = provider.options as Record<string, unknown>;
+    expect(options.baseURL).toBe('https://llm.example.com/v1');
+    expect((options.baseURL as string).endsWith('/v1/v1')).toBe(false);
+  });
+});
+
+// ── model and small_model pinning ─────────────────────────────────────────────
+
+describe('model and small_model — BOTH must be pinned to the same model (critical correctness trap)', () => {
+  it('model AND small_model are BOTH set to "<OPENCODE_PROVIDER_NAME>/llama-4-maverick-17b"', async () => {
+    await writeOpencodeConfig(tmpWorkspace, OPENCODE_DEFAULT_MODEL, { tools: [] });
+    const config = readConfig();
+
+    const expectedModelRef = `${OPENCODE_PROVIDER_NAME}/${OPENCODE_DEFAULT_MODEL}`;
+    expect(config.model).toBe(expectedModelRef);
+    // This is the critical assertion: small_model must be pinned to the same value.
+    // If small_model is missing or different, opencode's compaction/title calls
+    // will use a built-in model ID that the proxy will 400 on.
+    expect(config.small_model).toBe(expectedModelRef);
+    expect(config.model).toBe(config.small_model);
+  });
+
+  it('model AND small_model are BOTH updated when a custom model is passed', async () => {
+    const customModel = 'llama-3-70b';
+    await writeOpencodeConfig(tmpWorkspace, customModel, { tools: [] });
+    const config = readConfig();
+
+    const expectedModelRef = `${OPENCODE_PROVIDER_NAME}/${customModel}`;
+    expect(config.model).toBe(expectedModelRef);
+    expect(config.small_model).toBe(expectedModelRef);
+  });
+});
+
+// ── MCP servers: with tools:['mcp'] ──────────────────────────────────────────
+
+describe('MCP config — with tools: ["mcp"]', () => {
+  it('authed server appears as type:remote with {env:VAR} Authorization header', async () => {
+    mintMcpTokenMock.mockResolvedValueOnce('minted-token-xyz');
+
+    const result = await writeOpencodeConfig(tmpWorkspace, OPENCODE_DEFAULT_MODEL, { tools: ['mcp'] });
+    const config = readConfig();
+    const mcpServers = config.mcp as Record<string, Record<string, unknown>>;
+
+    expect(mcpServers).toBeDefined();
+    const authedServer = mcpServers['auth0-hosted-mcp'];
+    expect(authedServer).toBeDefined();
+    expect(authedServer.type).toBe('remote');
+    const headers = authedServer.headers as Record<string, string>;
+    expect(headers.Authorization).toMatch(/^Bearer \{env:MCP_BEARER_/);
+    expect(headers.Authorization).not.toContain('minted-token-xyz');
+
+    // Extract the env var name from the placeholder
+    const envVarMatch = /\{env:([^}]+)\}/.exec(headers.Authorization);
+    expect(envVarMatch).not.toBeNull();
+    const envVar = envVarMatch![1];
+
+    // bearerTokens carries the minted token under that env var name
+    expect(result.bearerTokens[envVar]).toBe('minted-token-xyz');
+  });
+
+  it('unauthed server appears as type:remote without Authorization header', async () => {
+    mintMcpTokenMock.mockResolvedValueOnce('minted-token-xyz');
+
+    await writeOpencodeConfig(tmpWorkspace, OPENCODE_DEFAULT_MODEL, { tools: ['mcp'] });
+    const config = readConfig();
+    const mcpServers = config.mcp as Record<string, Record<string, unknown>>;
+
+    const unauthedServer = mcpServers['auth0-docs'];
+    expect(unauthedServer).toBeDefined();
+    expect(unauthedServer.type).toBe('remote');
+    expect(unauthedServer.headers).toBeUndefined();
+  });
+
+  it('NO raw secret in the written file — only {env:...} placeholders', async () => {
+    const rawToken = 'super-secret-bearer-token-12345';
+    mintMcpTokenMock.mockResolvedValueOnce(rawToken);
+
+    await writeOpencodeConfig(tmpWorkspace, OPENCODE_DEFAULT_MODEL, { tools: ['mcp'] });
+    const fileText = readConfigRaw();
+
+    // Raw token must never appear in the config file
+    expect(fileText).not.toContain(rawToken);
+    // apiKey must not contain a raw key
+    expect(fileText).not.toContain('process.env');
+    // But the {env:...} placeholder must be there
+    expect(fileText).toContain('{env:LLM_API_KEY}');
+    expect(fileText).toContain('{env:MCP_BEARER_');
+  });
+
+  it('returns mcpServerNames for registered servers', async () => {
+    mintMcpTokenMock.mockResolvedValueOnce('tok');
+
+    const result = await writeOpencodeConfig(tmpWorkspace, OPENCODE_DEFAULT_MODEL, { tools: ['mcp'] });
+    expect(result.mcpServerNames).toContain('auth0-hosted-mcp');
+    expect(result.mcpServerNames).toContain('auth0-docs');
+  });
+
+  it('skips an authed server when the token mint fails (returns undefined)', async () => {
+    // mintMcpToken returns undefined → server is skipped, not registered
+    mintMcpTokenMock.mockResolvedValueOnce(undefined);
+    // auth0-docs is unauthed and always registers; auth0-hosted-mcp is authed and skipped
+
+    const result = await writeOpencodeConfig(tmpWorkspace, OPENCODE_DEFAULT_MODEL, { tools: ['mcp'] });
+    const config = readConfig();
+    const mcpServers = (config.mcp ?? {}) as Record<string, unknown>;
+
+    // auth0-hosted-mcp must not appear in the config
+    expect(mcpServers['auth0-hosted-mcp']).toBeUndefined();
+    // auth0-docs (unauthed) still appears
+    expect(mcpServers['auth0-docs']).toBeDefined();
+    // bearerTokens should be empty since no token was minted
+    expect(Object.keys(result.bearerTokens)).toHaveLength(0);
+  });
+});
+
+// ── MCP config: without tools:['mcp'] ────────────────────────────────────────
+
+describe('MCP config — without tools: ["mcp"]', () => {
+  it('no mcp key (or empty) when tools does not include mcp', async () => {
+    await writeOpencodeConfig(tmpWorkspace, OPENCODE_DEFAULT_MODEL, { tools: [] });
+    const config = readConfig();
+
+    // Either mcp key is absent or it is an empty object
+    if ('mcp' in config) {
+      const mcpServers = config.mcp as Record<string, unknown>;
+      expect(Object.keys(mcpServers)).toHaveLength(0);
+    } else {
+      expect(config.mcp).toBeUndefined();
+    }
+
+    // bearerTokens should be empty
+    const result = await writeOpencodeConfig(tmpWorkspace, OPENCODE_DEFAULT_MODEL, { tools: [] });
+    expect(Object.keys(result.bearerTokens)).toHaveLength(0);
+  });
+
+  it('mintMcpToken is never called when tools does not include mcp', async () => {
+    await writeOpencodeConfig(tmpWorkspace, OPENCODE_DEFAULT_MODEL, { tools: [] });
+    expect(mintMcpTokenMock).not.toHaveBeenCalled();
+  });
+});
+
+// ── config file is valid JSON ─────────────────────────────────────────────────
+
+describe('config file structure', () => {
+  it('writes a valid JSON file (JSONC subset — no comments in generated output)', async () => {
+    await writeOpencodeConfig(tmpWorkspace, OPENCODE_DEFAULT_MODEL, { tools: [] });
+    // If JSON.parse throws, the test fails — that's the assertion.
+    expect(() => readConfig()).not.toThrow();
+  });
+
+  it('includes the $schema field', async () => {
+    await writeOpencodeConfig(tmpWorkspace, OPENCODE_DEFAULT_MODEL, { tools: [] });
+    const config = readConfig();
+    expect(config.$schema).toBe('https://opencode.ai/config.json');
+  });
+});

--- a/packages/evals/tests/tool-translator.test.ts
+++ b/packages/evals/tests/tool-translator.test.ts
@@ -8,6 +8,7 @@ import { ClaudeCodeTranslator } from '../src/runners/claude-code/translator.js';
 import { CopilotCliTranslator } from '../src/runners/copilot/translator.js';
 import { GeminiCliTranslator } from '../src/runners/gemini-cli/translator.js';
 import { CodexTranslator, detectReadOnlyFileRead } from '../src/runners/codex/translator.js';
+import { OpencodeCliTranslator } from '../src/runners/opencode/translator.js';
 
 describe('ClaudeCodeTranslator — isDocLookup / isInterruption', () => {
   const translator = new ClaudeCodeTranslator();
@@ -427,5 +428,153 @@ describe('CodexTranslator — classifications', () => {
   it('never classifies any tool as internal', () => {
     expect(translator.isInternalTool('command_execution')).toBe(false);
     expect(translator.isInternalTool('anything')).toBe(false);
+  });
+});
+
+describe('OpencodeCliTranslator — mapName', () => {
+  const translator = new OpencodeCliTranslator();
+
+  it.each([
+    ['bash', 'run_command'],
+    ['read', 'read_file'],
+    ['write', 'write_file'],
+    ['edit', 'write_file'],
+    ['list', 'list_files'],
+    ['glob', 'list_files'],
+    ['grep', 'list_files'],
+    ['webfetch', 'fetch_url'],
+    ['todowrite', 'plan'],
+    ['todoread', 'plan'],
+  ])('maps "%s" → "%s"', (opencodeName, expected) => {
+    expect(translator.mapName(opencodeName)).toBe(expected);
+  });
+
+  it('passes through unknown tool names', () => {
+    expect(translator.mapName('some_unknown_tool')).toBe('some_unknown_tool');
+  });
+});
+
+describe('OpencodeCliTranslator — isInternalTool', () => {
+  const translator = new OpencodeCliTranslator();
+
+  it('classifies todowrite, todoread, and task as internal', () => {
+    expect(translator.isInternalTool('todowrite')).toBe(true);
+    expect(translator.isInternalTool('todoread')).toBe(true);
+    expect(translator.isInternalTool('task')).toBe(true);
+  });
+
+  it('does not classify regular tools as internal', () => {
+    expect(translator.isInternalTool('bash')).toBe(false);
+    expect(translator.isInternalTool('read')).toBe(false);
+    expect(translator.isInternalTool('write')).toBe(false);
+  });
+});
+
+describe('OpencodeCliTranslator — isDocLookup', () => {
+  const translator = new OpencodeCliTranslator();
+
+  it('classifies webfetch as doc lookup', () => {
+    expect(translator.isDocLookup('webfetch')).toBe(true);
+  });
+
+  it('classifies tool names containing "fetch" as doc lookup', () => {
+    expect(translator.isDocLookup('web_fetch')).toBe(true);
+  });
+
+  it('classifies tool names containing "doc" as doc lookup', () => {
+    expect(translator.isDocLookup('fetch_doc')).toBe(true);
+    expect(translator.isDocLookup('search_docs')).toBe(true);
+  });
+
+  it('classifies mcp__ prefixed tools as doc lookups', () => {
+    expect(translator.isDocLookup('mcp__auth0-docs__search_auth0_docs')).toBe(true);
+  });
+
+  it('does not classify file tools as doc lookups', () => {
+    expect(translator.isDocLookup('read')).toBe(false);
+    expect(translator.isDocLookup('bash')).toBe(false);
+    expect(translator.isDocLookup('write')).toBe(false);
+  });
+});
+
+describe('OpencodeCliTranslator — normalizeArgs', () => {
+  const translator = new OpencodeCliTranslator();
+
+  it('normalizes bash args to command', () => {
+    expect(translator.normalizeArgs('bash', { command: 'npm install' })).toEqual({ command: 'npm install' });
+  });
+
+  it('normalizes bash falls back to cmd', () => {
+    expect(translator.normalizeArgs('bash', { cmd: 'ls' })).toEqual({ command: 'ls' });
+  });
+
+  it('normalizes read filePath to path', () => {
+    expect(translator.normalizeArgs('read', { filePath: 'src/app.ts' })).toEqual({ path: 'src/app.ts' });
+  });
+
+  it('normalizes read path passthrough', () => {
+    expect(translator.normalizeArgs('read', { path: 'src/app.ts' })).toEqual({ path: 'src/app.ts' });
+  });
+
+  it('normalizes write to path and content', () => {
+    expect(translator.normalizeArgs('write', { filePath: 'out.ts', content: 'hello' })).toEqual({
+      path: 'out.ts',
+      content: 'hello',
+    });
+  });
+
+  it('normalizes edit to path and content (content field)', () => {
+    expect(translator.normalizeArgs('edit', { path: 'a.ts', content: 'updated' })).toEqual({
+      path: 'a.ts',
+      content: 'updated',
+    });
+  });
+
+  it('normalizes edit to path and content (new_content fallback)', () => {
+    expect(translator.normalizeArgs('edit', { path: 'a.ts', new_content: 'new' })).toEqual({
+      path: 'a.ts',
+      content: 'new',
+    });
+  });
+
+  it('normalizes webfetch url', () => {
+    expect(translator.normalizeArgs('webfetch', { url: 'https://auth0.com' })).toEqual({ url: 'https://auth0.com' });
+  });
+
+  it('passes through args for unknown tools', () => {
+    const args = { foo: 'bar' };
+    expect(translator.normalizeArgs('unknown_tool', args)).toEqual(args);
+  });
+});
+
+describe('OpencodeCliTranslator — MCP name normalization (via mapName)', () => {
+  const translator = new OpencodeCliTranslator();
+
+  it('already-normalized mcp__ names pass through unchanged', () => {
+    expect(translator.mapName('mcp__auth0-docs__search_auth0_docs')).toBe('mcp__auth0-docs__search_auth0_docs');
+  });
+
+  it('dot-separated server.tool is normalized to mcp__server__tool', () => {
+    expect(translator.mapName('auth0-docs.search_auth0_docs')).toBe('mcp__auth0-docs__search_auth0_docs');
+  });
+
+  it('double-underscore names are treated as MCP and passed through with mcp__ prefix if needed', () => {
+    // server__tool already contains __ → isMcpTool returns true → mapMcpName prefixes since no mcp__ prefix
+    expect(translator.mapName('server__tool')).toBe('mcp__server__tool');
+  });
+
+  it('hyphen+underscore combo (non-native) is normalized with mcp__ prefix', () => {
+    // auth0-docs_search_auth0_docs: not in native toolMap, has hyphen+underscore → MCP
+    expect(translator.mapName('auth0-docs_search_auth0_docs')).toBe('mcp__auth0-docs_search_auth0_docs');
+  });
+
+  it('native tools (bash, read) are NOT treated as MCP', () => {
+    expect(translator.mapName('bash')).toBe('run_command');
+    expect(translator.mapName('read')).toBe('read_file');
+  });
+
+  it('MCP tools are classified as Discovery after mapping', () => {
+    expect(classifyActionType(translator.mapName('mcp__auth0-docs__search_auth0_docs'), false)).toBe('Discovery');
+    expect(classifyActionType(translator.mapName('auth0-docs.search_auth0_docs'), false)).toBe('Discovery');
   });
 });


### PR DESCRIPTION
## What

Gives `llama-*` models **full agent-mode parity** (baseline + all agent configs L1–L5, including skills and MCP) via a new **opencode**-based `AgentRunner`. Previously llama-4-maverick-17b was baseline-only because no agent runner existed and the Copilot runner would silently coerce llama→GPT.

opencode drives the model through its CLI subprocess over an OpenAI-compatible provider pointed at the LLM proxy, and we parse its newline-delimited JSON event stream into a `RunRecord` — the same subprocess+JSONL pattern the gemini-cli runner uses.

## How

- **New runner** under `packages/evals/src/runners/opencode/`:
  - `runner.ts` — `OpencodeRunner implements AgentRunner`, `CopySkillsStrategy('.claude/skills')`, routes on the `opencode` sentinel or `isLlamaModel(model)`.
  - `agent.ts` — subprocess spawn + readline JSONL parsing, `MAX_TURNS`, timeout/abort, orphan-tool drain; `writeOpencodeConfig` generates `opencode.jsonc` per run.
  - `translator.ts` — `OpencodeCliTranslator` mapping opencode tool names → framework tool vocabulary + MCP name normalization.
- **Correctness trap handled:** `model` **and** `small_model` are both pinned to the requested model, so opencode's title/summary/compaction calls don't fall back to a provider-default model id the proxy rejects.
- **Secrets:** MCP bearer tokens are minted per job and injected via `{env:...}` placeholders only — never written into the config file (asserted in tests).
- **Routing:** `llama-*` auto-routes to `opencode` in agent mode; the baseline-only guard is removed. `OpencodeRunner` registered in both `run.ts` and `sandbox-runner.ts`.
- Added `opencode` proxy override to `eval.config.js` and `opencode-ai` dependency.

## Tests

- `opencode-agent.test.ts` — tool_use→ToolCallRecord, step_finish→tokens/cost/TurnMetric, text→finalSummary, error→providerErrors, malformed-line skip, MAX_TURNS enforcement, orphan drain.
- `opencode-config.test.ts` — provider block, `/v1` baseURL, `{env:LLM_API_KEY}`, **both `model` and `small_model` pinned**, MCP server wiring, no raw secret in the serialized file.
- `run.test.ts` — llama → baseline + agent(opencode) jobs, model preserved, tools carried.
- `tool-translator.test.ts` — `OpencodeCliTranslator` coverage.

`npm run build && npm test && npm run lint` pass for `@a0/evals` (795) and `@a0/evals-core` (527). The `@a0/evals-axis` build failure is pre-existing (missing `@netlify/axis`) and unrelated.

## Out of scope

AXIS integration; no live smoke test (the `opencode-ai` binary is resolved at runtime via `createRequire`, so build/test/lint don't require it).