### PR TITLE
feat(evals): Adds CLI evals for Organisation

### DIFF
--- a/apps/auth0-evals/README.md
+++ b/apps/auth0-evals/README.md
@@ -67,6 +67,7 @@ See [`@a0/evals` CLI docs](../../packages/evals/) for the full list of flags and
 | `express_api_mcd` | multi-tenant | Accept tokens from several Auth0 custom domains via `auth({ mcd: { issuers } })` |
 | `react_organizations` | organizations | Add Auth0 Organizations to a React SPA — org login, invitation acceptance, and org read-back from the `org_id` claim |
 | `spa_js_organizations`    | organizations | Add Auth0 Organizations (org-scoped login, invitation acceptance, org_id read-back) to a vanilla JS SPA using `@auth0/auth0-spa-js` |
+| `organizations_cli` | organizations | Set up B2B organization login on a live tenant using the Auth0 CLI - create an org, enable a connection with auto-membership, and require org login on the SPA |
 
 ## Configuration
 

--- a/apps/auth0-evals/src/evals/organizations/cli/PROMPT.md
+++ b/apps/auth0-evals/src/evals/organizations/cli/PROMPT.md
@@ -1,0 +1,15 @@
+---
+id: organizations_cli
+name: Organizations Login (CLI)
+category: organizations
+skills: auth0
+provision: auth0-tenant
+---
+
+## Task
+
+Our Auth0 tenant needs organization-based login configured using the Auth0 CLI. Set up a B2B organization called "Acme Corp" and enable organization login for the tenant's Single Page Application.
+
+- Create an organization with the name `acme-corp` and display name "Acme Corp".
+- Enable the tenant's default database connection ("Username-Password-Authentication") for the Acme Corp organization and configure the connection to automatically assign membership when users login with it.
+- Configure tenant to require organization login and users should be asked which organization they below to up front, before entering credentials.

--- a/apps/auth0-evals/src/evals/organizations/cli/PROMPT.md
+++ b/apps/auth0-evals/src/evals/organizations/cli/PROMPT.md
@@ -9,8 +9,8 @@ setup_command: bash seed.sh
 
 ## Task
 
-Our Auth0 tenant needs organization-based login configured using the Auth0 CLI. Set up a B2B organization called "Acme Corp" and enable organization login for the tenant's Single Page Application.
+Our Auth0 tenant needs organization-based login configured using the Auth0 CLI.
 
-- Create an organization with the name `acme-corp` and display name "Acme Corp".
-- Enable the tenant's default database connection ("Username-Password-Authentication") for the Acme Corp organization and configure the connection to automatically assign membership when users login with it.
-- Configure tenant to require organization login and users should be asked which organization they belong to up front, before entering credentials.
+Setup a new B2B Organization with `acme-corp` as the identifier and "Acme Corp" as the display name. The team signs in with an email and password, so our standard database login needs to work for Acme, and anyone who signs in that way should be added to the Acme organization automatically rather than invited by hand.
+
+Our single-page app also shouldn't let anyone log in outside of an organization. Users should choose which organization they're signing in to up front, before they're asked for credentials.

--- a/apps/auth0-evals/src/evals/organizations/cli/PROMPT.md
+++ b/apps/auth0-evals/src/evals/organizations/cli/PROMPT.md
@@ -4,6 +4,7 @@ name: Organizations Login (CLI)
 category: organizations
 skills: auth0
 provision: auth0-tenant
+setup_command: bash seed.sh
 ---
 
 ## Task
@@ -12,4 +13,4 @@ Our Auth0 tenant needs organization-based login configured using the Auth0 CLI. 
 
 - Create an organization with the name `acme-corp` and display name "Acme Corp".
 - Enable the tenant's default database connection ("Username-Password-Authentication") for the Acme Corp organization and configure the connection to automatically assign membership when users login with it.
-- Configure tenant to require organization login and users should be asked which organization they below to up front, before entering credentials.
+- Configure tenant to require organization login and users should be asked which organization they belong to up front, before entering credentials.

--- a/apps/auth0-evals/src/evals/organizations/cli/graders.ts
+++ b/apps/auth0-evals/src/evals/organizations/cli/graders.ts
@@ -1,4 +1,4 @@
-import { ranCommand, ranCommandsInOrder, notRanCommand, judge, GraderLevel } from '@a0/evals-graders';
+import { ranCommand, ranCommandOneOf, ranCommandsInOrder, notRanCommand, judge, GraderLevel } from '@a0/evals-graders';
 
 // A goal-only CLI eval run against a live, throwaway tenant the `auth0` CLI is
 // already logged into. The agent writes nothing to disk - grading leans entirely
