### PR TITLE
feat(evals): add Organizations evals for Auth0.Android and Auth0.swift

### DIFF
--- a/apps/auth0-evals/src/evals/organizations/android/PROMPT.md
+++ b/apps/auth0-evals/src/evals/organizations/android/PROMPT.md
@@ -1,0 +1,14 @@
+---
+id: android_organizations
+name: Android Organizations Login
+scaffold: src/evals/scaffolds/android/auth0
+skills: auth0
+---
+
+## Task
+
+My Android app already has Auth0 login working through Universal Login. Add Auth0 Organizations support: log users in to our "Acme" org (`org_barkbook_acme`), accept organization invitation links, and show which organization the signed-in user belongs to.
+
+Domain: dev-barkbook.us.auth0.com
+Client ID: barkbook_client_abc123xyz
+Audience: https://api.barkbook.com

--- a/apps/auth0-evals/src/evals/organizations/android/graders.ts
+++ b/apps/auth0-evals/src/evals/organizations/android/graders.ts
@@ -1,0 +1,77 @@
+import { contains, notContains, notContainsInSource, judge, GraderLevel } from '@a0/evals-graders';
+
+export function defineGraders() {
+  return [
+    // ── L1: Required Organizations symbols present ─────────────────────────
+    contains('organization', 'Passes the organization parameter for org-scoped login', GraderLevel.L1),
+    contains('org_barkbook_acme', 'Wires the specific Acme org (org_barkbook_acme)', GraderLevel.L1),
+    contains('invitation', 'Handles the organization invitation parameter', GraderLevel.L1),
+    contains('org_id', 'Reads the org_id claim to identify the logged-in organization', GraderLevel.L1),
+    contains('withOrganization', 'Uses WebAuthProvider.withOrganization for org-scoped login', GraderLevel.L1),
+    contains('withInvitationUrl', 'Uses WebAuthProvider.withInvitationUrl to accept invitation links', GraderLevel.L1),
+
+    // ── L2: Hallucination / wrong approach ─────────────────────────────────
+    notContains('@auth0/organizations', 'No hallucinated @auth0/organizations package', GraderLevel.L2),
+    notContains('auth0-java', 'No auth0-java (server-side SDK, not for Android)', GraderLevel.L2),
+    // Auth0.Android has no dedicated org accessor on Credentials; a useOrganization
+    // hook belongs to the React SDK, not the Android builder API.
+    notContains('useOrganization(', 'No non-existent useOrganization hook (not an Android API)', GraderLevel.L2),
+    notContains('client_secret', 'No client_secret in a public mobile client', GraderLevel.L2),
+
+    // ── L3: Security ───────────────────────────────────────────────────────
+    notContainsInSource(
+      'barkbook_client_abc123xyz',
+      'No hardcoded client ID in Kotlin source files (ok in strings.xml)',
+      GraderLevel.L3,
+    ),
+    notContainsInSource(
+      'dev-barkbook.us.auth0.com',
+      'No hardcoded domain in Kotlin source files (ok in strings.xml)',
+      GraderLevel.L3,
+    ),
+    judge(
+      'Does the code let SecureCredentialsManager (or CredentialsManager) handle token storage rather than ' +
+        'persisting Auth0 tokens (access tokens, ID tokens, refresh tokens) by hand in plain SharedPreferences? ' +
+        'Storing application state such as a pending organization is acceptable — only manual token storage is a violation.',
+      GraderLevel.L3,
+    ),
+
+    // ── L4: Structural correctness ─────────────────────────────────────────
+    judge(
+      'Is org-scoped login performed by chaining .withOrganization("org_barkbook_acme") onto ' +
+        'WebAuthProvider.login(account) and starting it, rather than by hand-appending an "organization" ' +
+        'query parameter to a URL?',
+      GraderLevel.L4,
+    ),
+    judge(
+      'Does the code accept an organization invitation by passing the inbound invitation URL to ' +
+        'WebAuthProvider.login(account).withInvitationUrl(...)? To pass, the invitation URL is forwarded as-is ' +
+        '(the SDK extracts its organization and invitation parameters), and the code must NOT reject or block a ' +
+        "valid invitation solely because its organization differs from the app's configured default org.",
+      GraderLevel.L4,
+    ),
+    judge(
+      'Does the code surface the organization the user logged into by reading the org_id claim from the ID token ' +
+        '(decoding credentials.idToken via the com.auth0.android:jwtdecode library, or reading it from ' +
+        'credentials.user.getExtraInfo()), rather than hardcoding or guessing it?',
+      GraderLevel.L4,
+    ),
+
+    // ── L5: Current API patterns ───────────────────────────────────────────
+    judge(
+      'Is the request built with the current builder API — WebAuthProvider.login(account) with ' +
+        '.withOrganization / .withInvitationUrl — rather than by hand-building an /authorize URL or using the ' +
+        'removed WebAuthProvider.init entry point?',
+      GraderLevel.L5,
+    ),
+
+    // ── Holistic judge (no level — always runs) ────────────────────────────
+    judge(
+      'Does the solution correctly add Auth0 Organizations support to the Android app using Auth0.Android — ' +
+        'logging users into org_barkbook_acme via WebAuthProvider.withOrganization, accepting organization ' +
+        'invitation links via withInvitationUrl, and identifying the logged-in organization from the org_id claim ' +
+        'in the ID token? Rejecting or blocking a valid invitation because its organization differs from the ' +
+        'configured default org is a correctness defect, not a cosmetic one — treat it as a failure of invitation acceptance.',
+    ),
+  ];
+}

