### PR TITLE
 feat(evals): Adds Organizations evals on express-openid-connect

### DIFF
--- a/apps/auth0-evals/src/evals/organizations/express-oidc/PROMPT.md
+++ b/apps/auth0-evals/src/evals/organizations/express-oidc/PROMPT.md
@@ -1,0 +1,19 @@
+---
+id: express_oidc_organizations
+name: Express OIDC Organizations Login
+scaffold: src/evals/scaffolds/express-oidc/auth0
+skills: auth0
+setup_command: npm install
+compile_command: node --check server.js
+---
+
+## Task
+
+Our Express web app already has Auth0 login working via `express-openid-connect`. Add Auth0
+Organizations support: log users in to our "Acme" org (`org_barkbook_acme`), accept organization
+invitation links (`?invitation=...&organization=...`), and show which organization the signed-in
+user belongs to.
+
+Domain: dev-barkbook.us.auth0.com
+Client ID: barkbook_client_abc123xyz
+Audience: https://api.barkbook.com

--- a/apps/auth0-evals/src/evals/organizations/express-oidc/graders.ts
+++ b/apps/auth0-evals/src/evals/organizations/express-oidc/graders.ts
@@ -45,12 +45,18 @@ export function defineGraders() {
 
     // ── L4: Structural correctness ─────────────────────────────────────────
     compiles('Project compiles (node --check succeeds)', GraderLevel.L4),
-    // Org-scoped login in express-openid-connect is only possible by passing
-    // `organization` inside an authorizationParams object — either on the auth()
-    // config or on res.oidc.login(). This is the same anchor the spa-js org eval uses.
+    // Org-scoped login in express-openid-connect is only possible by attaching
+    // `organization` to an authorizationParams object — on the auth() config or
+    // on res.oidc.login(). Bind `organization` to authorizationParams so a bare
+    // top-level `organization:` key (the anti-pattern L5 penalizes), a comment,
+    // or an unrelated identifier does NOT satisfy this grader. Two valid shapes:
+    //   • object literal:   authorizationParams: { organization: ... } (or `= {`)
+    //   • property assign:  authorizationParams.organization = req.query.organization
+    // The object form uses [^}]* so `organization` must appear before the object's
+    // closing brace (i.e. inside it), which the top-level-key placement never does.
     matches(
-      String.raw`authorizationParams[\s\S]{0,160}organization`,
-      'Passes organization inside an authorizationParams object (auth() config or res.oidc.login)',
+      String.raw`authorizationParams\s*\.\s*organization\b|authorizationParams\s*[:=]\s*\{[^}]*\borganization\b`,
+      'Attaches organization to an authorizationParams object (key inside the object, or authorizationParams.organization), not as a top-level config key',
       GraderLevel.L4,
     ),
     judge(

--- a/apps/auth0-evals/src/evals/organizations/express-oidc/graders.ts
+++ b/apps/auth0-evals/src/evals/organizations/express-oidc/graders.ts
@@ -1,4 +1,4 @@
-import { contains, notContains, notContainsInSource, matches, judge, compiles, GraderLevel } from '@a0/evals-graders';
+import { contains, notContains, notContainsInSource, judge, compiles, GraderLevel } from '@a0/evals-graders';
 
 export function defineGraders() {
   return [
@@ -46,17 +46,19 @@ export function defineGraders() {
     // ── L4: Structural correctness ─────────────────────────────────────────
     compiles('Project compiles (node --check succeeds)', GraderLevel.L4),
     // Org-scoped login in express-openid-connect is only possible by attaching
-    // `organization` to an authorizationParams object — on the auth() config or
-    // on res.oidc.login(). Bind `organization` to authorizationParams so a bare
-    // top-level `organization:` key (the anti-pattern L5 penalizes), a comment,
-    // or an unrelated identifier does NOT satisfy this grader. Two valid shapes:
-    //   • object literal:   authorizationParams: { organization: ... } (or `= {`)
-    //   • property assign:  authorizationParams.organization = req.query.organization
-    // The object form uses [^}]* so `organization` must appear before the object's
-    // closing brace (i.e. inside it), which the top-level-key placement never does.
-    matches(
-      String.raw`authorizationParams\s*\.\s*organization\b|authorizationParams\s*[:=]\s*\{[^}]*\borganization\b`,
-      'Attaches organization to an authorizationParams object (key inside the object, or authorizationParams.organization), not as a top-level config key',
+    // `organization` to an authorizationParams object. A textual regex can't tell
+    // real wiring from a property READ, a comment, a string literal, a wrong-cased
+    // identifier, or a value nested one object deeper — and the matches executor is
+    // case-insensitive by default. Use a source-aware judge that reads the code
+    // instead of pattern-matching raw text.
+    judge(
+      'Does the code perform org-scoped login by passing the organization VALUE into an ' +
+        'authorizationParams object — i.e. as a key inside `authorizationParams: { organization: ... }` ' +
+        '(on the auth() config or res.oidc.login), or by assigning `authorizationParams.organization = ...` ' +
+        'before calling res.oidc.login? To pass, `organization` must be an actual value SENT to Auth0 in the ' +
+        'authorize request. Answer NO if `organization` appears only as a top-level config key (a sibling of ' +
+        'authorizationParams, not inside it), only inside a comment or string literal, or is merely READ from ' +
+        'user/claims (e.g. logging req.oidc.user.org_id) without being passed into authorizationParams.',
       GraderLevel.L4,
     ),
     judge(

--- a/apps/auth0-evals/src/evals/organizations/express-oidc/graders.ts
+++ b/apps/auth0-evals/src/evals/organizations/express-oidc/graders.ts
@@ -1,0 +1,97 @@
+import { contains, notContains, notContainsInSource, matches, judge, compiles, GraderLevel } from '@a0/evals-graders';
+
+export function defineGraders() {
+  return [
+    // ── L1: Required Organizations symbols present ─────────────────────────
+    contains('organization', 'Passes the organization parameter for org-scoped login', GraderLevel.L1),
+    contains('org_barkbook_acme', 'Wires the specific Acme org (org_barkbook_acme)', GraderLevel.L1),
+    contains('invitation', 'Handles the organization invitation parameter', GraderLevel.L1),
+    contains('org_id', 'Reads the org_id claim to identify the logged-in organization', GraderLevel.L1),
+
+    // ── L2: Hallucination / wrong SDK ──────────────────────────────────────
+    notContains('@auth0/organizations', 'No hallucinated @auth0/organizations package', GraderLevel.L2),
+    notContains(
+      'useOrganization(',
+      'No non-existent useOrganization hook (express-openid-connect is not hook-based)',
+      GraderLevel.L2,
+    ),
+    notContains('@auth0/auth0-react', 'No React SDK in an Express web app', GraderLevel.L2),
+    notContains('@auth0/nextjs-auth0', 'No Next.js SDK in an Express web app', GraderLevel.L2),
+    notContains(
+      'express-oauth2-jwt-bearer',
+      'No express-oauth2-jwt-bearer (that is the API/bearer-token SDK, not the web-app OIDC SDK)',
+      GraderLevel.L2,
+    ),
+    notContains(
+      'passport',
+      'No passport — the app uses express-openid-connect, not Passport strategies',
+      GraderLevel.L2,
+    ),
+
+    // ── L3: Security ───────────────────────────────────────────────────────
+    // The scaffold already reads issuer/client/secret from AUTH0_* env vars, so
+    // these must never be hardcoded into source (allowed in a local .env).
+    notContainsInSource(
+      'dev-barkbook.us.auth0.com',
+      'No hardcoded issuer domain in source files (ok in .env)',
+      GraderLevel.L3,
+    ),
+    notContainsInSource(
+      'barkbook_client_abc123xyz',
+      'No hardcoded client ID in source files (ok in .env)',
+      GraderLevel.L3,
+    ),
+    notContainsInSource('api.barkbook.com', 'No hardcoded audience in source files (ok in .env)', GraderLevel.L3),
+
+    // ── L4: Structural correctness ─────────────────────────────────────────
+    compiles('Project compiles (node --check succeeds)', GraderLevel.L4),
+    // Org-scoped login in express-openid-connect is only possible by passing
+    // `organization` inside an authorizationParams object — either on the auth()
+    // config or on res.oidc.login(). This is the same anchor the spa-js org eval uses.
+    matches(
+      String.raw`authorizationParams[\s\S]{0,160}organization`,
+      'Passes organization inside an authorizationParams object (auth() config or res.oidc.login)',
+      GraderLevel.L4,
+    ),
+    judge(
+      'Does the code read the "invitation" and "organization" parameters from the request URL query ' +
+        'string and forward them (inside authorizationParams) to res.oidc.login when present — typically by ' +
+        'disabling the default login route (routes.login = false) and defining a custom /login handler? ' +
+        'To pass, the invitation\'s own "organization" must be forwarded (overriding any default/configured ' +
+        'org), and the code must NOT reject or block a valid invitation solely because its organization ' +
+        "differs from the app's configured default org.",
+      GraderLevel.L4,
+    ),
+    judge(
+      'Does the code surface the organization the user logged into by reading the org_id claim from the ' +
+        'session/ID token (e.g. req.oidc.user.org_id or req.oidc.idTokenClaims.org_id), rather than ' +
+        'hardcoding or guessing it? Validating org_id in an afterCallback hook (decoding session.id_token ' +
+        'and checking claims.org_id) is an acceptable, good-practice way to satisfy this.',
+      GraderLevel.L4,
+    ),
+
+    // ── L5: Current API patterns ───────────────────────────────────────────
+    judge(
+      'Does the code pass the organization value inside an authorizationParams object (on the auth() ' +
+        'config or on res.oidc.login) rather than as a top-level "organization" config key or a positional ' +
+        'argument? Also confirm it uses current express-openid-connect APIs (auth(), requiresAuth(), ' +
+        'res.oidc.login, req.oidc) and not removed/deprecated options such as httpAgent or top-level ' +
+        'audience/scope keys.',
+      GraderLevel.L5,
+    ),
+
+    // ── Holistic judge (no level — always runs) ────────────────────────────
+    judge(
+      'Does the solution correctly add Auth0 Organizations support to the Express web app using ' +
+        'express-openid-connect — logging users into the specified organization (org_barkbook_acme) via ' +
+        'organization inside authorizationParams, accepting organization invitation links via the invitation ' +
+        'and organization query parameters, and identifying the logged-in organization from the org_id claim ' +
+        '(req.oidc.user.org_id / req.oidc.idTokenClaims)? Enforcing or validating org membership via an ' +
+        'afterCallback org_id check, or via the claimEquals/claimCheck/claimIncludes route helpers, is ' +
+        'good practice and must not be marked wrong. Rejecting or blocking a valid invitation because its ' +
+        'organization differs from the configured default org is a correctness defect, not a cosmetic one — ' +
+        'treat it as a failure of invitation acceptance. The issuer, client ID and secret come from AUTH0_* ' +
+        'environment variables — judge only from the source code and do not assume the contents of any .env file.',
+    ),
+  ];
+}


### PR DESCRIPTION
## Summary

Adds an Organizations eval for the `express-openid-connect` SDK, Auth0's server-side web-app OIDC SDK for session-based login.

The eval reuses the existing `src/evals/scaffolds/express-oidc/auth0` scaffold (no new scaffold needed) and follows the pattern established by the `organizations/react` and `organizations/spa-js` evals.

**New eval:** `express_oidc_organizations`  
**Location:** `apps/auth0-evals/src/evals/organizations/express-oidc/`

## What It Tests

Given an Express web app that already logs in via `express-openid-connect`, the agent must add Auth0 Organizations support:

1. **Org-scoped login:** Log users into the Acme org (`org_barkbook_acme`) by passing `organization` inside `authorizationParams`, either on the `auth()` config or `res.oidc.login`.
2. **Invitation acceptance:** Handle `?invitation=…&organization=…` links by forwarding both parameters to `res.oidc.login`, typically through a custom `/login` route with `routes.login = false`.
3. **Surfacing the org:** Read the `org_id` claim from `req.oidc.user.org_id` or `req.oidc.idTokenClaims`.

## Key Grader Decisions

- **19 graders** across L1 to L5 plus one holistic judge:
  - L1: 4
  - L2: 6
  - L3: 3
  - L4: 4
  - L5: 1
  - Holistic: 1

- **Org-login regex is bound to `authorizationParams`:** The L4 `matches()` grader requires `organization` to be attached to an `authorizationParams` object. Supported forms include an object-literal key, `authorizationParams = { … }`, or incremental assignment such as `authorizationParams.organization = …`.

  A bare top-level `organization:` key, comment, or stray identifier does not satisfy the grader. This is important because the scaffold already contains an `authorizationParams` block. An unanchored regex could therefore produce false positives.

- **No `wroteFile('.env')` grader:** Agents commonly create `.env` via shell commands such as `cp` or heredocs, which surface as `run_command` rather than write-tool telemetry. Instead, secrets are enforced through L3 `notContainsInSource` checks, preventing hardcoded issuer domains, client IDs, and audiences in source while allowing them in `.env`.

- **`claimCheck` / `claimEquals` / `claimIncludes` are allowed:** These are valid route-middleware helpers in `express-openid-connect`. Using them to enforce or validate organization membership, or checking `org_id` in `afterCallback`, is accepted by the L4 and holistic judges.

- **Wrong SDKs are rejected:** L2 rejects:
  - `express-oauth2-jwt-bearer`
  - `@auth0/auth0-react`
  - `@auth0/nextjs-auth0`
  - `passport`
  - `@auth0/organizations`
  - `useOrganization()`

- **Invitation correctness:** A valid invitation must not be rejected solely because its organization differs from the configured default organization. The dedicated L4 judge treats this as a correctness issue rather than a cosmetic concern.

## Validation

| Check | Result |
| --- | --- |
| `npm run build` | ✅ Passes |
| `npm run lint` | ✅ Passes |
| `npm test` | ✅ 627 tests pass |
| Eval discovery | ✅ `express_oidc_organizations` loads |
| Grader load | ✅ 19 graders |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Express OIDC evaluation for Auth0 Organizations.
  * Added guidance for organization login, invitation-link handling, and displaying the signed-in user’s organization.
  * Added automated grading checks covering configuration, implementation correctness, API usage, and organization claim handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->