### PR TITLE
feat(evals): Adds Organisation evals for auth0-auth-js

### DIFF
--- a/apps/auth0-evals/src/evals/organizations/auth0-auth-js/PROMPT.md
+++ b/apps/auth0-evals/src/evals/organizations/auth0-auth-js/PROMPT.md
@@ -1,0 +1,21 @@
+---
+id: auth0_auth_js_organizations
+name: auth0-auth-js Organizations Login
+scaffold: src/evals/scaffolds/auth0-auth-js/auth0
+skills: auth0
+setup_command: npm install
+compile_command: npm run build
+---
+
+## Task
+
+Our Node.js auth service already has Auth0 login working via `@auth0/auth0-auth-js`. Add Auth0
+Organizations support: build authorization URLs scoped to our "Acme" org (`org_barkbook_acme`),
+accept organization invitation links, validate the org claim
+when exchanging the authorization code for tokens, and expose the logged-in organization (`org_id`)
+from the ID token in the `/auth/callback` response.
+
+Domain: dev-barkbook.us.auth0.com
+Client ID: barkbook_client_abc123xyz
+Audience: https://api.barkbook.com
+Redirect URI: http://localhost:3000/auth/callback

--- a/apps/auth0-evals/src/evals/organizations/auth0-auth-js/graders.ts
+++ b/apps/auth0-evals/src/evals/organizations/auth0-auth-js/graders.ts
@@ -1,0 +1,89 @@
+import {
+  contains,
+  notContains,
+  notContainsInSource,
+  matches,
+  judge,
+  compiles,
+  GraderLevel,
+} from '@a0/evals-graders';
+
+export function defineGraders() {
+  return [
+    // ── L1: Required Organizations symbols present ─────────────────────────
+    contains('organization', 'Passes the organization parameter for org-scoped login', GraderLevel.L1),
+    contains('org_barkbook_acme', 'Wires the specific Acme org (org_barkbook_acme)', GraderLevel.L1),
+    contains('invitation', 'Handles the organization invitation parameter', GraderLevel.L1),
+    contains('org_id', 'Reads the org_id claim to identify the logged-in organization', GraderLevel.L1),
+    contains('buildAuthorizationUrl', 'Uses buildAuthorizationUrl to initiate org-scoped login', GraderLevel.L1),
+    contains('getTokenByCode', 'Uses getTokenByCode to exchange the authorization code', GraderLevel.L1),
+
+    // ── L2: Hallucination / wrong SDK ─────────────────────────────────────
+    notContains('@auth0/organizations', 'No hallucinated @auth0/organizations package', GraderLevel.L2),
+    notContains('@auth0/auth0-react', 'No React SDK in a Node.js server app', GraderLevel.L2),
+    notContains(
+      'useOrganization(',
+      'No non-existent useOrganization hook (auth0-auth-js is not hook-based)',
+      GraderLevel.L2,
+    ),
+    notContains(
+      'express-openid-connect',
+      'No express-openid-connect (wrong SDK for this low-level auth client)',
+      GraderLevel.L2,
+    ),
+
+    // ── L3: Security ───────────────────────────────────────────────────────
+    notContainsInSource(
+      'dev-barkbook.us.auth0.com',
+      'No hardcoded domain in source files (ok in .env)',
+      GraderLevel.L3,
+    ),
+    notContainsInSource(
+      'barkbook_client_abc123xyz',
+      'No hardcoded client ID in source files (ok in .env)',
+      GraderLevel.L3,
+    ),
+
+    // ── L4: Structural correctness ─────────────────────────────────────────
+    compiles('Project compiles (tsc succeeds)', GraderLevel.L4),
+    matches(
+      String.raw`authorizationParams[\s\S]{0,160}organization`,
+      'Passes organization inside authorizationParams when building the authorization URL',
+      GraderLevel.L4,
+    ),
+    judge(
+      'Does the code read the "invitation" and "organization" parameters from the callback/login ' +
+        'request URL and forward them to buildAuthorizationUrl (inside authorizationParams) when present? ' +
+        "The invitation's own organization must be forwarded and must not be rejected solely because it " +
+        "differs from the app's default org.",
+      GraderLevel.L4,
+    ),
+    judge(
+      'Does the code pass the organization to getTokenByCode (as the "organization" option) so the ' +
+        'SDK validates the org_id claim of the returned ID token? And does it handle ' +
+        'OrganizationValidationError (imported from @auth0/auth0-auth-js) when the claim is missing ' +
+        'or mismatched?',
+      GraderLevel.L4,
+    ),
+
+    // ── L5: Current API patterns ───────────────────────────────────────────
+    judge(
+      'Does the code pass the organization value inside an authorizationParams object when calling ' +
+        'buildAuthorizationUrl - i.e. as authorizationParams.organization - rather than as a top-level ' +
+        'option or a legacy format? Also confirm it uses the current @auth0/auth0-auth-js APIs ' +
+        '(AuthClient, buildAuthorizationUrl, getTokenByCode) and not any removed or deprecated patterns.',
+      GraderLevel.L5,
+    ),
+
+    // ── Holistic judge (no level - always runs) ────────────────────────────
+    judge(
+      'Does the solution correctly add Auth0 Organizations support to the Node.js auth service using ' +
+        '@auth0/auth0-auth-js - building authorization URLs scoped to the specified organization ' +
+        '(org_barkbook_acme) via authorizationParams.organization, accepting organization invitation ' +
+        'links by forwarding invitation and organization query params to buildAuthorizationUrl, ' +
+        'validating the org claim during getTokenByCode, and surfacing the org_id claim from the ' +
+        'returned ID token? Rejecting a valid invitation because its organization differs from the ' +
+        'configured default is a correctness defect - treat it as a failure.',
+    ),
+  ];
+}

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-auth-js/auth0/.env.example
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-auth-js/auth0/.env.example
@@ -1,0 +1,4 @@
+AUTH0_DOMAIN=dev-barkbook.us.auth0.com
+AUTH0_CLIENT_ID=barkbook_client_abc123xyz
+AUTH0_CLIENT_SECRET=barkbook_secret_def456uvw
+AUTH0_AUDIENCE=https://api.barkbook.com

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-auth-js/auth0/package.json
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-auth-js/auth0/package.json
@@ -9,7 +9,6 @@
   },
   "dependencies": {
     "@auth0/auth0-auth-js": "^1.12.1",
-    "dotenv": "^16.4.7",
     "express": "^5.1.0"
   },
   "devDependencies": {

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-auth-js/auth0/src/index.ts
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-auth-js/auth0/src/index.ts
@@ -1,4 +1,3 @@
-import 'dotenv/config';
 import express from 'express';
 import type { Request, Response } from 'express';
 import { audience, authClient } from './auth0.js';


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description
- Adds Organisation evals for `@auth0/auth0-auth-js`

### References

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an Auth0 Organizations evaluation scenario covering organization-scoped authorization, invitation links, organization claims, and callback responses.
  - Added automated checks for organization configuration, invitation handling, token validation, compilation, and overall implementation correctness.
  - Added an environment configuration example for Auth0 domain, client, secret, and audience settings.

- **Chores**
  - Removed the dotenv dependency and automatic `.env` loading from the authentication scaffold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->