### PR TITLE
feat(evals): Adds Organisation evals for auth0-server-js

### DIFF
--- a/apps/auth0-evals/src/evals/organizations/auth0-server-js/PROMPT.md
+++ b/apps/auth0-evals/src/evals/organizations/auth0-server-js/PROMPT.md
@@ -1,0 +1,18 @@
+---
+id: auth0_server_js_organizations
+name: auth0-server-js Organizations Login
+scaffold: src/evals/scaffolds/auth0-server-js/auth0
+skills: auth0
+setup_command: npm install
+compile_command: npm run build
+---
+
+## Task
+
+Our Express web app already has Auth0 login working via `@auth0/auth0-server-js`. Add Auth0
+Organizations support: log users in to our "Acme" org (`org_barkbook_acme`), accept organization
+invitation links, handle `OrganizationValidationError` when org claim validation fails, and show which organization the signed-in user belongs to.
+
+Domain: dev-barkbook.us.auth0.com
+Client ID: barkbook_client_abc123xyz
+Audience: https://api.barkbook.com

--- a/apps/auth0-evals/src/evals/organizations/auth0-server-js/graders.ts
+++ b/apps/auth0-evals/src/evals/organizations/auth0-server-js/graders.ts
@@ -1,0 +1,103 @@
+import {
+  contains,
+  notContains,
+  notContainsInSource,
+  matches,
+  judge,
+  compiles,
+  GraderLevel,
+} from '@a0/evals-graders';
+
+export function defineGraders() {
+  return [
+    // ── L1: Required Organizations symbols present ─────────────────────────
+    contains('organization', 'Passes the organization parameter for org-scoped login', GraderLevel.L1),
+    contains('org_barkbook_acme', 'Wires the specific Acme org (org_barkbook_acme)', GraderLevel.L1),
+    contains('invitation', 'Handles the organization invitation parameter', GraderLevel.L1),
+    contains('org_id', 'Reads the org_id claim to identify the logged-in organization', GraderLevel.L1),
+    contains('startInteractiveLogin', 'Uses startInteractiveLogin to initiate org-scoped login', GraderLevel.L1),
+
+    // ── L2: Hallucination / wrong SDK ─────────────────────────────────────
+    notContains('@auth0/organizations', 'No hallucinated @auth0/organizations package', GraderLevel.L2),
+    notContains('@auth0/auth0-react', 'No React SDK in a Node.js web app', GraderLevel.L2),
+    notContains(
+      'useOrganization(',
+      'No non-existent useOrganization hook (auth0-server-js is not hook-based)',
+      GraderLevel.L2,
+    ),
+    notContains(
+      'express-openid-connect',
+      'No express-openid-connect (wrong SDK - app uses @auth0/auth0-server-js)',
+      GraderLevel.L2,
+    ),
+    notContains('@auth0/auth0-auth-js', 'No low-level auth0-auth-js (wrong SDK for this web app)', GraderLevel.L2),
+
+    // ── L3: Security ───────────────────────────────────────────────────────
+    notContainsInSource(
+      'dev-barkbook.us.auth0.com',
+      'No hardcoded domain in source files (ok in .env)',
+      GraderLevel.L3,
+    ),
+    notContainsInSource(
+      'barkbook_client_abc123xyz',
+      'No hardcoded client ID in source files (ok in .env)',
+      GraderLevel.L3,
+    ),
+
+    // ── L4: Structural correctness ─────────────────────────────────────────
+    compiles('Project compiles (tsc succeeds)', GraderLevel.L4),
+    matches(
+      String.raw`startInteractiveLogin[\s\S]{0,200}organization`,
+      'Passes organization to startInteractiveLogin for org-scoped login',
+      GraderLevel.L4,
+    ),
+    judge(
+      'Does the code read the "invitation" and "organization" parameters from the request URL query ' +
+        'string and forward them to startInteractiveLogin (as the "invitation" and "organization" options) ' +
+        'when both are present? PASS when the code forwards both params to startInteractiveLogin and does ' +
+        "not reject an invitation solely because its organization differs from the app's default org. " +
+        'Grounding facts you MUST apply: Auth0 invitation links always carry both an `invitation` and an ' +
+        '`organization` parameter, and the SDK requires `organization` whenever `invitation` is set ' +
+        '(startInteractiveLogin/completeInteractiveLogin throws otherwise). Therefore returning an error ' +
+        '(e.g. a 400) when an `invitation` arrives WITHOUT an `organization` param is CORRECT handling of a ' +
+        'malformed link - it is the SDK-required precondition, NOT a defect, and MUST NOT cause a fail. ' +
+        'Fail ONLY if the code ignores/drops the params, or rejects an invitation whose organization merely ' +
+        "differs from the app's configured default org.",
+      GraderLevel.L4,
+    ),
+    judge(
+      'Does the code handle OrganizationValidationError (imported from @auth0/auth0-server-js) in the ' +
+        'callback route - i.e. catch errors thrown by completeInteractiveLogin and check whether the error ' +
+        'is an instanceof OrganizationValidationError, then respond appropriately?',
+      GraderLevel.L4,
+    ),
+    judge(
+      'Does the code surface the organization the user logged into by reading the org_id claim from the ' +
+        'session user (e.g. user.org_id obtained via serverClient.getUser), rather than hardcoding or guessing it?',
+      GraderLevel.L4,
+    ),
+
+    // ── L5: Current API patterns ───────────────────────────────────────────
+    judge(
+      'Does the code use current @auth0/auth0-server-js APIs - passing organization as a first-class ' +
+        'option to startInteractiveLogin (not inside authorizationParams alone) or as the client-wide ' +
+        '"organization" config key on ServerClient? Also confirm it does not use any removed or deprecated ' +
+        'patterns such as initAuth0, handleAuth, or withPageAuthRequired from next-auth packages.',
+      GraderLevel.L5,
+    ),
+
+    // ── Holistic judge (no level - always runs) ────────────────────────────
+    judge(
+      'Does the solution correctly add Auth0 Organizations support to the Express web app using ' +
+        '@auth0/auth0-server-js - logging users into the specified organization (org_barkbook_acme) via ' +
+        'the organization option on startInteractiveLogin, accepting organization invitation links by ' +
+        'forwarding invitation and organization query params, handling OrganizationValidationError on ' +
+        'completeInteractiveLogin, and identifying the logged-in organization from the org_id claim on ' +
+        'the session user? Auth0 invitation links always carry both an `invitation` and an ' +
+        '`organization` parameter, and the SDK requires `organization` whenever `invitation` is set, so ' +
+        'requiring or validating the organization param when an invitation is present is correct and must ' +
+        'not be penalised. The only invitation-related correctness defect is rejecting a valid invitation ' +
+        'because its organization differs from the configured default - treat that as a failure.',
+    ),
+  ];
+}

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-server-js/auth0/.env.example
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-server-js/auth0/.env.example
@@ -1,0 +1,6 @@
+AUTH0_DOMAIN=dev-barkbook.us.auth0.com
+AUTH0_CLIENT_ID=barkbook_client_abc123xyz
+AUTH0_CLIENT_SECRET=barkbook_secret_def456uvw
+AUTH0_AUDIENCE=https://api.barkbook.com
+AUTH0_SESSION_SECRET=a-long-secret-value-for-local-dev-only
+APP_BASE_URL=http://localhost:3000

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-server-js/auth0/package.json
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-server-js/auth0/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "@auth0/auth0-server-js": "^1.12.1",
     "cookie-parser": "^1.4.7",
-    "dotenv": "^16.4.7",
     "express": "^5.1.0",
     "express-rate-limit": "^8.6.2"
   },

--- a/apps/auth0-evals/src/evals/scaffolds/auth0-server-js/auth0/src/index.ts
+++ b/apps/auth0-evals/src/evals/scaffolds/auth0-server-js/auth0/src/index.ts
@@ -1,4 +1,3 @@
-import 'dotenv/config';
 import cookieParser from 'cookie-parser';
 import express from 'express';
 import { rateLimit } from 'express-rate-limit';


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description
- Adds Organisation evals for `auth0-server-js`


### References

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an Auth0 Organizations evaluation covering organization login, invitation acceptance, validation errors, and displaying the signed-in user’s organization.
  - Added configuration examples for Auth0 domain, client credentials, audience, session secret, and application URL.

- **Tests**
  - Added automated checks for required organization flows, SDK usage, configuration handling, compilation, and overall solution correctness.

- **Chores**
  - Removed the scaffold’s automatic environment-variable loading through dotenv.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->