### PR TITLE
feat(evals): Adds Organizations evals on node-oauth2-jwt-bearer

### DIFF
--- a/apps/auth0-evals/src/evals/organizations/express-api/PROMPT.md
+++ b/apps/auth0-evals/src/evals/organizations/express-api/PROMPT.md
@@ -1,0 +1,21 @@
+---
+id: express_api_organizations
+name: Express API Organizations
+scaffold: src/evals/scaffolds/express-api/auth0
+skills: auth0
+setup_command: npm install
+compile_command: node --check server.js
+---
+
+## Task
+
+My Express API is already protected with `express-oauth2-jwt-bearer`. Add Auth0 Organizations support:
+
+1. Restrict `GET /api/org/members` to users in the "Acme" org (`org_barkbook_acme`)
+2. Add `GET /api/org/profile` that returns the organization the signed-in user belongs to (the `org_id` from their token)
+
+Domain: dev-barkbook.us.auth0.com
+Audience: https://api.barkbook.com
+
+There is a `.env.example` in the project — create the real `.env` from it with the values above.
+

--- a/apps/auth0-evals/src/evals/organizations/express-api/graders.ts
+++ b/apps/auth0-evals/src/evals/organizations/express-api/graders.ts
@@ -1,0 +1,103 @@
+import {
+  contains,
+  notContains,
+  notContainsInSource,
+  matches,
+  judge,
+  wroteFile,
+  compiles,
+  GraderLevel,
+} from '@a0/evals-graders';
+
+export function defineGraders() {
+  return [
+    // ── L1: Positive presence ──────────────────────────────────────────────────
+    contains('express-oauth2-jwt-bearer', 'Uses express-oauth2-jwt-bearer SDK', GraderLevel.L1),
+    contains('org_id', 'References the org_id claim from the JWT', GraderLevel.L1),
+    contains('org_barkbook_acme', 'Wires the specific Acme org (org_barkbook_acme)', GraderLevel.L1),
+
+    // ── L2: Hallucination / wrong approach ────────────────────────────────────
+    notContains('@auth0/organizations', 'No hallucinated @auth0/organizations package', GraderLevel.L2),
+    notContains(
+      'requiresOrg(',
+      'No invented requiresOrg() helper (does not exist in express-oauth2-jwt-bearer)',
+      GraderLevel.L2,
+    ),
+    notContains('requiresOrganization(', 'No invented requiresOrganization() helper', GraderLevel.L2),
+    // org_name is a real Auth0 claim (display name) but org_id is correct for programmatic enforcement.
+    // Check for quoted form only to avoid false positives from prose/comments.
+    notContains("'org_name'", "No 'org_name' as a claim argument — use org_id for org enforcement", GraderLevel.L2),
+    notContains('"org_name"', 'No "org_name" as a claim argument — use org_id for org enforcement', GraderLevel.L2),
+    notContains('express-openid-connect', 'No express-openid-connect (web app SDK, not for APIs)', GraderLevel.L2),
+    notContains('jsonwebtoken', 'No manual JWT decoding with jsonwebtoken (use SDK middleware)', GraderLevel.L2),
+
+    // ── L3: Security checks ────────────────────────────────────────────────────
+    notContainsInSource(
+      'dev-barkbook.us.auth0.com',
+      'No hardcoded issuer domain in source files (ok in .env)',
+      GraderLevel.L3,
+    ),
+    notContainsInSource('api.barkbook.com', 'No hardcoded audience in source files (ok in .env)', GraderLevel.L3),
+
+    // ── L4: Structural / behavioral correctness ───────────────────────────────
+    wroteFile('.env', 'Wrote Auth0 config to .env file', GraderLevel.L4, [
+      'dev-barkbook.us.auth0.com',
+      'api.barkbook.com',
+    ]),
+    compiles('Project compiles (node --check succeeds)', GraderLevel.L4),
+    matches(
+      String.raw`(claimEquals\s*\(\s*['"\`]org_id['"\`][\s\S]{0,100}org_barkbook_acme|claimCheck[\s\S]{0,200}org_barkbook_acme)`,
+      'Uses claimEquals("org_id", "org_barkbook_acme") or claimCheck with org_barkbook_acme to enforce org membership',
+      GraderLevel.L4,
+    ),
+    judge(
+      'Does GET /api/org/members correctly restrict access to users in org_barkbook_acme? ' +
+        'The route must apply both the auth() JWT validation middleware and a claimEquals (or claimCheck) ' +
+        'middleware that enforces org_id === "org_barkbook_acme". A missing or wrong org_id should yield a 4xx error.',
+      GraderLevel.L4,
+    ),
+    judge(
+      'Does GET /api/org/profile return the org_id from the verified token (e.g. req.auth.payload.org_id)? ' +
+        'The route must be protected by auth() and read org_id from the decoded token payload, not hardcode it.',
+      GraderLevel.L4,
+    ),
+
+    // ── L5: Version-specific API correctness ──────────────────────────────────
+    notContains(
+      'req.user',
+      'No req.user — express-oauth2-jwt-bearer exposes claims on req.auth.payload',
+      GraderLevel.L5,
+    ),
+    notContains(
+      'req.auth.payload.org_id ===',
+      'No manual org_id equality check — use claimEquals() or claimCheck() SDK helpers',
+      GraderLevel.L5,
+    ),
+    notContains(
+      'req.auth.payload.org_id !==',
+      'No manual org_id inequality check — use claimEquals() or claimCheck() SDK helpers',
+      GraderLevel.L5,
+    ),
+    judge(
+      'Does the solution use current express-oauth2-jwt-bearer patterns? ' +
+        'Specifically: does it apply auth() for JWT validation, use claimEquals() or claimCheck() for ' +
+        'org_id enforcement (not a manual req.auth.payload.org_id comparison inside the handler), ' +
+        'and access token data via req.auth.payload? ' +
+        'Judge only from the source code; the issuer and audience may be supplied via environment variables ' +
+        '(ISSUER_BASE_URL / AUDIENCE), so do not assume the contents of any .env file.',
+      GraderLevel.L5,
+    ),
+
+    // ── Holistic judge ────────────────────────────────────────────────────────
+    judge(
+      'Does the solution correctly add Auth0 Organizations support to the Express API using ' +
+        'express-oauth2-jwt-bearer? ' +
+        'GET /api/org/members must be protected by auth() and restricted to users whose org_id claim equals ' +
+        '"org_barkbook_acme" using the SDK middleware (claimEquals or claimCheck) — a missing or mismatched ' +
+        'org_id must yield a 4xx response. ' +
+        "GET /api/org/profile must return the caller's org_id read from req.auth.payload. " +
+        'The issuer and audience may come from ISSUER_BASE_URL / AUDIENCE environment variables — ' +
+        'judge only from the source code and do not assume the contents of any .env file.',
+    ),
+  ];
+}