@@ -16,10 +16,13 @@ export function defineGraders() {
     ),
 
     // ── L4: Organization created ──────────────────────────────────────────
-    ranCommand(
-      'organizations',
-      ['acme-corp'],
-      'Created the acme-corp organization',
+    // Accept either CLI form: the `auth0 orgs create` subcommand or the
+    // `auth0 api post organizations` passthrough. Key the subcommand form on
+    // `orgs create --name`/`-n` (an actual create), not bare `orgs create` —
+    // that would also match an `orgs create --help` probe, which creates nothing.
+    ranCommandOneOf(
+      ['orgs create --name', 'orgs create -n', 'api post organizations'],
+      'Created an organization via `auth0 orgs create` or `auth0 api post organizations`',
       GraderLevel.L4,
     ),
 

--- a/apps/auth0-evals/src/evals/organizations/cli/graders.ts
+++ b/apps/auth0-evals/src/evals/organizations/cli/graders.ts
@@ -1,0 +1,78 @@
+import { ranCommand, ranCommandsInOrder, notRanCommand, judge, GraderLevel } from '@a0/evals-graders';
+
+// A goal-only CLI eval run against a live, throwaway tenant the `auth0` CLI is
+// already logged into. The agent writes nothing to disk - grading leans entirely
+// on event graders (command trace) plus a trace-aware judge.
+// Tests org creation, enabling a database connection for the org with
+// auto-membership, and configuring the SPA to require org login.
+export function defineGraders() {
+  return [
+    // ── L2: Hallucination - agent must NOT configure SAML ─────────────────
+    // for a basic org setup that uses a database connection
+    notRanCommand(
+      'saml',
+      'Did not configure SAML connections for a basic username/password org setup',
+      GraderLevel.L2,
+    ),
+
+    // ── L4: Organization created ──────────────────────────────────────────
+    ranCommand(
+      'organizations',
+      ['acme-corp'],
+      'Created the acme-corp organization',
+      GraderLevel.L4,
+    ),
+
+    // ── L4: Connection enabled for organization with auto-membership ───────
+    // Pin the value to `true` - the task requires auto-assignment, and matching
+    // the bare key would also pass for `assign_membership_on_login: false`.
+    ranCommand(
+      'enabled_connections',
+      ['assign_membership_on_login', 'true'],
+      'Enabled connection with auto-membership (true) for the organization',
+      GraderLevel.L4,
+    ),
+
+    // ── L4: Application configured to require organization login ──────────
+    // Quote the value: the bare substring `require` also appears inside
+    // `organization_require_behavior`, so it would pass even when
+    // organization_usage is `allow`/`deny`. `"require"` only matches the value.
+    ranCommand(
+      'clients',
+      ['organization_usage', '"require"'],
+      'Configured application with organization_usage set to require',
+      GraderLevel.L4,
+    ),
+
+    // ── L4: The acme-corp organization created before connections enabled ──
+    // Key step 1 on `acme-corp` rather than `organizations`: the enable call's
+    // own URL (organizations/{id}/enabled_connections) contains both needles in
+    // order, so keying on `organizations` would pass without a real create step.
+    ranCommandsInOrder(
+      ['acme-corp', 'enabled_connections'],
+      'acme-corp organization created before enabling its connections',
+      GraderLevel.L4,
+    ),
+
+    // ── L5: Correct pre-login prompt behavior set ─────────────────────────
+    ranCommand(
+      'clients',
+      ['organization_require_behavior', 'pre_login_prompt'],
+      'Set organization_require_behavior to pre_login_prompt',
+      GraderLevel.L5,
+    ),
+
+    // ── Holistic judge (no level - always runs) ───────────────────────────
+    judge(
+      'Based on the command trace, does the solution: ' +
+        '(1) create an organization with name "acme-corp" and display name "Acme Corp"; ' +
+        '(2) enable the "Username-Password-Authentication" connection for that organization ' +
+        'with assign_membership_on_login set to true; ' +
+        '(3) configure the Single Page Application with organization_usage set to "require" and ' +
+        'organization_require_behavior set to "pre_login_prompt" - ' +
+        'using only the Auth0 CLI, not the dashboard or Terraform?',
+      undefined,
+      { includeCommandTrace: true },
+    ),
+  ];
+}

--- a/apps/auth0-evals/src/evals/organizations/cli/scaffold/seed.sh
+++ b/apps/auth0-evals/src/evals/organizations/cli/scaffold/seed.sh
@@ -22,19 +22,25 @@ log "start: seeding tenant prerequisites"
 if auth0 api get "connections?name=Username-Password-Authentication" | jq -e '.[0]' >/dev/null 2>&1; then
   log "connection 'Username-Password-Authentication' already present — skipping"
 else
-  auth0 api post connections \
-    --data '{"name":"Username-Password-Authentication","strategy":"auth0"}' >/dev/null
+  if ! auth0 api post connections \
+    --data '{"name":"Username-Password-Authentication","strategy":"auth0"}' >/dev/null; then
+    log "error: failed to create connection 'Username-Password-Authentication'"
+    exit 1
+  fi
   log "created connection 'Username-Password-Authentication'"
 fi
 
 # A Single Page Application for the agent to configure org login on.
-if auth0 apps list | jq -e '.[] | select(.app_type=="spa")' >/dev/null 2>&1; then
+if auth0 apps list --json | jq -e '.[] | select(.app_type=="spa")' >/dev/null 2>&1; then
   log "a Single Page Application already exists — skipping"
 else
-  auth0 apps create --name "Acme SPA" --type spa --auth-method None \
+  if ! auth0 apps create --name "Acme SPA" --type spa --auth-method None \
     --callbacks "http://localhost:3000" \
     --logout-urls "http://localhost:3000" \
-    --origins "http://localhost:3000" >/dev/null
+    --origins "http://localhost:3000" >/dev/null; then
+    log "error: failed to create Single Page Application 'Acme SPA'"
+    exit 1
+  fi
   log "created Single Page Application 'Acme SPA'"
 fi
 

--- a/apps/auth0-evals/src/evals/organizations/cli/scaffold/seed.sh
+++ b/apps/auth0-evals/src/evals/organizations/cli/scaffold/seed.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Seeds the throwaway tenant with the prerequisites this task assumes already
+# exist: a Single Page Application to configure, and the default database
+# connection to enable for the organization.
+#
+# Runs before the agent, in the same container the `auth0` CLI is authenticated
+# into (see docs/ADDING_EVALS.md — "Seeding prerequisites for CLI evals").
+#
+# Must be idempotent: never assume a pristine tenant, and never abort the run on
+# an "already exists" — hence `set -uo pipefail` (not `-e`) and check-or-create.
+set -uo pipefail
+
+# Progress goes to stderr, which the framework inherits into the run / CI job
+# log (spawnSync stdio: 'inherit'). These lines survive the self-delete below,
+# so the log is how you confirm later that the seed ran and what it did.
+log() { echo "[seed] $*" >&2; }
+
+log "start: seeding tenant prerequisites"
+
+# Default database connection (normally auto-created with a tenant, but seed
+# defensively — some provisioned tenants come up bare).
+if auth0 api get "connections?name=Username-Password-Authentication" | jq -e '.[0]' >/dev/null 2>&1; then
+  log "connection 'Username-Password-Authentication' already present — skipping"
+else
+  auth0 api post connections \
+    --data '{"name":"Username-Password-Authentication","strategy":"auth0"}' >/dev/null
+  log "created connection 'Username-Password-Authentication'"
+fi
+
+# A Single Page Application for the agent to configure org login on.
+if auth0 apps list | jq -e '.[] | select(.app_type=="spa")' >/dev/null 2>&1; then
+  log "a Single Page Application already exists — skipping"
+else
+  auth0 apps create --name "Acme SPA" --type spa --auth-method None \
+    --callbacks "http://localhost:3000" \
+    --logout-urls "http://localhost:3000" \
+    --origins "http://localhost:3000" >/dev/null
+  log "created Single Page Application 'Acme SPA'"
+fi
+
+log "done: prerequisites ready"
+
+# Remove self so the agent never sees this script (keeps it out of the agent's
+# view and out of the grading corpus). The [seed] log lines above are already
+# emitted, so this does not cost us the trace.
+rm -f -- "$0"
+exit 0


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.


### Description

Adds a new eval **`organizations_cli`** (Organizations Login (CLI)), that measures how accurately an agent can configure B2B organization login on a live Auth0 tenant using only the `auth0` CLI. No code is written to disk; grading relies entirely on the command trace.

Also adds a **`scaffold/seed.sh`**, idempotent setup script that provisions prerequisites before the agent runs. Ensures `Username-Password-Authentication` connection exists, and creates a Single Page Application (`Acme SPA`) if none exists. Self-deletes after running so the agent never sees it and it stays out of the grading corpus.


### References


### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Organizations Login evaluation for the Auth0 CLI.
  * The evaluation covers creating an organization, enabling automatic membership on login, and requiring organization selection before authentication.
  * Added setup support for standard database login and a sample single-page application.
  * Added validation for required configuration, command ordering, and prevention of unrelated SAML setup.
* **Bug Fixes**
  * Improved setup reliability by reporting connection or application creation failures and using machine-readable application data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->