### PR TITLE
feat(evals): add passkey sign-in evals for Auth0.Android and Auth0.swift

### DIFF
--- a/apps/auth0-evals/src/evals/passkeys/android/PROMPT.md
+++ b/apps/auth0-evals/src/evals/passkeys/android/PROMPT.md
@@ -1,0 +1,14 @@
+---
+id: android_passkeys
+name: Android Passkey Sign-In
+scaffold: src/evals/scaffolds/android/auth0
+skills: auth0
+---
+
+## Task
+
+My Android app already has Auth0 login working through Universal Login. I want to let users sign in with a passkey — using the device fingerprint or screen lock — as an alternative to the hosted login page, so they can log in without a password. Add that passkey sign-in option.
+
+Domain: dev-barkbook.us.auth0.com
+Client ID: barkbook_client_abc123xyz
+Audience: https://api.barkbook.com

--- a/apps/auth0-evals/src/evals/passkeys/android/graders.ts
+++ b/apps/auth0-evals/src/evals/passkeys/android/graders.ts
@@ -1,0 +1,94 @@
+import { contains, notContains, notContainsInSource, judge, GraderLevel } from '@a0/evals-graders';
+
+export function defineGraders() {
+  return [
+    // ── L1: Required passkey sign-in symbols present ──────────────────────
+    contains('passkeyChallenge', 'Requests a passkey sign-in challenge from AuthenticationAPIClient', GraderLevel.L1),
+    contains('signinWithPasskey', 'Exchanges the platform credential for Auth0 credentials', GraderLevel.L1),
+    // The SDK does not wrap the OS credential API — the app must drive the
+    // platform authenticator through AndroidX CredentialManager itself.
+    contains(
+      'GetPublicKeyCredentialOption',
+      'Builds a get-credential option (sign-in), not a create-credential request',
+      GraderLevel.L1,
+    ),
+    // Required on every signinWithPasskey call — without it ID token claim
+    // validation is silently skipped (see L3).
+    contains('validateClaims', 'Chains validateClaims on the sign-in request', GraderLevel.L1),
+
+    // ── L2: Hallucination / wrong approach ────────────────────────────────
+    notContains('auth0-java', 'No auth0-java (server-side SDK, not for Android)', GraderLevel.L2),
+    // The SDK uses only AndroidX androidx.credentials; the older Google Play
+    // Services FIDO API is the wrong, lower-level path.
+    notContains(
+      'com.google.android.gms.fido',
+      'Does not use the deprecated Google Play Services FIDO API instead of CredentialManager',
+      GraderLevel.L2,
+    ),
+
+    // ── L3: Security ──────────────────────────────────────────────────────
+    notContainsInSource(
+      'barkbook_client_abc123xyz',
+      'No hardcoded client ID in Kotlin source files (ok in strings.xml)',
+      GraderLevel.L3,
+    ),
+    notContainsInSource(
+      'dev-barkbook.us.auth0.com',
+      'No hardcoded domain in Kotlin source files (ok in strings.xml)',
+      GraderLevel.L3,
+    ),
+    judge(
+      'Is validateClaims() actually chained on the signinWithPasskey request before it is started/awaited, so ' +
+        'ID token claims (issuer, audience, nonce, expiry) are validated? Omitting it makes the SDK skip that ' +
+        'validation with only a warning, which is a security defect.',
+      GraderLevel.L3,
+    ),
+    judge(
+      'Is the CredentialManager get-request built from the challenge object returned by Auth0 ' +
+        '(challenge.authParamsPublicKey and challenge.authSession) rather than a hardcoded relying-party id or a ' +
+        'fabricated/reused challenge, and is the PublicKeyCredentials obtained from the platform authenticator ' +
+        'rather than constructed by hand?',
+      GraderLevel.L3,
+    ),
+    judge(
+      'Does the code let SecureCredentialsManager (or CredentialsManager) store the Credentials returned from the ' +
+        'passkey sign-in rather than persisting Auth0 tokens (access tokens, ID tokens, refresh tokens) by hand ' +
+        'in SharedPreferences? Storing only application/UI state is acceptable — only manual token storage is a ' +
+        'violation.',
+      GraderLevel.L3,
+    ),
+
+    // ── L4: Structural correctness ────────────────────────────────────────
+    judge(
+      'Does the sign-in follow the correct passkey ceremony in order: (1) obtain a PasskeyChallenge via ' +
+        'passkeyChallenge; (2) build GetPublicKeyCredentialOption from the JSON of challenge.authParamsPublicKey ' +
+        'wrapped in a GetCredentialRequest; (3) call credentialManager.getCredential and read the ' +
+        'authenticationResponseJson from the returned PublicKeyCredential; (4) pass it plus challenge.authSession ' +
+        'to signinWithPasskey(...).validateClaims() to obtain Credentials, which are then saved via the ' +
+        'credentials manager?',
+      GraderLevel.L4,
+    ),
+
+    // ── L5: Current API patterns ──────────────────────────────────────────
+    // PasskeyAuthProvider was deprecated in v3; PasskeyProvider and
+    // PasskeyManager were removed in v4 (V4_MIGRATION_GUIDE.md). The current
+    // path is AuthenticationAPIClient + AndroidX CredentialManager directly.
+    notContains('PasskeyAuthProvider', 'Does not use the removed PasskeyAuthProvider wrapper', GraderLevel.L5),
+    notContains('PasskeyProvider', 'Does not use the removed PasskeyProvider wrapper', GraderLevel.L5),
+    notContains('PasskeyManager', 'Does not use the removed PasskeyManager wrapper', GraderLevel.L5),
+    judge(
+      'Is the passkey sign-in built with the current API — AuthenticationAPIClient (passkeyChallenge / ' +
+        'signinWithPasskey) combined directly with AndroidX CredentialManager — rather than the removed ' +
+        'PasskeyAuthProvider/PasskeyProvider/PasskeyManager wrappers or the Google Play Services FIDO2 API?',
+      GraderLevel.L5,
+    ),
+
+    // ── Holistic judge (no level — always runs) ───────────────────────────
+    judge(
+      'Does the solution correctly add passkey sign-in to an Android app — requesting a challenge via ' +
+        'passkeyChallenge, driving the platform authenticator through AndroidX CredentialManager with the ' +
+        "challenge's authParamsPublicKey, and exchanging the resulting PublicKeyCredential back via " +
+        'signinWithPasskey(...).validateClaims() to obtain and store Credentials?',
+    ),
+  ];
+}

