### PR TITLE
feat(evals-core): classify run_command by command intent

### DIFF
--- a/packages/evals-core/src/runners/classify.ts
+++ b/packages/evals-core/src/runners/classify.ts
@@ -66,6 +66,9 @@ const READ_ONLY_LEADERS = [
   'env',
   'which',
   'echo',
+  'jq', // JSON filter — reads/reshapes stdin, never writes the workspace
+  'set', // shell option toggle (`set -e`) — a no-op prefix, not a mutation
+  'export', // sets an env var — orientation, not a workspace write
   'sed', // only when NOT in-place (`sed -i` is caught as a mutation below)
 ];
 
@@ -105,6 +108,19 @@ function tokens(segment: string): string[] {
   return segment.trim().split(/\s+/).filter(Boolean);
 }
 
+/**
+ * True when a segment redirects to a real file (a workspace write). Ignores
+ * redirects that don't touch the workspace: file-descriptor duplication
+ * (`2>&1`, `>&2`) and the discard sink (`2>/dev/null`, `>/dev/null`). Quoted
+ * spans are stripped first so a literal `>` inside an argument (e.g.
+ * `grep ">" file`) never counts as a redirect.
+ */
+function hasFileRedirect(segment: string): boolean {
+  const unquoted = segment.replace(/'[^']*'/g, ' ').replace(/"[^"]*"/g, ' ');
+  const stripped = unquoted.replace(/\d*>&\d*/g, ' ').replace(/\d*>>?\s*\/dev\/null\b/g, ' ');
+  return />>?/.test(stripped);
+}
+
 /** Classify a single (already-split) command segment. */
 function classifySegment(segment: string): SegmentIntent {
   const trimmed = segment.trim();
@@ -112,27 +128,46 @@ function classifySegment(segment: string): SegmentIntent {
     return 'discovery';
   }
 
-  // A redirect writes to the filesystem regardless of the leading verb.
-  if (/>>?/.test(trimmed)) {
+  // A redirect to a real file writes the workspace regardless of the leading
+  // verb. fd-redirects (`2>&1`) and the discard sink (`2>/dev/null`) do not.
+  if (hasFileRedirect(trimmed)) {
     return 'mutation';
   }
 
   const parts = tokens(trimmed);
   const leader = parts[0];
 
-  // auth0 api <verb> …  — reads are Discovery, writes are TenantConfig.
-  // Match on the verb position (token after `api`) so a quoted path such as
-  // `auth0 api get "clients/create-x"` classifies on `get`, not on `create`.
-  if (leader === 'auth0' && parts[1] === 'api') {
-    const verb = (parts[2] ?? '').toLowerCase();
-    if (['put', 'post', 'patch', 'delete'].includes(verb)) {
-      return 'tenant-write';
+  if (leader === 'auth0') {
+    // auth0 api <verb> …  — reads are Discovery, writes are TenantConfig.
+    // Match on the verb position (token after `api`) so a quoted path such as
+    // `auth0 api get "clients/create-x"` classifies on `get`, not on `create`.
+    if (parts[1] === 'api') {
+      const verb = (parts[2] ?? '').toLowerCase();
+      if (['put', 'post', 'patch', 'delete'].includes(verb)) {
+        return 'tenant-write';
+      }
+      if (['get', 'list', 'show'].includes(verb)) {
+        return 'discovery';
+      }
+      // Unknown api verb — treat conservatively as a mutation.
+      return 'mutation';
     }
-    if (['get', 'list', 'show'].includes(verb)) {
+
+    // auth0 <resource> <action> … — resource-command reads (`auth0 apps list`,
+    // `auth0 tenants list`, `... show`) are Discovery; writes (create/update/
+    // delete/use) reconfigure the tenant → TenantConfig.
+    const action = (parts[2] ?? parts[1] ?? '').toLowerCase();
+    if (['list', 'show', 'open', 'get'].includes(action)) {
       return 'discovery';
     }
-    // Unknown api verb — treat conservatively as a mutation.
-    return 'mutation';
+    if (['create', 'update', 'delete', 'use', 'rotate', 'enable', 'disable'].includes(action)) {
+      return 'tenant-write';
+    }
+    // Orientation probes (`auth0 --version`) fall through to the --help/--version
+    // guard below; any other auth0 command is treated conservatively as mutation.
+    if (!parts.some((t) => t === '--version' || t === '--help')) {
+      return 'mutation';
+    }
   }
 
   // `sed -i` edits in place; any other `sed` invocation is a read.
@@ -169,13 +204,67 @@ function classifySegment(segment: string): SegmentIntent {
 }
 
 /**
+ * Split a shell command into segments on the operators that separate commands
+ * (`&&`, `||`, `;`, `|`) and on newlines, **ignoring any operator that falls
+ * inside single or double quotes**. A naive `String.split` mis-splits real
+ * commands: `grep "a\|b" f` (alternation inside quotes), `sed -n '1,5p;9p'`
+ * (`;` inside a range), and multi-line heredoc/`&&` blocks would each be torn
+ * into meaningless fragments and misclassified.
+ */
+function splitSegments(command: string): string[] {
+  const segments: string[] = [];
+  let current = '';
+  let quote: "'" | '"' | null = null;
+
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i];
+    const next = command[i + 1];
+
+    if (quote) {
+      current += ch;
+      if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      current += ch;
+      continue;
+    }
+
+    // Two-char operators: && and ||
+    if ((ch === '&' && next === '&') || (ch === '|' && next === '|')) {
+      segments.push(current);
+      current = '';
+      i++; // consume the second operator char
+      continue;
+    }
+
+    // Single-char separators: ; | and newline
+    if (ch === ';' || ch === '|' || ch === '\n') {
+      segments.push(current);
+      current = '';
+      continue;
+    }
+
+    current += ch;
+  }
+  segments.push(current);
+
+  return segments.filter((s) => s.trim().length > 0);
+}
+
+/**
  * Classify a shell command by intent. Chained commands are split on `&&`, `||`,
- * `;`, and `|`, then combined by precedence: any tenant write wins, then any
- * mutation, otherwise Discovery. Unrecognised commands fall back to
- * `Implementation` so we never over-claim Discovery.
+ * `;`, `|`, and newlines (quote-aware — separators inside quotes are ignored),
+ * then combined by precedence: any tenant write wins, then any mutation,
+ * otherwise Discovery. Unrecognised commands fall back to `Implementation` so we
+ * never over-claim Discovery.
  */
 export function classifyCommandIntent(command: string): ActionType {
-  const segments = command.split(/&&|\|\||;|\|/).filter((s) => s.trim().length > 0);
+  const segments = splitSegments(command);
   if (segments.length === 0) {
     return 'Implementation';
   }

--- a/packages/evals-core/src/runners/classify.ts
+++ b/packages/evals-core/src/runners/classify.ts
@@ -17,7 +17,7 @@ const TOOL_ACTION_TYPES: Record<string, ActionType> = {
   read_file: 'Discovery',
   list_files: 'Discovery',
   write_file: 'Implementation',
-  run_command: 'Implementation',
+  // run_command is intentionally absent: it is classified by command intent in classifyActionType (see classifyCommandIntent)
   finish_task: 'Implementation',
   search_auth0_docs: 'Discovery',
   skill: 'Skill',
@@ -109,15 +109,35 @@ function tokens(segment: string): string[] {
 }
 
 /**
+ * Drop leading command wrappers (`env`, `sudo`, `command`, `nohup`, `time`,
+ * `xargs`) and inline `KEY=VALUE` environment assignments so the *real* leading
+ * verb is selected. Without this, `env DOMAIN=x auth0 api put …` would classify
+ * on `env` (Discovery) and `sudo auth0 apps create` on `sudo` (ambiguous →
+ * Implementation), masking the tenant write underneath.
+ */
+const COMMAND_WRAPPERS = new Set(['env', 'sudo', 'command', 'nohup', 'time', 'xargs']);
+function stripWrappers(parts: string[]): string[] {
+  let i = 0;
+  while (i < parts.length) {
+    const part = parts[i];
+    if (part === undefined || !(COMMAND_WRAPPERS.has(part) || /^[A-Za-z_][A-Za-z0-9_]*=/.test(part))) {
+      break;
+    }
+    i++;
+  }
+  return parts.slice(i);
+}
+
+/**
  * True when a segment redirects to a real file (a workspace write). Ignores
  * redirects that don't touch the workspace: file-descriptor duplication
- * (`2>&1`, `>&2`) and the discard sink (`2>/dev/null`, `>/dev/null`). Quoted
- * spans are stripped first so a literal `>` inside an argument (e.g.
- * `grep ">" file`) never counts as a redirect.
+ * (`2>&1`, `>&2`) and device sinks (`/dev/null`, `/dev/stderr`, `/dev/tty`,
+ * `/dev/fd/N`, …). Quoted spans are stripped first so a literal `>` inside an
+ * argument (e.g. `grep ">" file`) never counts as a redirect.
  */
 function hasFileRedirect(segment: string): boolean {
   const unquoted = segment.replace(/'[^']*'/g, ' ').replace(/"[^"]*"/g, ' ');
-  const stripped = unquoted.replace(/\d*>&\d*/g, ' ').replace(/\d*>>?\s*\/dev\/null\b/g, ' ');
+  const stripped = unquoted.replace(/\d*>&\d*/g, ' ').replace(/\d*>>?\s*\/dev\/\S+/g, ' ');
   return />>?/.test(stripped);
 }
 
@@ -134,7 +154,14 @@ function classifySegment(segment: string): SegmentIntent {
     return 'mutation';
   }
 
-  const parts = tokens(trimmed);
+  // Strip wrappers/env-assignments so `env FOO=x auth0 api put …` and
+  // `sudo auth0 apps create` classify on the real verb, not the wrapper. A bare
+  // wrapper with nothing after it (e.g. `env` alone prints the environment) is
+  // orientation → Discovery.
+  const parts = stripWrappers(tokens(trimmed));
+  if (parts.length === 0) {
+    return 'discovery';
+  }
   const leader = parts[0];
 
   if (leader === 'auth0') {

--- a/packages/evals-core/src/runners/classify.ts
+++ b/packages/evals-core/src/runners/classify.ts
@@ -27,10 +27,14 @@ const TOOL_ACTION_TYPES: Record<string, ActionType> = {
 };
 
 /**
- * Classify the type of action represented by a tool call based on its name
- * and whether it caused an error.
+ * Classify the type of action represented by a tool call based on its name,
+ * its arguments, and whether it caused an error.
+ *
+ * `run_command` is classified by *command intent* (see `classifyCommandIntent`)
+ * rather than by tool name, so shell-driven discovery / doc-reads / navigation do
+ * not all collapse into `Implementation`. All other tools map by name.
  */
-export function classifyActionType(name: string, causedError: boolean): ActionType {
+export function classifyActionType(name: string, args: Record<string, unknown>, causedError: boolean): ActionType {
   if (causedError) {
     return 'Error';
   }
@@ -40,7 +44,151 @@ export function classifyActionType(name: string, causedError: boolean): ActionTy
     return 'Discovery';
   }
 
+  if (name === 'run_command') {
+    return classifyCommandIntent(String(args.command ?? ''));
+  }
+
   return TOOL_ACTION_TYPES[name] ?? 'unknown';
+}
+
+// ── Command intent classification (for run_command) ──────────────────────────
+
+/** Leading verbs / shapes that read state or orient — never mutate. */
+const READ_ONLY_LEADERS = [
+  'ls',
+  'cat',
+  'grep',
+  'head',
+  'tail',
+  'find',
+  'pwd',
+  'cd',
+  'env',
+  'which',
+  'echo',
+  'sed', // only when NOT in-place (`sed -i` is caught as a mutation below)
+];
+
+/** Leading verbs that mutate the local workspace (files, installs, git writes). */
+const MUTATION_LEADERS = [
+  'touch',
+  'mkdir',
+  'rm',
+  'mv',
+  'cp',
+  'ln',
+  'tee',
+  'npm',
+  'npx',
+  'yarn',
+  'pnpm',
+  'pip',
+  'pip3',
+  'chmod',
+  'chown',
+];
+
+/** Read-only git subcommands (everything else under `git` is treated as a mutation). */
+const READ_ONLY_GIT_SUBCOMMANDS = ['status', 'log', 'diff', 'show', 'branch', 'remote'];
+
+/** Read-only npm subcommands (everything else under `npm` — install/run/… — mutates). */
+const READ_ONLY_NPM_SUBCOMMANDS = ['ls', 'list', 'view', 'outdated', 'why', 'search'];
+
+type SegmentIntent = 'tenant-write' | 'mutation' | 'discovery' | 'ambiguous';
+
+/**
+ * Tokenise a shell segment on whitespace, dropping empty tokens. Quotes are not
+ * interpreted — we only ever inspect the leading verb and (for `auth0 api`) the
+ * verb position, so quoted arguments never influence the classification.
+ */
+function tokens(segment: string): string[] {
+  return segment.trim().split(/\s+/).filter(Boolean);
+}
+
+/** Classify a single (already-split) command segment. */
+function classifySegment(segment: string): SegmentIntent {
+  const trimmed = segment.trim();
+  if (!trimmed) {
+    return 'discovery';
+  }
+
+  // A redirect writes to the filesystem regardless of the leading verb.
+  if (/>>?/.test(trimmed)) {
+    return 'mutation';
+  }
+
+  const parts = tokens(trimmed);
+  const leader = parts[0];
+
+  // auth0 api <verb> …  — reads are Discovery, writes are TenantConfig.
+  // Match on the verb position (token after `api`) so a quoted path such as
+  // `auth0 api get "clients/create-x"` classifies on `get`, not on `create`.
+  if (leader === 'auth0' && parts[1] === 'api') {
+    const verb = (parts[2] ?? '').toLowerCase();
+    if (['put', 'post', 'patch', 'delete'].includes(verb)) {
+      return 'tenant-write';
+    }
+    if (['get', 'list', 'show'].includes(verb)) {
+      return 'discovery';
+    }
+    // Unknown api verb — treat conservatively as a mutation.
+    return 'mutation';
+  }
+
+  // `sed -i` edits in place; any other `sed` invocation is a read.
+  if (leader === 'sed') {
+    return parts.some((t) => t === '-i' || t.startsWith('-i')) ? 'mutation' : 'discovery';
+  }
+
+  // `git` — read-only subcommands are Discovery; writes (add/commit/push/…) mutate.
+  if (leader === 'git') {
+    const sub = (parts[1] ?? '').toLowerCase();
+    return READ_ONLY_GIT_SUBCOMMANDS.includes(sub) ? 'discovery' : 'mutation';
+  }
+
+  // `npm` — read-only subcommands (ls/view/outdated/…) are Discovery; install/run/… mutate.
+  if (leader === 'npm') {
+    const sub = (parts[1] ?? '').toLowerCase();
+    return READ_ONLY_NPM_SUBCOMMANDS.includes(sub) ? 'discovery' : 'mutation';
+  }
+
+  // A bare `--version` / `--help` probe (e.g. `auth0 --version`) is orientation.
+  if (parts.some((t) => t === '--version' || t === '--help')) {
+    return 'discovery';
+  }
+
+  if (leader && MUTATION_LEADERS.includes(leader)) {
+    return 'mutation';
+  }
+
+  if (leader && READ_ONLY_LEADERS.includes(leader)) {
+    return 'discovery';
+  }
+
+  return 'ambiguous';
+}
+
+/**
+ * Classify a shell command by intent. Chained commands are split on `&&`, `||`,
+ * `;`, and `|`, then combined by precedence: any tenant write wins, then any
+ * mutation, otherwise Discovery. Unrecognised commands fall back to
+ * `Implementation` so we never over-claim Discovery.
+ */
+export function classifyCommandIntent(command: string): ActionType {
+  const segments = command.split(/&&|\|\||;|\|/).filter((s) => s.trim().length > 0);
+  if (segments.length === 0) {
+    return 'Implementation';
+  }
+
+  const intents = segments.map(classifySegment);
+
+  if (intents.includes('tenant-write')) {
+    return 'TenantConfig';
+  }
+  if (intents.includes('mutation') || intents.includes('ambiguous')) {
+    return 'Implementation';
+  }
+  return 'Discovery';
 }
 
 // ── Primary argument extraction (for retry detection) ────────────────────────

--- a/packages/evals-core/src/types/scorer.ts
+++ b/packages/evals-core/src/types/scorer.ts
@@ -9,7 +9,8 @@ import type { GraderLevel } from './graders.js';
 
 export type FinishReason = 'tool_calls' | 'stop' | 'max_tokens' | 'length' | 'error' | 'unknown';
 
-export type ActionType = 'Implementation' | 'Discovery' | 'Error' | 'Interruption' | 'Skill' | 'unknown';
+export type ActionType =
+  'Implementation' | 'Discovery' | 'TenantConfig' | 'Error' | 'Interruption' | 'Skill' | 'unknown';
 
 // ── Per-turn metrics ─────────────────────────────────────────────────────────
 

--- a/packages/evals-core/tests/classify.test.ts
+++ b/packages/evals-core/tests/classify.test.ts
@@ -124,6 +124,10 @@ describe('classifyCommandIntent', () => {
     expect(classifyCommandIntent('auth0 tenants list 2>&1 | head')).toBe('Discovery');
     expect(classifyCommandIntent('ls dist/ 2>/dev/null; find . -name "*.js"')).toBe('Discovery');
     expect(classifyCommandIntent('cat pkg.json 2>/dev/null | head')).toBe('Discovery');
+    // Other device sinks (stderr/tty/fd) are not workspace writes either.
+    expect(classifyCommandIntent('auth0 tenants list 2>/dev/stderr')).toBe('Discovery');
+    expect(classifyCommandIntent('cat server.js 2>/dev/tty | head')).toBe('Discovery');
+    expect(classifyCommandIntent('auth0 api get factors 1>/dev/fd/2')).toBe('Discovery');
     // A real file redirect is still a mutation.
     expect(classifyCommandIntent('echo "x" > out.txt')).toBe('Implementation');
     expect(classifyCommandIntent('cat a.md > combined.md')).toBe('Implementation');
@@ -139,5 +143,15 @@ describe('classifyCommandIntent', () => {
     expect(classifyCommandIntent("sed -n '313,360p;495,545p' dist/index.js")).toBe('Discovery');
     // A `|` outside quotes still splits (all-read pipe stays Discovery).
     expect(classifyCommandIntent('cat data.json | jq -c "[.[] | select(.active)]"')).toBe('Discovery');
+  });
+
+  it('leading wrappers and env assignments do not mask the real verb', () => {
+    // A wrapper/assignment prefix used to shift the leader off the real command.
+    expect(classifyCommandIntent('env DOMAIN=x auth0 api put "guardian/policies"')).toBe('TenantConfig');
+    expect(classifyCommandIntent('sudo auth0 apps create')).toBe('TenantConfig');
+    expect(classifyCommandIntent('AUTH0_DOMAIN=dev-barkbook.us.auth0.com auth0 api get factors')).toBe('Discovery');
+    expect(classifyCommandIntent('env FOO=1 BAR=2 npm install')).toBe('Implementation');
+    // A bare wrapper with nothing after it is orientation → Discovery.
+    expect(classifyCommandIntent('env')).toBe('Discovery');
   });
 });

--- a/packages/evals-core/tests/classify.test.ts
+++ b/packages/evals-core/tests/classify.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { classifyActionType } from '../src/runners/classify.js';
+import { classifyActionType, classifyCommandIntent } from '../src/runners/classify.js';
 
 describe('classifyActionType', () => {
   it.each([
@@ -9,25 +9,89 @@ describe('classifyActionType', () => {
     ['search_auth0_docs', 'Discovery'],
     ['plan', 'Discovery'],
     ['write_file', 'Implementation'],
-    ['run_command', 'Implementation'],
     ['finish_task', 'Implementation'],
     ['ask_user', 'Interruption'],
     ['skill', 'Skill'],
   ])('%s (no error) → %s', (name, expected) => {
-    expect(classifyActionType(name, false)).toBe(expected);
+    expect(classifyActionType(name, {}, false)).toBe(expected);
   });
 
   it('any tool with causedError → Error', () => {
-    expect(classifyActionType('read_file', true)).toBe('Error');
-    expect(classifyActionType('plan', true)).toBe('Error');
-    expect(classifyActionType('write_file', true)).toBe('Error');
+    expect(classifyActionType('read_file', {}, true)).toBe('Error');
+    expect(classifyActionType('plan', {}, true)).toBe('Error');
+    expect(classifyActionType('write_file', {}, true)).toBe('Error');
   });
 
   it('mcp__ prefixed tools → Discovery', () => {
-    expect(classifyActionType('mcp__auth0__search_docs', false)).toBe('Discovery');
+    expect(classifyActionType('mcp__auth0__search_docs', {}, false)).toBe('Discovery');
   });
 
   it('unknown tool → unknown', () => {
-    expect(classifyActionType('some_future_tool', false)).toBe('unknown');
+    expect(classifyActionType('some_future_tool', {}, false)).toBe('unknown');
+  });
+
+  it('run_command is classified by command intent, not tool name', () => {
+    // The bug this fixes: pure-reading shell commands used to collapse into Implementation.
+    expect(classifyActionType('run_command', { command: 'ls -la && cat a.md && cat b.md' }, false)).toBe('Discovery');
+    expect(classifyActionType('run_command', { command: 'npm install' }, false)).toBe('Implementation');
+    expect(classifyActionType('run_command', { command: 'auth0 api put "guardian/policies"' }, false)).toBe(
+      'TenantConfig',
+    );
+  });
+});
+
+describe('classifyCommandIntent', () => {
+  it.each([
+    // Read-only / orientation → Discovery
+    ['ls -la', 'Discovery'],
+    ['cat references/setup.md', 'Discovery'],
+    ['grep -r "auth0" src', 'Discovery'],
+    ['head -5 package.json', 'Discovery'],
+    ['sed -n "1,40p" references/mfa.md', 'Discovery'],
+    ['which auth0', 'Discovery'],
+    ['auth0 --version', 'Discovery'],
+    ['pwd', 'Discovery'],
+    ['git status', 'Discovery'],
+    ['git log --oneline', 'Discovery'],
+    ['git diff', 'Discovery'],
+    ['npm ls', 'Discovery'],
+    // Tenant reads → Discovery
+    ['auth0 api get "guardian/factors"', 'Discovery'],
+    ['auth0 api list', 'Discovery'],
+    ['auth0 api show clients', 'Discovery'],
+    // Verb-position guard: `create` inside a quoted path must not trip mutation
+    ['auth0 api get "clients/create-x"', 'Discovery'],
+    // Tenant writes → TenantConfig
+    ['auth0 api put "guardian/policies"', 'TenantConfig'],
+    ['auth0 api post clients', 'TenantConfig'],
+    ['auth0 api patch "clients/abc"', 'TenantConfig'],
+    ['auth0 api delete "clients/abc"', 'TenantConfig'],
+    // Local mutations → Implementation
+    ['npm install', 'Implementation'],
+    ['npm run build', 'Implementation'],
+    ['mkdir -p src/lib', 'Implementation'],
+    ['rm -rf dist', 'Implementation'],
+    ['sed -i "s/a/b/" file.txt', 'Implementation'],
+    ['echo "x" > .env', 'Implementation'],
+    ['git commit -m "wip"', 'Implementation'],
+    ['git add .', 'Implementation'],
+    // Unrecognised → Implementation (conservative guardrail)
+    ['some_unknown_binary --flag', 'Implementation'],
+  ] as [string, string][])('%j → %s', (command, expected) => {
+    expect(classifyCommandIntent(command)).toBe(expected);
+  });
+
+  it('chained commands combine by precedence: tenant-write > mutation > discovery', () => {
+    // Mutation anywhere in the chain wins over reads.
+    expect(classifyCommandIntent('sed -n "1,5p" refs.md && npm install')).toBe('Implementation');
+    // Tenant write wins over everything, including a mutation.
+    expect(classifyCommandIntent('auth0 api get factors && auth0 api put factors')).toBe('TenantConfig');
+    expect(classifyCommandIntent('npm install && auth0 api put factors')).toBe('TenantConfig');
+    // All-reads chain stays Discovery.
+    expect(classifyCommandIntent('ls | grep auth0 | head -3')).toBe('Discovery');
+  });
+
+  it('empty command → Implementation', () => {
+    expect(classifyCommandIntent('')).toBe('Implementation');
   });
 });

--- a/packages/evals-core/tests/classify.test.ts
+++ b/packages/evals-core/tests/classify.test.ts
@@ -59,6 +59,14 @@ describe('classifyCommandIntent', () => {
     ['auth0 api get "guardian/factors"', 'Discovery'],
     ['auth0 api list', 'Discovery'],
     ['auth0 api show clients', 'Discovery'],
+    // auth0 resource-command reads → Discovery
+    ['auth0 tenants list', 'Discovery'],
+    ['auth0 apps list', 'Discovery'],
+    ['auth0 apps show abc123', 'Discovery'],
+    // auth0 resource-command writes → TenantConfig
+    ['auth0 apps create', 'TenantConfig'],
+    ['auth0 apps update abc123', 'TenantConfig'],
+    ['auth0 tenants use dev-barkbook.us.auth0.com', 'TenantConfig'],
     // Verb-position guard: `create` inside a quoted path must not trip mutation
     ['auth0 api get "clients/create-x"', 'Discovery'],
     // Tenant writes → TenantConfig
@@ -93,5 +101,43 @@ describe('classifyCommandIntent', () => {
 
   it('empty command → Implementation', () => {
     expect(classifyCommandIntent('')).toBe('Implementation');
+  });
+
+  // ── Regression: quote-aware / newline-aware splitting (real rendered traces) ──
+
+  it('newline-separated blocks classify per line, tenant-write wins', () => {
+    // Bug 1 (worst): the splitter did not break on `\n`, so a multi-line block
+    // was classified by its first token only. Here `echo`/`set` led → the block
+    // rendered Discovery/Implementation and the trailing tenant WRITE was lost.
+    expect(classifyCommandIntent('echo "configuring email"\nauth0 api put "guardian/factors/email"')).toBe(
+      'TenantConfig',
+    );
+    expect(classifyCommandIntent('set -e\necho "step"\nauth0 api put sms/message-types/selected-provider')).toBe(
+      'TenantConfig',
+    );
+    // A pure multi-line read block stays Discovery.
+    expect(classifyCommandIntent('cat a.md\ngrep -rn "auth0" src\nls -la')).toBe('Discovery');
+  });
+
+  it('fd-redirects and /dev/null are not file writes', () => {
+    // Bug 2: `2>&1` / `2>/dev/null` tripped the `>` redirect check → Implementation.
+    expect(classifyCommandIntent('auth0 tenants list 2>&1 | head')).toBe('Discovery');
+    expect(classifyCommandIntent('ls dist/ 2>/dev/null; find . -name "*.js"')).toBe('Discovery');
+    expect(classifyCommandIntent('cat pkg.json 2>/dev/null | head')).toBe('Discovery');
+    // A real file redirect is still a mutation.
+    expect(classifyCommandIntent('echo "x" > out.txt')).toBe('Implementation');
+    expect(classifyCommandIntent('cat a.md > combined.md')).toBe('Implementation');
+  });
+
+  it('separators inside quotes do not split the segment', () => {
+    // Bug 3: `|` inside a grep alternation and `;` inside a sed range false-split
+    // the command into junk fragments → ambiguous → Implementation.
+    expect(classifyCommandIntent('grep -rn "issuerBaseURL\\|jwksUri\\|audience" src')).toBe('Discovery');
+    expect(classifyCommandIntent('grep -n "interface MCDOptions\\|IssuerConfig" src/index.ts | head')).toBe(
+      'Discovery',
+    );
+    expect(classifyCommandIntent("sed -n '313,360p;495,545p' dist/index.js")).toBe('Discovery');
+    // A `|` outside quotes still splits (all-read pipe stays Discovery).
+    expect(classifyCommandIntent('cat data.json | jq -c "[.[] | select(.active)]"')).toBe('Discovery');
   });
 });

--- a/packages/evals-core/tests/traces.test.ts
+++ b/packages/evals-core/tests/traces.test.ts
@@ -75,23 +75,22 @@ function makeRunRecord(toolCalls: ToolCallRecord[] = [], turnMetrics: TurnMetric
 
 describe('classifyActionType', () => {
   it('causedError=true takes priority over tool name for all tools', () => {
-    expect(classifyActionType('read_file', true)).toBe('Error');
-    expect(classifyActionType('write_file', true)).toBe('Error');
-    expect(classifyActionType('ask_user', true)).toBe('Error');
+    expect(classifyActionType('read_file', {}, true)).toBe('Error');
+    expect(classifyActionType('write_file', {}, true)).toBe('Error');
+    expect(classifyActionType('ask_user', {}, true)).toBe('Error');
   });
 
   it('discovery tools are classified correctly', () => {
-    expect(classifyActionType('read_file', false)).toBe('Discovery');
-    expect(classifyActionType('list_files', false)).toBe('Discovery');
-    expect(classifyActionType('fetch_url', false)).toBe('Discovery');
-    expect(classifyActionType('ask_user', false)).toBe('Interruption');
+    expect(classifyActionType('read_file', {}, false)).toBe('Discovery');
+    expect(classifyActionType('list_files', {}, false)).toBe('Discovery');
+    expect(classifyActionType('fetch_url', {}, false)).toBe('Discovery');
+    expect(classifyActionType('ask_user', {}, false)).toBe('Interruption');
   });
 
   it('implementation tools are classified correctly', () => {
-    expect(classifyActionType('write_file', false)).toBe('Implementation');
-    expect(classifyActionType('run_command', false)).toBe('Implementation');
-    expect(classifyActionType('finish_task', false)).toBe('Implementation');
-    expect(classifyActionType('unknown_tool', false)).toBe('unknown');
+    expect(classifyActionType('write_file', {}, false)).toBe('Implementation');
+    expect(classifyActionType('finish_task', {}, false)).toBe('Implementation');
+    expect(classifyActionType('unknown_tool', {}, false)).toBe('unknown');
   });
 });
 

--- a/packages/evals-reporter/src/templates/report.css
+++ b/packages/evals-reporter/src/templates/report.css
@@ -436,6 +436,7 @@ a { color: var(--link); }
                          font-weight: 600; letter-spacing: .03em; display: inline-block; }
 .action-implementation { background: var(--clr-green-bg); color: var(--clr-green); }
 .action-discovery      { background: var(--clr-blue-bg);  color: var(--clr-blue); }
+.action-tenantconfig   { background: var(--clr-orange-bg); color: var(--clr-orange); }
 .action-error          { background: var(--clr-red-bg);   color: var(--clr-red); }
 .action-interruption   { background: var(--clr-amber-bg); color: var(--clr-amber); }
 .action-unknown        { background: var(--clr-dim-bg);   color: var(--text-sec); }

--- a/packages/evals-reporter/tests/report-filters.test.ts
+++ b/packages/evals-reporter/tests/report-filters.test.ts
@@ -71,6 +71,7 @@ describe('actionCssClass', () => {
   it.each([
     ['Implementation', 'action-implementation'],
     ['Discovery', 'action-discovery'],
+    ['TenantConfig', 'action-tenantconfig'],
     ['Error', 'action-error'],
     // Empty / falsy falls back to action-unknown
     ['', 'action-unknown'],

--- a/packages/evals/src/runners/claude-code/agent.ts
+++ b/packages/evals/src/runners/claude-code/agent.ts
@@ -259,7 +259,7 @@ export async function runClaudeCodeAgent(
         isDocLookup: translator.isDocLookup(pend.name),
         isInterruption: translator.isInterruption(pend.name),
         causedError: true,
-        actionType: classifyActionType(mappedName, true),
+        actionType: classifyActionType(mappedName, normArgs, true),
         isRetry: detectRetry(record.toolCalls, mappedName, normArgs),
         recoveredFromError: false,
         errorCategory: 'unknown',
@@ -424,7 +424,7 @@ export function handleMessage(
         isDocLookup: isDoc,
         isInterruption: isInterrupt,
         causedError: isError,
-        actionType: classifyActionType(mappedName, isError),
+        actionType: classifyActionType(mappedName, toolArgs, isError),
         isRetry,
         recoveredFromError: recovered,
       };

--- a/packages/evals/src/runners/codex/agent.ts
+++ b/packages/evals/src/runners/codex/agent.ts
@@ -184,7 +184,7 @@ function pushToolCall(
     isDocLookup: translator.isDocLookup(rawName),
     isInterruption: translator.isInterruption(rawName),
     causedError: isError,
-    actionType: classifyActionType(mappedName, isError),
+    actionType: classifyActionType(mappedName, toolArgs, isError),
     isRetry,
     recoveredFromError: isRetry && !isError,
   };

--- a/packages/evals/src/runners/copilot/agent.ts
+++ b/packages/evals/src/runners/copilot/agent.ts
@@ -321,7 +321,7 @@ export async function runCopilotAgent(
         isDocLookup: translator.isDocLookup(pend.name),
         isInterruption: translator.isInterruption(pend.name),
         causedError: isError,
-        actionType: classifyActionType(mappedName, isError),
+        actionType: classifyActionType(mappedName, toolArgs, isError),
         isRetry,
         recoveredFromError: recovered,
       };
@@ -374,7 +374,7 @@ export async function runCopilotAgent(
         isDocLookup: translator.isDocLookup(pend.name),
         isInterruption: translator.isInterruption(pend.name),
         causedError: true,
-        actionType: classifyActionType(mappedName, true),
+        actionType: classifyActionType(mappedName, toolArgs, true),
         isRetry: detectRetry(record.toolCalls, mappedName, toolArgs),
         recoveredFromError: false,
         errorCategory: 'unknown',

--- a/packages/evals/src/runners/gemini-cli/agent.ts
+++ b/packages/evals/src/runners/gemini-cli/agent.ts
@@ -339,7 +339,7 @@ export async function runGeminiCliAgent(
               isDocLookup: translator.isDocLookup(rawName),
               isInterruption: translator.isInterruption(rawName),
               causedError: isError,
-              actionType: classifyActionType(mappedName, isError),
+              actionType: classifyActionType(mappedName, toolArgs, isError),
               isRetry,
               recoveredFromError: isRetry && !isError,
             };
@@ -453,16 +453,17 @@ export async function runGeminiCliAgent(
       // or unexpected exit) so we don't silently lose tool-call metrics.
       for (const [, pend] of pending) {
         const mappedName = translator.mapName(pend.name);
+        const normArgs = translator.normalizeArgs(pend.name, pend.args);
         const tc: ToolCallRecord = {
           name: mappedName,
-          args: translator.normalizeArgs(pend.name, pend.args),
+          args: normArgs,
           result: '',
           startTime: pend.startTime,
           endTime: Date.now() / 1000,
           isDocLookup: translator.isDocLookup(pend.name),
           isInterruption: translator.isInterruption(pend.name),
           causedError: true,
-          actionType: classifyActionType(mappedName, true),
+          actionType: classifyActionType(mappedName, normArgs, true),
           isRetry: false,
           recoveredFromError: false,
           errorCategory: 'unknown',

--- a/packages/evals/tests/tool-translator.test.ts
+++ b/packages/evals/tests/tool-translator.test.ts
@@ -105,8 +105,8 @@ describe('CopilotCliTranslator — mapping and args', () => {
   });
 
   it('classifies MCP tool calls as Discovery after mapping (both formats)', () => {
-    expect(classifyActionType(translator.mapName('mcp__auth0-docs__search_auth0_docs'), false)).toBe('Discovery');
-    expect(classifyActionType(translator.mapName('auth0-docs-search_auth0_docs'), false)).toBe('Discovery');
+    expect(classifyActionType(translator.mapName('mcp__auth0-docs__search_auth0_docs'), {}, false)).toBe('Discovery');
+    expect(classifyActionType(translator.mapName('auth0-docs-search_auth0_docs'), {}, false)).toBe('Discovery');
   });
 });
 


### PR DESCRIPTION
## Description

Fixes run_command action classification command-intent aware.

Previously, run_command steps were classified as Implementation based solely on the tool name. This caused CLI-first evals, such as Auth0 CLI evals, to incorrectly classify discovery, documentation reads, navigation, and mutations as the same action type.

This PR classifies run_command actions based on the intent of the command being executed.

Implementation

**`classify.ts`**

- Added classifyCommandIntent(command) for command-aware classification.
- Supports chained commands (&&, ||, ;, |) with precedence: TenantConfig → Implementation → Discovery.
- Added rules for common Auth0 API, shell, git, npm, and file commands.
- Auth0 API verbs are matched by position to avoid false positives from quoted paths.
- Unknown commands conservatively fall back to Implementation.

**`scorer.ts`**

- Added TenantConfig to ActionType.

**`report.css`**

- Added .action-tenantconfig styling.

**`Runners`**

- Updated 7 call sites across Claude Code, Codex, Copilot, and Gemini CLI to pass args to classifyActionType.

### Impact / Compatibility
Score-neutral: actionType is only used by JSON serializers and the report UI; no scoring dimensions or eval results are affected.
No breaking API changes.


### Testing

- evals-core — 617 passed, including new command-intent classification coverage.
- evals-reporter — 76 passed, including TenantConfig CSS mapping.
- npm run build — 6/6 packages passed.
- npm run lint — clean.
- npm test — 721 passed. The 2 docker.test.ts symlink failures are pre-existing and unrelated.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved command-line action classification for discovery, workspace changes, tenant configuration, and ambiguous commands.
  * Added a distinct **Tenant Configuration** action type to evaluation and reporting results.
  * Command analysis now recognizes chained commands, redirects, quoted arguments, wrappers, and read/write configuration operations.

* **Style**
  * Added dedicated visual styling for Tenant Configuration actions in reports.

* **Tests**
  * Expanded coverage for command intent classification and report filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->