--- a/apps/auth0-evals/src/evals/organizations/express-api/graders.ts
+++ b/apps/auth0-evals/src/evals/organizations/express-api/graders.ts
@@ -45,9 +45,11 @@ export function defineGraders() {
       'api.barkbook.com',
     ]),
     compiles('Project compiles (node --check succeeds)', GraderLevel.L4),
+    // The org value may be a literal or read from an env var (ACME_ORG_ID) — good practice.
+    // Assert the SDK helper targets the org_id claim; L1 confirms org_barkbook_acme is present somewhere.
     matches(
-      String.raw`(claimEquals\s*\(\s*['"\`]org_id['"\`][\s\S]{0,100}org_barkbook_acme|claimCheck[\s\S]{0,200}org_barkbook_acme)`,
-      'Uses claimEquals("org_id", "org_barkbook_acme") or claimCheck with org_barkbook_acme to enforce org membership',
+      String.raw`(claimEquals\s*\(\s*['"\`]org_id['"\`]|claimCheck)`,
+      'Uses claimEquals("org_id", ...) or claimCheck to enforce org membership',
       GraderLevel.L4,
     ),
     judge(
@@ -92,12 +94,15 @@ export function defineGraders() {
     judge(
       'Does the solution correctly add Auth0 Organizations support to the Express API using ' +
         'express-oauth2-jwt-bearer? ' +
-        'GET /api/org/members must be protected by auth() and restricted to users whose org_id claim equals ' +
-        '"org_barkbook_acme" using the SDK middleware (claimEquals or claimCheck) — a missing or mismatched ' +
-        'org_id must yield a 4xx response. ' +
+        'GET /api/org/members must be protected by auth() and restricted to the Acme organization ' +
+        'using the SDK middleware (claimEquals or claimCheck) — a missing or mismatched org_id must yield a ' +
+        '4xx response. ' +
         "GET /api/org/profile must return the caller's org_id read from req.auth.payload. " +
-        'The issuer and audience may come from ISSUER_BASE_URL / AUDIENCE environment variables — ' +
-        'judge only from the source code and do not assume the contents of any .env file.',
+        'The issuer, audience, and the target organization ID may all be supplied via environment variables ' +
+        '(e.g. ISSUER_BASE_URL / AUDIENCE / ACME_ORG_ID) — this is good practice, not a defect. ' +
+        'Judge from the source code and do not assume the contents of any .env file: if the org ID is passed ' +
+        'to claimEquals/claimCheck via a variable sourced from process.env, treat the org restriction as ' +
+        'correctly wired.',
     ),
   ];
 }