--- a/apps/auth0-evals/src/evals/passkeys/android/graders.ts
+++ b/apps/auth0-evals/src/evals/passkeys/android/graders.ts
@@ -25,6 +25,14 @@ export function defineGraders() {
       'Does not use the deprecated Google Play Services FIDO API instead of CredentialManager',
       GraderLevel.L2,
     ),
+    // The SDK exposes passkeyChallenge/signinWithPasskey (no slash); a literal
+    // /passkey/challenge path means the model hand-rolled the Auth0 exchange
+    // over raw HTTP instead of using the SDK — observed in baseline runs.
+    notContains(
+      '/passkey/challenge',
+      'Does not hand-roll the raw /passkey/challenge endpoint instead of the SDK',
+      GraderLevel.L2,
+    ),
 
     // ── L3: Security ──────────────────────────────────────────────────────
     notContainsInSource(

--- a/apps/auth0-evals/src/evals/passkeys/swift/PROMPT.md
+++ b/apps/auth0-evals/src/evals/passkeys/swift/PROMPT.md
@@ -1,0 +1,14 @@
+---
+id: swift_passkeys
+name: Swift Passkey Sign-In
+scaffold: src/evals/scaffolds/swift/auth0
+skills: auth0
+---
+
+## Task
+
+My iOS app already has Auth0 login working through Universal Login. I want to let users sign in with a passkey — using Face ID or Touch ID on their device — as an alternative to the hosted login page, so they can log in without a password. Add that passkey sign-in option.
+
+Domain: dev-barkbook.us.auth0.com
+Client ID: barkbook_client_abc123xyz
+Audience: https://api.barkbook.com

--- a/apps/auth0-evals/src/evals/passkeys/swift/graders.ts
+++ b/apps/auth0-evals/src/evals/passkeys/swift/graders.ts
@@ -1,4 +1,4 @@
-import { contains, notContains, notContainsInSource, judge, GraderLevel } from '@a0/evals-graders';
+import { contains, notContains, notContainsInSource, matches, judge, GraderLevel } from '@a0/evals-graders';
 
 export function defineGraders() {
   return [
@@ -8,7 +8,14 @@ export function defineGraders() {
       'Requests a passkey login challenge from the Authentication client',
       GraderLevel.L1,
     ),
-    contains('PasskeyLoginChallenge', 'Uses the PasskeyLoginChallenge type returned by the SDK', GraderLevel.L1),
+    // Swift infers the challenge type, so correct code often never spells out
+    // PasskeyLoginChallenge — accept either the type name or the login(passkey:)
+    // exchange that consumes the challenge.
+    matches(
+      String.raw`PasskeyLoginChallenge|login\(\s*passkey:`,
+      'Uses the login challenge — as the PasskeyLoginChallenge type or via login(passkey:challenge:)',
+      GraderLevel.L1,
+    ),
     // The SDK does not wrap the OS credential API — the app must drive the
     // platform authenticator through Apple AuthenticationServices itself.
     contains(
@@ -23,9 +30,15 @@ export function defineGraders() {
     ),
 
     // ── L2: Hallucination / wrong approach ────────────────────────────────
-    // No passkey-specific wrong approach or third-party substitution could be
-    // sourced for Auth0.swift, so L2 is thin here — only the package-name guard.
     notContains('Auth0SDK', 'No hallucinated Auth0SDK package name (correct package is Auth0)', GraderLevel.L2),
+    // The SDK exposes passkeyLoginChallenge (no slash); a literal
+    // /passkey/challenge path means the model hand-rolled the exchange over raw
+    // HTTP instead of using the SDK — observed on Android baseline runs.
+    notContains(
+      '/passkey/challenge',
+      'Does not hand-roll the raw /passkey/challenge endpoint instead of the SDK',
+      GraderLevel.L2,
+    ),
 
     // ── L3: Security ──────────────────────────────────────────────────────
     notContainsInSource(

--- a/apps/auth0-evals/src/evals/passkeys/swift/graders.ts
+++ b/apps/auth0-evals/src/evals/passkeys/swift/graders.ts
@@ -1,0 +1,89 @@
+import { contains, notContains, notContainsInSource, judge, GraderLevel } from '@a0/evals-graders';
+
+export function defineGraders() {
+  return [
+    // ── L1: Required passkey sign-in symbols present ──────────────────────
+    contains(
+      'passkeyLoginChallenge',
+      'Requests a passkey login challenge from the Authentication client',
+      GraderLevel.L1,
+    ),
+    contains('PasskeyLoginChallenge', 'Uses the PasskeyLoginChallenge type returned by the SDK', GraderLevel.L1),
+    // The SDK does not wrap the OS credential API — the app must drive the
+    // platform authenticator through Apple AuthenticationServices itself.
+    contains(
+      'ASAuthorizationPlatformPublicKeyCredentialProvider',
+      'Bridges to the platform authenticator via AuthenticationServices',
+      GraderLevel.L1,
+    ),
+    contains(
+      'createCredentialAssertionRequest',
+      'Builds an assertion request (sign-in), not a registration request',
+      GraderLevel.L1,
+    ),
+
+    // ── L2: Hallucination / wrong approach ────────────────────────────────
+    // No passkey-specific wrong approach or third-party substitution could be
+    // sourced for Auth0.swift, so L2 is thin here — only the package-name guard.
+    notContains('Auth0SDK', 'No hallucinated Auth0SDK package name (correct package is Auth0)', GraderLevel.L2),
+
+    // ── L3: Security ──────────────────────────────────────────────────────
+    notContainsInSource(
+      'barkbook_client_abc123xyz',
+      'No hardcoded client ID in Swift source files (ok in Auth0.plist)',
+      GraderLevel.L3,
+    ),
+    notContainsInSource(
+      'dev-barkbook.us.auth0.com',
+      'No hardcoded domain in Swift source files (ok in Auth0.plist)',
+      GraderLevel.L3,
+    ),
+    judge(
+      'Are the relying-party identifier and challenge fed to the platform authenticator taken directly from ' +
+        'the SDK challenge object (challenge.relyingPartyId and challenge.challengeData), rather than a ' +
+        'hardcoded relying-party string or a fabricated/reused challenge?',
+      GraderLevel.L3,
+    ),
+    judge(
+      'Does the code let CredentialsManager store the Credentials returned from the passkey login rather than ' +
+        'persisting Auth0 tokens (access tokens, ID tokens, refresh tokens) by hand in UserDefaults or the ' +
+        'Keychain? Storing only application/UI state is acceptable — only manual token storage is a violation.',
+      GraderLevel.L3,
+    ),
+
+    // ── L4: Structural correctness ────────────────────────────────────────
+    judge(
+      'Does the sign-in follow the correct passkey ceremony in order: (1) obtain a PasskeyLoginChallenge via ' +
+        'passkeyLoginChallenge; (2) build ASAuthorizationPlatformPublicKeyCredentialProvider with ' +
+        "challenge.relyingPartyId and createCredentialAssertionRequest(challenge:) with the challenge's data; " +
+        '(3) run it through ASAuthorizationController.performRequests() with a delegate; (4) pass the resulting ' +
+        'ASAuthorizationPlatformPublicKeyCredentialAssertion to Authentication.login(passkey:challenge:) to ' +
+        'obtain Credentials?',
+      GraderLevel.L4,
+    ),
+    judge(
+      'Does the solution set up (or explicitly call out as required) the Associated Domains capability with a ' +
+        'webcredentials entitlement for the Auth0 domain, without which the OS will refuse the passkey assertion? ' +
+        'An entitlements change or an explicit instruction to add it both count.',
+      GraderLevel.L4,
+    ),
+
+    // ── L5: Current API patterns ──────────────────────────────────────────
+    // Auth0.swift has no deprecated passkey symbols, so this only checks the
+    // model used the SDK's passkey methods rather than reinventing the ceremony.
+    judge(
+      'Is the passkey exchange done through the SDK Authentication client methods (passkeyLoginChallenge and ' +
+        'login(passkey:challenge:)) rather than by hand-building HTTP requests to the /passkey authentication ' +
+        'endpoints or pulling in a third-party WebAuthn library?',
+      GraderLevel.L5,
+    ),
+
+    // ── Holistic judge (no level — always runs) ───────────────────────────
+    judge(
+      'Does the solution correctly add passkey sign-in to a Swift iOS app — requesting a login challenge from ' +
+        'the Auth0 Authentication client, driving the platform authenticator through Apple AuthenticationServices ' +
+        'with the relying-party id and challenge from that object, and exchanging the resulting assertion back ' +
+        'via login(passkey:challenge:) to obtain and store Credentials?',
+    ),
+  ];
+}


### PR DESCRIPTION
Adds evals covering passkey sign-in for the two mobile SDKs, Auth0.Android and Auth0.swift. Each starts from a working Universal Login app and asks the model to add passwordless passkey login.

The graders check that the solution requests a passkey challenge, drives the platform authenticator (AndroidX CredentialManager / Apple AuthenticationServices) from that challenge, and exchanges the result back through the SDK to obtain and store credentials — including the security-sensitive parts: taking the relying-party id and challenge from the SDK object rather than hardcoding them, letting the credentials manager hold the tokens, and on Android chaining validateClaims() so ID-token validation isn't skipped. L5 also guards against the passkey wrapper classes removed in Auth0.Android v4.