### PR TITLE
fix(evals): align react MFA grader to interactiveErrorHandler step-up pattern

### DIFF
--- a/apps/auth0-evals/src/evals/mfa/angular/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/angular/graders.ts
@@ -44,8 +44,8 @@ export function defineGraders() {
 
     // ── L5: Current API patterns ──────────────────────────────────────────
     judge(
-      'Is interactiveErrorHandler set to "popup" in the provideAuth0 configuration, alongside ' +
-        'useRefreshTokens: true? (If using the manual acr_values approach instead, are acr_values ' +
+      'Is interactiveErrorHandler set to "popup" in the provideAuth0 configuration? ' +
+        '(If using the manual acr_values approach instead, are acr_values ' +
         'and max_age: 0 passed inside authorizationParams on loginWithRedirect?)',
       GraderLevel.L5,
     ),
@@ -53,8 +53,8 @@ export function defineGraders() {
     // ── Holistic judge (no level — always runs) ───────────────────────────
     judge(
       'Does the solution correctly implement MFA step-up authentication in an Angular app using ' +
-        '@auth0/auth0-angular — either by configuring interactiveErrorHandler: "popup" with ' +
-        'useRefreshTokens: true so that getAccessTokenSilently automatically triggers an MFA popup ' +
+        '@auth0/auth0-angular — either by configuring interactiveErrorHandler: "popup" ' +
+        'so that getAccessTokenSilently automatically triggers an MFA popup ' +
         'when the API requires it, or by explicitly requesting step-up via acr_values — and gating ' +
         'the Transfer Funds action behind successful MFA completion?',
     ),

--- a/apps/auth0-evals/src/evals/mfa/angular/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/angular/graders.ts
@@ -8,8 +8,11 @@ export function defineGraders() {
       'Step-up configured via interactiveErrorHandler (SDK default) or acr_values (manual approach)',
       GraderLevel.L1,
     ),
-    contains('useRefreshTokens', 'Refresh token flow enabled (required for automatic step-up)', GraderLevel.L1),
-    contains('getAccessTokenSilently', 'Access token requested via getAccessTokenSilently to trigger step-up', GraderLevel.L1),
+    contains(
+      'getAccessTokenSilently',
+      'Access token requested via getAccessTokenSilently to trigger step-up',
+      GraderLevel.L1,
+    ),
 
     // ── L2: Hallucination / wrong approach ────────────────────────────────
     notContains('speakeasy', 'No server-side TOTP library (speakeasy) used in client', GraderLevel.L2),

--- a/apps/auth0-evals/src/evals/mfa/react/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/react/graders.ts
@@ -1,14 +1,16 @@
-import { contains, notContains, judge, compiles, GraderLevel } from '@a0/evals-graders';
+import { contains, notContains, matches, judge, compiles, GraderLevel } from '@a0/evals-graders';
 
 export function defineGraders() {
   return [
-    // ── L1: Required MFA step-up symbols present ───────────────────────────
-    contains('acr_values', 'Step-up request uses acr_values parameter', GraderLevel.L1),
-    contains('amr', 'AMR claim checked to detect prior MFA completion', GraderLevel.L1),
-    contains('getIdTokenClaims', 'ID token claims inspected via getIdTokenClaims', GraderLevel.L1),
+    // ── L1: Required step-up symbols present ───────────────────────────
+    matches(
+      String.raw`interactiveErrorHandler|acr_values`,
+      'Step-up configured via interactiveErrorHandler (SDK default) or acr_values (manual approach)',
+      GraderLevel.L1,
+    ),
     contains(
-      'schemas.openid.net/pape/policies/2007/06/multi-factor',
-      'Uses correct multi-factor acr_values policy URI',
+      'getAccessTokenSilently',
+      'Access token requested via getAccessTokenSilently to trigger step-up',
       GraderLevel.L1,
     ),
 
@@ -29,28 +31,34 @@ export function defineGraders() {
     // ── L4: Structural correctness ────────────────────────────────────────
     compiles('Project compiles (build succeeds)', GraderLevel.L4),
     judge(
-      'Does the code check the amr claim before executing the transfer action, and only ' +
-        'proceed when "mfa" is present in the amr array?',
+      'Does the code gate the Transfer Funds action behind MFA step-up so the transfer cannot run ' +
+        'without MFA — either by calling getAccessTokenSilently for the sensitive scope so the SDK ' +
+        'triggers an interactiveErrorHandler popup when the API signals mfa_required, or by checking ' +
+        'the amr claim and requesting step-up via acr_values when "mfa" is not present?',
       GraderLevel.L4,
     ),
 
     // ── L5: Current API patterns ──────────────────────────────────────────
     judge(
-      'Does the code pass acr_values inside an authorizationParams object rather than ' +
-        'as a top-level property on getAccessTokenSilently or loginWithRedirect?',
+      'If the code takes the manual acr_values approach, are acr_values and max_age: 0 passed inside ' +
+        'an authorizationParams object (rather than as top-level properties) on getAccessTokenSilently, ' +
+        'getAccessTokenWithPopup or loginWithRedirect? (Not applicable when relying on interactiveErrorHandler.)',
       GraderLevel.L5,
     ),
     judge(
-      'Does the code include max_age: 0 inside authorizationParams when requesting MFA ' +
-        'step-up, to force re-authentication rather than reusing a cached session?',
+      'If the code takes the manual acr_values approach, is the value the multi-factor policy URI ' +
+        'http://schemas.openid.net/pape/policies/2007/06/multi-factor rather than an invented or ' +
+        'misspelled value? (Not applicable when relying on interactiveErrorHandler.)',
       GraderLevel.L5,
     ),
 
     // ── Holistic judge (no level — always runs) ───────────────────────────
     judge(
-      'Does the solution correctly implement MFA step-up authentication in a React app — ' +
-        'checking the amr claim via getIdTokenClaims, requesting step-up via acr_values when ' +
-        'MFA is not present, and gating the Transfer Funds action behind MFA verification?',
+      'Does the solution correctly implement MFA step-up authentication in a React app using ' +
+        '@auth0/auth0-react — either by configuring interactiveErrorHandler: "popup" so that ' +
+        'getAccessTokenSilently automatically triggers an MFA popup when the API requires it, or by ' +
+        'explicitly requesting step-up via acr_values — and gating the Transfer Funds action behind ' +
+        'successful MFA completion?',
     ),
   ];
 }

--- a/apps/auth0-evals/src/evals/mfa/spa-js/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/spa-js/graders.ts
@@ -48,8 +48,8 @@ export function defineGraders() {
 
     // ── L5: Current API patterns ──────────────────────────────────────────
     judge(
-      'Is interactiveErrorHandler set to "popup" in the createAuth0Client configuration, alongside ' +
-        'useRefreshTokens: true? (If using the manual acr_values approach instead, are acr_values ' +
+      'Is interactiveErrorHandler set to "popup" in the createAuth0Client configuration? ' +
+        '(If using the manual acr_values approach instead, are acr_values ' +
         'and max_age: 0 passed inside authorizationParams on loginWithPopup?)',
       GraderLevel.L5,
     ),
@@ -75,8 +75,8 @@ export function defineGraders() {
     // ── Holistic judge (no level — always runs) ───────────────────────────
     judge(
       'Does the solution correctly implement MFA step-up authentication in a vanilla JavaScript SPA ' +
-        'using @auth0/auth0-spa-js — either by configuring interactiveErrorHandler: "popup" with ' +
-        'useRefreshTokens: true so that getTokenSilently automatically triggers an MFA popup ' +
+        'using @auth0/auth0-spa-js — either by configuring interactiveErrorHandler: "popup" ' +
+        'so that getTokenSilently automatically triggers an MFA popup ' +
         'when the API requires it, or by explicitly requesting step-up via acr_values — and gating ' +
         'the Transfer Funds action behind successful MFA completion?',
     ),

--- a/apps/auth0-evals/src/evals/mfa/spa-js/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/spa-js/graders.ts
@@ -8,7 +8,6 @@ export function defineGraders() {
       'Step-up configured via interactiveErrorHandler (SDK default) or acr_values (manual approach)',
       GraderLevel.L1,
     ),
-    contains('useRefreshTokens', 'Refresh token flow enabled (required for automatic step-up)', GraderLevel.L1),
     contains('getTokenSilently', 'Access token requested via getTokenSilently to trigger step-up', GraderLevel.L1),
 
     // ── L2: Hallucination / wrong approach ────────────────────────────────

--- a/apps/auth0-evals/src/evals/mfa/vue/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/vue/graders.ts
@@ -45,8 +45,8 @@ export function defineGraders() {
 
     // ── L5: Current API patterns ──────────────────────────────────────────
     judge(
-      'Is interactiveErrorHandler set to "popup" in the createAuth0 plugin configuration, alongside ' +
-        'useRefreshTokens: true? (If using the manual acr_values approach instead, are acr_values ' +
+      'Is interactiveErrorHandler set to "popup" in the createAuth0 plugin configuration? ' +
+        '(If using the manual acr_values approach instead, are acr_values ' +
         'and max_age: 0 passed inside authorizationParams on loginWithRedirect?)',
       GraderLevel.L5,
     ),
@@ -54,8 +54,8 @@ export function defineGraders() {
     // ── Holistic judge (no level — always runs) ───────────────────────────
     judge(
       'Does the solution correctly implement MFA step-up authentication in a Vue 3 app using ' +
-        '@auth0/auth0-vue — either by configuring interactiveErrorHandler: "popup" with ' +
-        'useRefreshTokens: true so that getAccessTokenSilently automatically triggers an MFA popup ' +
+        '@auth0/auth0-vue — either by configuring interactiveErrorHandler: "popup" ' +
+        'so that getAccessTokenSilently automatically triggers an MFA popup ' +
         'when the API requires it, or by explicitly requesting step-up via acr_values — and gating ' +
         'the Transfer Funds action behind successful MFA completion?',
     ),

--- a/apps/auth0-evals/src/evals/mfa/vue/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/vue/graders.ts
@@ -8,8 +8,11 @@ export function defineGraders() {
       'Step-up configured via interactiveErrorHandler (SDK default) or acr_values (manual approach)',
       GraderLevel.L1,
     ),
-    contains('useRefreshTokens', 'Refresh token flow enabled (required for automatic step-up)', GraderLevel.L1),
-    contains('getAccessTokenSilently', 'Access token requested via getAccessTokenSilently to trigger step-up', GraderLevel.L1),
+    contains(
+      'getAccessTokenSilently',
+      'Access token requested via getAccessTokenSilently to trigger step-up',
+      GraderLevel.L1,
+    ),
 
     // ── L2: Hallucination / wrong approach ────────────────────────────────
     notContains('speakeasy', 'No server-side TOTP library (speakeasy) used in client', GraderLevel.L2),


### PR DESCRIPTION
The react MFA grader was left behind when #265/#268 realigned the vue/angular/spa-js graders to the interactiveErrorHandler step-up pattern. It still asserted the older manual acr_values shape, so solutions that rely on the SDK default (interactiveErrorHandler: "popup" + getAccessTokenSilently) were graded as failures even when correct.

This brings react in line with its siblings: L1/L4/L5 now accept either mechanic — the interactiveErrorHandler popup or an explicit acr_values step-up — and the holistic judge is unchanged.

Also drops the `useRefreshTokens` L1 substring check from the spa-js/vue/angular graders. It's an implementation detail of one path, not a required protocol symbol, and asserting it at L1 failed otherwise-correct solutions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated MFA step-up evaluations for React applications to accept either SDK-managed interactive handling or explicit step-up authorization.
  * Broadened validation to recognize both supported implementation patterns and verify correct authorization parameters when applicable.
  * Relaxed Angular, SPA JavaScript, and Vue evaluations so refresh-token configuration is no longer required for MFA step-up detection.
  * Refined checks for token retrieval and MFA-gated actions while preserving existing validation messages and severity levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->