--- a/apps/auth0-evals/src/evals/organizations/swift/PROMPT.md
+++ b/apps/auth0-evals/src/evals/organizations/swift/PROMPT.md
@@ -1,0 +1,14 @@
+---
+id: swift_organizations
+name: Swift Organizations Login
+scaffold: src/evals/scaffolds/swift/auth0
+skills: auth0
+---
+
+## Task
+
+My iOS app already has Auth0 login working through Universal Login. Add Auth0 Organizations support: log users in to our "Acme" org (`org_barkbook_acme`), accept organization invitation links, and show which organization the signed-in user belongs to.
+
+Domain: dev-barkbook.us.auth0.com
+Client ID: barkbook_client_abc123xyz
+Audience: https://api.barkbook.com

--- a/apps/auth0-evals/src/evals/organizations/swift/graders.ts
+++ b/apps/auth0-evals/src/evals/organizations/swift/graders.ts
@@ -1,0 +1,73 @@
+import { contains, notContains, notContainsInSource, judge, GraderLevel } from '@a0/evals-graders';
+
+export function defineGraders() {
+  return [
+    // ── L1: Required Organizations symbols present ─────────────────────────
+    contains('organization', 'Passes the organization parameter for org-scoped login', GraderLevel.L1),
+    contains('org_barkbook_acme', 'Wires the specific Acme org (org_barkbook_acme)', GraderLevel.L1),
+    contains('invitation', 'Handles the organization invitation parameter', GraderLevel.L1),
+    contains('org_id', 'Reads the org_id claim to identify the logged-in organization', GraderLevel.L1),
+    contains('.organization(', 'Uses WebAuth .organization for org-scoped login', GraderLevel.L1),
+    contains('.invitationURL(', 'Uses WebAuth .invitationURL to accept invitation links', GraderLevel.L1),
+
+    // ── L2: Hallucination / wrong approach ─────────────────────────────────
+    notContains('@auth0/organizations', 'No hallucinated @auth0/organizations package', GraderLevel.L2),
+    notContains('Auth0SDK', 'No hallucinated Auth0SDK package name (correct module is Auth0)', GraderLevel.L2),
+    notContains('client_secret', 'No client_secret in a public mobile client', GraderLevel.L2),
+
+    // ── L3: Security ───────────────────────────────────────────────────────
+    notContainsInSource(
+      'barkbook_client_abc123xyz',
+      'No hardcoded client ID in Swift source files (ok in Auth0.plist)',
+      GraderLevel.L3,
+    ),
+    notContainsInSource(
+      'dev-barkbook.us.auth0.com',
+      'No hardcoded domain in Swift source files (ok in Auth0.plist)',
+      GraderLevel.L3,
+    ),
+    judge(
+      'Does the code let CredentialsManager handle token storage rather than persisting Auth0 tokens ' +
+        '(access tokens, ID tokens, refresh tokens) by hand in UserDefaults or the Keychain? Storing ' +
+        'application state such as a pending organization is acceptable — only manual token storage is a violation.',
+      GraderLevel.L3,
+    ),
+
+    // ── L4: Structural correctness ─────────────────────────────────────────
+    judge(
+      'Is org-scoped login performed by chaining .organization("org_barkbook_acme") onto Auth0.webAuth() ' +
+        'and starting it, rather than by hand-appending an "organization" query parameter to a URL?',
+      GraderLevel.L4,
+    ),
+    judge(
+      'Does the code accept an organization invitation by passing the inbound invitation URL to ' +
+        'Auth0.webAuth().invitationURL(...)? To pass, the invitation URL is forwarded as-is (the SDK extracts ' +
+        'its organization and invitation parameters), and the code must NOT reject or block a valid invitation ' +
+        "solely because its organization differs from the app's configured default org.",
+      GraderLevel.L4,
+    ),
+    judge(
+      'Does the code surface the organization the user logged into by reading the org_id claim from the ID token ' +
+        '(decoding credentials.idToken with JWTDecode, e.g. decode(jwt:).claim(name: "org_id"), or via ' +
+        'UserProfile customClaims), rather than hardcoding or guessing it?',
+      GraderLevel.L4,
+    ),
+
+    // ── L5: Current API patterns ───────────────────────────────────────────
+    judge(
+      'Is org login built with the current Web Auth builder — Auth0.webAuth() with .organization / ' +
+        '.invitationURL — rather than by hand-building an /authorize URL, or by using the Authentication API ' +
+        'token methods (login/codeExchange with organization) that are not the Universal Login path this task needs?',
+      GraderLevel.L5,
+    ),
+
+    // ── Holistic judge (no level — always runs) ────────────────────────────
+    judge(
+      'Does the solution correctly add Auth0 Organizations support to the iOS app using Auth0.swift — logging ' +
+        'users into org_barkbook_acme via Auth0.webAuth().organization, accepting organization invitation links ' +
+        'via .invitationURL, and identifying the logged-in organization from the org_id claim in the ID token? ' +
+        'Rejecting or blocking a valid invitation because its organization differs from the configured default ' +
+        'org is a correctness defect, not a cosmetic one — treat it as a failure of invitation acceptance.',
+    ),
+  ];
+}


### PR DESCRIPTION
Extends Organizations coverage to the two mobile SDKs. Both evals test the same three-part feature: org-scoped login, invitation link acceptance, and reading the org_id claim from the ID token.

Graders are sourced from the Auth0.Android and Auth0.swift repos directly (WebAuthProvider.withOrganization / Auth0.webAuth().organization, and the respective invitation builders). Mobile evals follow the mfa/android and mfa/swift pattern — no compile_command, notContainsInSource for config secrets, structural coverage via judge graders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Android and Swift evaluation scenarios for Auth0 Organizations login.
  - Scenarios cover organization-scoped authentication, accepting organization invitations, and displaying the signed-in user’s organization.
  - Added automated checks for required Organizations integrations, secure credential handling, valid invitation flows, organization claims, and current SDK usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->