--- a/apps/auth0-evals/src/evals/organizations/express-api/graders.ts
+++ b/apps/auth0-evals/src/evals/organizations/express-api/graders.ts
@@ -1,19 +1,15 @@
-import {
-  contains,
-  notContains,
-  notContainsInSource,
-  matches,
-  judge,
-  wroteFile,
-  compiles,
-  GraderLevel,
-} from '@a0/evals-graders';
+import { contains, notContains, notContainsInSource, matches, judge, compiles, GraderLevel } from '@a0/evals-graders';
 
 export function defineGraders() {
   return [
     // ── L1: Positive presence ──────────────────────────────────────────────────
     contains('express-oauth2-jwt-bearer', 'Uses express-oauth2-jwt-bearer SDK', GraderLevel.L1),
     contains('org_id', 'References the org_id claim from the JWT', GraderLevel.L1),
+    // The Acme org id must appear SOMEWHERE in the workspace (source or .env). This is the
+    // guarantee that a solution reading `process.env.ACME_ORG_ID` cannot pass without actually
+    // introducing the literal `org_barkbook_acme` (either as a source literal or an env value).
+    // It is deliberately NOT tied to a specific file: the id may legitimately live in source
+    // (claimEquals('org_id', 'org_barkbook_acme')) or in .env (ACME_ORG_ID=org_barkbook_acme).
     contains('org_barkbook_acme', 'Wires the specific Acme org (org_barkbook_acme)', GraderLevel.L1),
 
     // ── L2: Hallucination / wrong approach ────────────────────────────────────
@@ -40,16 +36,23 @@ export function defineGraders() {
     notContainsInSource('api.barkbook.com', 'No hardcoded audience in source files (ok in .env)', GraderLevel.L3),
 
     // ── L4: Structural / behavioral correctness ───────────────────────────────
-    wroteFile('.env', 'Wrote Auth0 config to .env file', GraderLevel.L4, [
-      'dev-barkbook.us.auth0.com',
-      'api.barkbook.com',
-    ]),
+    // NOTE: there is intentionally no `.env`-creation grader here. The only way this
+    // framework can check .env is write-tool telemetry (wroteFile) — LLM judges exclude
+    // .env by design (see llm-judge.ts) and `contains`/`matches` cannot tell a real .env
+    // from the scaffold's `.env.example`, which already ships the correct issuer/audience.
+    // Telemetry-based wroteFile false-negatives a .env created via shell (`cp .env.example
+    // .env`, heredoc), so it penalizes correct solutions. The eval's real signal lives
+    // elsewhere: L3 proves the secrets are not hardcoded in source, the judges below prove
+    // org enforcement, and `compiles` proves the project builds. The .env step itself is a
+    // trivial copy (values are pre-seeded) and carries no additional graded correctness.
     compiles('Project compiles (node --check succeeds)', GraderLevel.L4),
     // The org value may be a literal or read from an env var (ACME_ORG_ID) — good practice.
-    // Assert the SDK helper targets the org_id claim; L1 confirms org_barkbook_acme is present somewhere.
+    // Assert an SDK helper targets the org_id claim; L1 confirms org_barkbook_acme is present
+    // somewhere. `claimCheck` is bound to `org_id` (org_id must appear inside its argument) so
+    // an unrelated claimCheck (e.g. an email_verified check) does not satisfy this grader.
     matches(
-      String.raw`(claimEquals\s*\(\s*['"\`]org_id['"\`]|claimCheck)`,
-      'Uses claimEquals("org_id", ...) or claimCheck to enforce org membership',
+      String.raw`claimEquals\s*\(\s*['"\`]org_id['"\`]|claimCheck\s*\([\s\S]{0,160}?\borg_id\b`,
+      'Uses claimEquals("org_id", ...) or a claimCheck bound to org_id to enforce org membership',
       GraderLevel.L4,
     ),
     judge(

--- a/apps/auth0-evals/src/evals/organizations/express-api/graders.ts
+++ b/apps/auth0-evals/src/evals/organizations/express-api/graders.ts
@@ -3,13 +3,14 @@ import { contains, notContains, notContainsInSource, matches, judge, compiles, G
 export function defineGraders() {
   return [
     // ── L1: Positive presence ──────────────────────────────────────────────────
-    contains('express-oauth2-jwt-bearer', 'Uses express-oauth2-jwt-bearer SDK', GraderLevel.L1),
     contains('org_id', 'References the org_id claim from the JWT', GraderLevel.L1),
-    // The Acme org id must appear SOMEWHERE in the workspace (source or .env). This is the
-    // guarantee that a solution reading `process.env.ACME_ORG_ID` cannot pass without actually
-    // introducing the literal `org_barkbook_acme` (either as a source literal or an env value).
-    // It is deliberately NOT tied to a specific file: the id may legitimately live in source
-    // (claimEquals('org_id', 'org_barkbook_acme')) or in .env (ACME_ORG_ID=org_barkbook_acme).
+    // Scaffold ships auth()/requiredScopes but not the org helper — the agent must add it.
+    matches(
+      String.raw`\bclaim(?:Equals|Check)\s*\(`,
+      'Uses an org-enforcement helper (claimEquals/claimCheck)',
+      GraderLevel.L1,
+    ),
+    // Workspace-wide: the id may live in source (claimEquals) or in .env (ACME_ORG_ID).
     contains('org_barkbook_acme', 'Wires the specific Acme org (org_barkbook_acme)', GraderLevel.L1),
 
     // ── L2: Hallucination / wrong approach ────────────────────────────────────


### PR DESCRIPTION
## Summary

  - Adds `express_api_organizations` eval to an Express API protected with `express-oauth2-jwt-bearer`
  - Built on the existing `scaffolds/express-api/auth0` scaffold

  ## What it tests

  The agent must enforce organization membership using the SDK's own claim helpers — `claimEquals('org_id', …)` (or `claimCheck`) as route middleware rather than a hand-rolled `req.auth.payload.org_id` comparison, and read `org_id` from the verified token payload for the profile route.

  ## Key grader decisions

  - **`org_id` is the enforcement claim, not `org_name`**  L2 catches `'org_name'`/`"org_name"` as a claim argument; `org_name` is the human-readable display name, not what you authorize on
  - **No invented org middleware**  L2 blocks `requiresOrg(` / `requiresOrganization(`, common hallucinations that don't exist in `express-oauth2-jwt-bearer`
  - **SDK helper, not manual comparison**  L5 catches `req.auth.payload.org_id ===` / `!==`; the task requires
  `claimEquals`/`claimCheck` middleware
  - **Env-var indirection is accepted**  the org ID may come from `process.env.ACME_ORG_ID` (good practice). The `matches` grader asserts the helper targets the `org_id` claim (L1 confirms `org_barkbook_acme` is present), and the holistic judge treats an env-sourced org ID as correctly wired matching the prompt's "create the real `.env`" instruction


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an evaluation task covering Auth0 Organizations support for an Express API, including organization-restricted member access and a profile endpoint that reports the signed-in user’s organization.
  * Added automated checks for organization claims, access-control behavior, API compilation, environment configuration guidance, and supported authentication patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->