### PR TITLE
feat(evals): Adds Organisation evals for auth0-api-js

### DIFF
--- a/apps/auth0-evals/src/evals/organizations/auth0-api-js/PROMPT.md
+++ b/apps/auth0-evals/src/evals/organizations/auth0-api-js/PROMPT.md
@@ -1,0 +1,18 @@
+---
+id: auth0_api_js_organizations
+name: auth0-api-js Organizations API Protection
+scaffold: src/evals/scaffolds/auth0-api-js/auth0
+skills: auth0
+setup_command: npm install
+compile_command: npm run build
+---
+
+## Task
+
+Our Express API already verifies Auth0 access tokens using `@auth0/auth0-api-js`. Now, verify that every incoming access token carries a valid `org_id` claim,
+reject tokens that do not belong to our "Acme" org (`org_barkbook_acme`), and include the
+`org_id` in the API responses so clients can see which organization's data they are accessing.
+
+Domain: dev-barkbook.us.auth0.com
+Audience: https://api.barkbook.com
+Expected org: org_barkbook_acme

--- a/apps/auth0-evals/src/evals/organizations/auth0-api-js/graders.ts
+++ b/apps/auth0-evals/src/evals/organizations/auth0-api-js/graders.ts
@@ -1,0 +1,105 @@
+import {
+  contains,
+  notContains,
+  notContainsInSource,
+  matches,
+  judge,
+  compiles,
+  GraderLevel,
+} from '@a0/evals-graders';
+
+export function defineGraders() {
+  return [
+    // ── L1: Required Organizations symbols present ─────────────────────────
+    contains('org_id', 'Checks the org_id claim on verified tokens', GraderLevel.L1),
+    contains('org_barkbook_acme', 'Enforces the specific Acme org (org_barkbook_acme)', GraderLevel.L1),
+    contains('verifyAccessToken', 'Uses verifyAccessToken to validate incoming tokens', GraderLevel.L1),
+    contains('@auth0/auth0-api-js', 'Uses the @auth0/auth0-api-js SDK', GraderLevel.L1),
+    contains('ApiClient', 'Creates an ApiClient instance', GraderLevel.L1),
+
+    // ── L2: Hallucination / wrong SDK ─────────────────────────────────────
+    notContains('@auth0/organizations', 'No hallucinated @auth0/organizations package', GraderLevel.L2),
+    notContains(
+      'express-oauth2-jwt-bearer',
+      'No express-oauth2-jwt-bearer (wrong SDK - task uses @auth0/auth0-api-js)',
+      GraderLevel.L2,
+    ),
+    notContains('@auth0/auth0-react', 'No React SDK in an Express API', GraderLevel.L2),
+    notContains(
+      'express-openid-connect',
+      'No express-openid-connect (that is the web-app OIDC SDK, not the API SDK)',
+      GraderLevel.L2,
+    ),
+    notContains(
+      'jwks-rsa',
+      'No manual jwks-rsa (the SDK handles JWKS internally)',
+      GraderLevel.L2,
+    ),
+    notContains(
+      'jsonwebtoken',
+      'No manual JWT verification with jsonwebtoken - verifyAccessToken must do the parsing',
+      GraderLevel.L2,
+    ),
+    notContains(
+      'jwt-decode',
+      'No manual JWT decoding with jwt-decode - verifyAccessToken must do the parsing',
+      GraderLevel.L2,
+    ),
+
+    // ── L3: Security ───────────────────────────────────────────────────────
+    notContainsInSource(
+      'dev-barkbook.us.auth0.com',
+      'No hardcoded domain in source files (ok in .env)',
+      GraderLevel.L3,
+    ),
+    notContainsInSource(
+      'api.barkbook.com',
+      'No hardcoded audience in source files (ok in .env)',
+      GraderLevel.L3,
+    ),
+    notContains(
+      'algorithm: "none"',
+      'No disabled JWT algorithm verification',
+      GraderLevel.L3,
+    ),
+
+    // ── L4: Structural correctness ─────────────────────────────────────────
+    compiles('Project compiles (tsc succeeds)', GraderLevel.L4),
+    matches(
+      String.raw`requiredClaims[\s\S]{0,80}org_id`,
+      'Passes org_id in requiredClaims to enforce it is present on the token',
+      GraderLevel.L4,
+    ),
+    judge(
+      'Does the code enforce that the org_id claim on the verified token matches "org_barkbook_acme" ' +
+        'and respond with a 403 (or equivalent rejection) when the claim is absent or does not match? ' +
+        'Simply requiring org_id to be present via requiredClaims is necessary but not sufficient - ' +
+        'the code must also compare the claim value against the expected org.',
+      GraderLevel.L4,
+    ),
+    judge(
+      'Does the code include the org_id from the verified token in the API response body so clients ' +
+        'can see which organization granted access?',
+      GraderLevel.L4,
+    ),
+
+    // ── L5: Current API patterns ───────────────────────────────────────────
+    judge(
+      'Does the code rely exclusively on apiClient.verifyAccessToken to parse and validate the JWT - ' +
+        'i.e. it does NOT manually decode the token by splitting on ".", calling Buffer.from with base64, ' +
+        'importing jose directly, or using any JWT library other than what @auth0/auth0-api-js exposes? ' +
+        'The org_id claim must be read from the claims object returned by verifyAccessToken, not extracted ' +
+        'by hand from the raw token string.',
+      GraderLevel.L5,
+    ),
+
+    // ── Holistic judge (no level - always runs) ────────────────────────────
+    judge(
+      'Does the solution correctly add Auth0 Organizations support to the Express API using ' +
+        '@auth0/auth0-api-js - verifying access tokens with org_id in requiredClaims, rejecting tokens ' +
+        'that do not carry the org_barkbook_acme org_id claim with an appropriate error response, ' +
+        'and including the org_id in the API response? The domain and audience must be read from ' +
+        'environment variables rather than hardcoded.',
+    ),
+  ];
+}

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-api-js/auth0/.env.example
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-api-js/auth0/.env.example
@@ -1,0 +1,2 @@
+AUTH0_DOMAIN=dev-barkbook.us.auth0.com
+AUTH0_AUDIENCE=https://api.barkbook.com

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-api-js/auth0/package.json
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-api-js/auth0/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "barkbook-api",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "start": "node dist/server.js"
+  },
+  "dependencies": {
+    "@auth0/auth0-api-js": "^1.6.1",
+    "express": "^5.1.0"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.1",
+    "@types/node": "^22.13.0",
+    "typescript": "~5.8.3"
+  }
+}

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-api-js/auth0/src/auth0.ts
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-api-js/auth0/src/auth0.ts
@@ -1,0 +1,6 @@
+import { ApiClient } from '@auth0/auth0-api-js';
+
+export const apiClient = new ApiClient({
+  domain: process.env.AUTH0_DOMAIN as string,
+  audience: process.env.AUTH0_AUDIENCE as string,
+});

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-api-js/auth0/src/server.ts
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-api-js/auth0/src/server.ts
@@ -1,0 +1,48 @@
+import express from 'express';
+import type { Request, Response } from 'express';
+import { apiClient } from './auth0.js';
+
+const app = express();
+app.use(express.json());
+
+function getBearerToken(req: Request): string | null {
+  const header = req.headers.authorization;
+  if (!header?.toLowerCase().startsWith('bearer ')) return null;
+  return header.slice('Bearer '.length).trim();
+}
+
+app.get('/api/balance', async (request: Request, response: Response) => {
+  const accessToken = getBearerToken(request);
+
+  if (!accessToken) {
+    response.status(401).json({ error: 'Missing Bearer token' });
+    return;
+  }
+
+  try {
+    const claims = await apiClient.verifyAccessToken({ accessToken });
+    response.json({ balance: 4200, sub: claims.sub });
+  } catch (error) {
+    response.status(401).json({ error: (error as Error).message });
+  }
+});
+
+app.post('/api/transfers', async (request: Request, response: Response) => {
+  const accessToken = getBearerToken(request);
+
+  if (!accessToken) {
+    response.status(401).json({ error: 'Missing Bearer token' });
+    return;
+  }
+
+  try {
+    const claims = await apiClient.verifyAccessToken({ accessToken });
+    const { amount, to } = request.body ?? {};
+    response.status(201).json({ transferred: amount, to, sub: claims.sub });
+  } catch (error) {
+    response.status(401).json({ error: (error as Error).message });
+  }
+});
+
+const port = process.env.PORT ?? 3001;
+app.listen(port, () => console.log(`Barkbook API listening on http://localhost:${port}`));

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-api-js/auth0/tsconfig.json
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-api-js/auth0/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "moduleDetection": "force",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description
- Adds Organisation evals for `auth0-api-js`. 
- Adds a scaffold app for evals.

### References

### Testing


- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
