### PR TITLE
fix(evals): align spa-js MFA grader to interactiveErrorHandler step-up pattern

### DIFF
--- a/apps/auth0-evals/src/evals/mfa/spa-js/PROMPT.md
+++ b/apps/auth0-evals/src/evals/mfa/spa-js/PROMPT.md
@@ -9,7 +9,7 @@ compile_command: npm run build
 
 ## Task
 
-My vanilla JavaScript SPA has Auth0 login set up. I want to add a Transfer Funds feature where users must complete MFA before the transfer runs. If they haven't done MFA yet, prompt them for it.
+My vanilla JavaScript SPA has Auth0 login set up. I want to add a Transfer Funds feature that requires step-up authentication before the transfer runs. If the user's current session doesn't satisfy the MFA requirement, trigger step-up to prompt them for it.
 
 Domain: dev-barkbook.us.auth0.com
 Client ID: barkbook_client_abc123xyz

--- a/apps/auth0-evals/src/evals/mfa/spa-js/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/spa-js/graders.ts
@@ -1,22 +1,15 @@
-import { notContainsInSource, matches, judge, compiles, GraderLevel } from '@a0/evals-graders';
+import { contains, notContainsInSource, matches, judge, compiles, GraderLevel } from '@a0/evals-graders';
 
 export function defineGraders() {
   return [
     // ── L1: Required step-up symbols present ───────────────────────────
-    // Reactive approach: MfaRequiredError caught and mfa_token passed to loginWithPopup.
-    // Proactive approach: acr_values or interactiveErrorHandler trigger step-up upfront.
     matches(
-      String.raw`MfaRequiredError|acr_values|interactiveErrorHandler`,
-      'Step-up triggered via MfaRequiredError (reactive) or acr_values / interactiveErrorHandler (proactive)',
+      String.raw`interactiveErrorHandler|acr_values`,
+      'Step-up configured via interactiveErrorHandler (SDK default) or acr_values (manual approach)',
       GraderLevel.L1,
     ),
-    // Reactive: mfa_token forwarded to loginWithPopup.
-    // Proactive: AMR claim read from ID token to verify MFA completed.
-    matches(
-      String.raw`mfa_token|\.\s*amr\b|\bamr\s*[,}=)]|\[\s*['"]amr['"]\s*\]`,
-      'mfa_token used with loginWithPopup (reactive) or AMR claim verified after step-up (proactive)',
-      GraderLevel.L1,
-    ),
+    contains('useRefreshTokens', 'Refresh token flow enabled (required for automatic step-up)', GraderLevel.L1),
+    contains('getTokenSilently', 'Access token requested via getTokenSilently to trigger step-up', GraderLevel.L1),
 
     // ── L2: Hallucination / wrong approach ────────────────────────────────
     // In-source rather than whole-workspace: agents write design notes, and a note
@@ -43,37 +36,38 @@ export function defineGraders() {
     // ── L4: Structural correctness ────────────────────────────────────────
     compiles('Project compiles (build succeeds)', GraderLevel.L4),
     judge(
-      'Does the code gate the transfer action behind MFA completion — either by catching ' +
-        'MfaRequiredError and calling loginWithPopup with the mfa_token before proceeding ' +
-        '(reactive), or by checking the amr claim upfront and requesting step-up when "mfa" ' +
-        'is absent (proactive)?',
+      'Does the code call getTokenSilently (not loginWithPopup) before executing the transfer ' +
+        'action, so that the SDK can automatically trigger an MFA step-up popup (via interactiveErrorHandler) ' +
+        'when the API signals mfa_required?',
       GraderLevel.L4,
     ),
     judge(
-      'After triggering step-up, does the code confirm MFA actually completed before running ' +
-        'the transfer — for the reactive approach, verifying loginWithPopup resolved without ' +
-        'error; for the proactive approach, re-reading the token claims to check amr again? ' +
-        'Proceeding unconditionally after triggering step-up does not satisfy this.',
+      'Does the code handle popup failure errors (PopupCancelledError, PopupTimeoutError) or otherwise ' +
+        'prevent the transfer from proceeding when MFA step-up was not completed?',
       GraderLevel.L4,
     ),
 
     // ── L5: Current API patterns ──────────────────────────────────────────
     judge(
+      'Is interactiveErrorHandler set to "popup" in the createAuth0Client configuration, alongside ' +
+        'useRefreshTokens: true? (If using the manual acr_values approach instead, are acr_values ' +
+        'and max_age: 0 passed inside authorizationParams on loginWithPopup?)',
+      GraderLevel.L5,
+    ),
+    judge(
       'If the code uses the proactive approach (acr_values), is the value the multi-factor ' +
         'policy URI http://schemas.openid.net/pape/policies/2007/06/multi-factor rather than an ' +
-        'invented or misspelled value? (Not applicable when using the reactive MfaRequiredError approach.)',
+        'invented or misspelled value? (Not applicable when using interactiveErrorHandler.)',
       GraderLevel.L5,
     ),
     judge(
       'If the code passes acr_values or max_age, are they inside an authorizationParams object ' +
-        'rather than as top-level properties? ' +
-        '(Not applicable when using the reactive MfaRequiredError approach.)',
+        'rather than as top-level properties? (Not applicable when using interactiveErrorHandler.)',
       GraderLevel.L5,
     ),
     judge(
       'Does the solution force a fresh MFA challenge — via max_age: 0 inside authorizationParams ' +
-        "or cacheMode: 'off' on the silent token request (proactive), or by passing the mfa_token " +
-        'directly to loginWithPopup (reactive)?',
+        "or cacheMode: 'off' on the getTokenSilently call?",
       GraderLevel.L5,
     ),
     judge(
@@ -87,10 +81,10 @@ export function defineGraders() {
     // ── Holistic judge (no level — always runs) ───────────────────────────
     judge(
       'Does the solution correctly implement MFA step-up authentication in a vanilla JavaScript SPA ' +
-        'using @auth0/auth0-spa-js — either reactively (catching MfaRequiredError from getTokenSilently ' +
-        'and calling loginWithPopup with the mfa_token) or proactively (requesting step-up via ' +
-        'acr_values in authorizationParams and verifying the amr claim) — and gating the Transfer ' +
-        'Funds action behind confirmed MFA completion?',
+        'using @auth0/auth0-spa-js — either by configuring interactiveErrorHandler: "popup" with ' +
+        'useRefreshTokens: true so that getTokenSilently automatically triggers an MFA popup ' +
+        'when the API requires it, or by explicitly requesting step-up via acr_values — and gating ' +
+        'the Transfer Funds action behind successful MFA completion?',
     ),
   ];
 }

--- a/apps/auth0-evals/src/evals/mfa/spa-js/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/spa-js/graders.ts
@@ -66,11 +66,6 @@ export function defineGraders() {
       GraderLevel.L5,
     ),
     judge(
-      'Does the solution force a fresh MFA challenge — via max_age: 0 inside authorizationParams ' +
-        "or cacheMode: 'off' on the getTokenSilently call?",
-      GraderLevel.L5,
-    ),
-    judge(
       'Does the solution use the auth0-spa-js v2 API — authorizationParams for auth parameters, ' +
         'camelCase clientId, and argument-less getIdTokenClaims() — rather than the v1 patterns ' +
         'of top-level audience/scope/redirect_uri, snake_case client_id, or ' +


### PR DESCRIPTION
## Summary

- Rewrites `spa-js` MFA grader to match the current `@auth0/auth0-spa-js` step-up auth pattern (`interactiveErrorHandler: "popup"` + `useRefreshTokens: true` + `getTokenSilently`) — aligning it with the already-updated `angular` and `vue` graders
- Drops the legacy `MfaRequiredError` + `loginWithPopup` + `mfa_token` reactive path throughout (L1, L4, L5, holistic) — this is a backend MFA API pattern not applicable to SPAs
- Adds missing L5 judge for `interactiveErrorHandler: "popup"` + `useRefreshTokens: true` in `createAuth0Client`
- Updates PROMPT.md task description to use "step-up authentication" terminology so the Auth0 skill's intent detection routes to `feature:mfa` correctly

## What changed and why

The step-up auth doc for `@auth0/auth0-spa-js` describes one primary pattern: configure `interactiveErrorHandler: 'popup'` in `createAuth0Client`, then call `getTokenSilently()` — the SDK automatically opens a popup when MFA is required. `MfaRequiredError` is only thrown when `interactiveErrorHandler` is **not** configured (and in that case the docs point to the MFA API, a server-side flow). The old grader accepted the legacy pattern at every level, meaning agents using stale training knowledge would still pass L5.

## Test plan

- [ ] `npm run build` passes (axis package failure is pre-existing, unrelated)
- [ ] `npm test` — evals-graders primitives suite passes
- [ ] `npm run lint` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that transferring funds requires step-up authentication when the current session does not meet MFA requirements.
  * Updated evaluation guidance to favor automatic MFA prompts through the SDK’s interactive handling or explicit step-up configuration.
  * Refined validation criteria for refresh-token usage, silent token retrieval, popup failure handling, and successful MFA completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->