### PR TITLE
fix(evals): align MFA graders to SDK example step-up flows

### DIFF
--- a/apps/auth0-evals/src/evals/mfa/android/PROMPT.md
+++ b/apps/auth0-evals/src/evals/mfa/android/PROMPT.md
@@ -7,7 +7,7 @@ skills: auth0
 
 ## Task
 
-My Android app already has Auth0 login working through Universal Login. I want to add a Transfer Funds action where users must complete MFA before the transfer runs. If they haven't done MFA yet, prompt them for it.
+My Android app signs users in against a database connection with the Authentication API (`AuthenticationAPIClient`). Accounts with MFA enabled don't return credentials on login — the login call fails with an "MFA required" error instead. I need to handle that in-app: read the `mfaToken` off the error, then complete MFA through the SDK's MFA API — challenge an enrolled authenticator and verify the one-time code (enrolling a factor first if the user has none) — so login finishes and the credentials are stored.
 
 Domain: dev-barkbook.us.auth0.com
 Client ID: barkbook_client_abc123xyz

--- a/apps/auth0-evals/src/evals/mfa/android/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/android/graders.ts
@@ -2,36 +2,26 @@ import { contains, notContains, notContainsInSource, matches, judge, GraderLevel
 
 export function defineGraders() {
   return [
-    // ── L1: Required MFA step-up symbols present ───────────────────────────
-    contains('acr_values', 'Step-up request uses acr_values parameter', GraderLevel.L1),
-    contains('amr', 'AMR claim checked to detect prior MFA completion', GraderLevel.L1),
-    contains(
-      'schemas.openid.net/pape/policies/2007/06/multi-factor',
-      'Uses correct multi-factor acr_values policy URI',
+    // ── L1: Required MFA-API symbols present ───────────────────────────────
+    matches(
+      String.raw`isMultifactorRequired|mfaRequiredErrorPayload`,
+      'Detects the MFA-required signal on the AuthenticationException',
       GraderLevel.L1,
     ),
-    contains('withParameters', 'Passes acr_values through WebAuthProvider withParameters', GraderLevel.L1),
-    // The SDK surfaces custom claims through UserProfile.getExtraInfo(); the separate
-    // com.auth0.android:jwtdecode library is an equally valid way to read amr.
+    contains('mfaToken', 'Reads the mfa_token off the error', GraderLevel.L1),
     matches(
-      String.raw`getExtraInfo\(\)|com\.auth0\.android:jwtdecode`,
-      'Reads ID token claims via UserProfile.getExtraInfo() or the jwtdecode library',
+      String.raw`mfaClient|MfaApiClient`,
+      'Drives the flow through the SDK MFA API client (authentication.mfaClient(mfaToken))',
       GraderLevel.L1,
     ),
 
     // ── L2: Hallucination / wrong approach ────────────────────────────────
     notContains('auth0-java', 'No auth0-java (server-side SDK, not for Android)', GraderLevel.L2),
-    // Auth0.Android has no Credentials.claims property — claims come from credentials.user.
-    notContains('credentials.claims', 'No hallucinated Credentials.claims property', GraderLevel.L2),
-    // Every embedded-MFA path carries the mfa_token, whether or not the
-    // MfaApiClient type is ever named.
     notContains(
-      'mfaToken',
-      'Does not use the embedded MFA grant (MfaApiClient) — wrong approach for a Universal Login app',
+      'mfa/challenge',
+      'Does not hand-roll the raw /mfa/challenge endpoint — use the SDK MFA client',
       GraderLevel.L2,
-      { caseSensitive: false },
     ),
-    notContains('mfa/challenge', 'Does not call the raw MFA challenge endpoint', GraderLevel.L2),
 
     // ── L3: Security ──────────────────────────────────────────────────────
     notContainsInSource(
@@ -47,43 +37,39 @@ export function defineGraders() {
     judge(
       'Does the code let SecureCredentialsManager (or CredentialsManager) handle token storage rather than ' +
         'persisting Auth0 tokens (access tokens, ID tokens, refresh tokens) by hand in SharedPreferences? ' +
-        'Storing application state such as a pending transfer is acceptable — only manual token storage is a violation.',
+        'Storing application state is acceptable — only manual token storage is a violation.',
       GraderLevel.L3,
     ),
 
     // ── L4: Structural correctness ────────────────────────────────────────
     judge(
-      'Does the code check the amr claim before executing the transfer action, and only proceed when ' +
-        '"mfa" is present in the amr array? Reading amr via credentials.user.getExtraInfo()["amr"] or via ' +
-        'the com.auth0.android:jwtdecode library are both acceptable.',
+      'Does the code catch the MFA-required error from the Authentication API login (isMultifactorRequired / ' +
+        'mfaRequiredErrorPayload), read the mfaToken, and drive the MFA API flow through ' +
+        'authentication.mfaClient(mfaToken) — challenging an enrolled factor and verifying the code (enrolling ' +
+        'one first when the user has none) — before the login is treated as complete?',
       GraderLevel.L4,
     ),
     judge(
-      'When MFA is missing, is step-up performed by launching a new WebAuthProvider.login(...) — with ' +
-        'withScheme and the MFA acr_values — rather than by calling the Authentication API MFA endpoints ' +
-        '(challenge/verify) directly?',
+      'After a successful verify, does the code store the returned Credentials via the ' +
+        'SecureCredentialsManager/CredentialsManager, rather than calling the raw /mfa endpoints directly or ' +
+        'managing the returned tokens by hand?',
       GraderLevel.L4,
     ),
 
     // ── L5: Current API patterns ──────────────────────────────────────────
     judge(
-      'Does the step-up request force fresh authentication with a max_age of 0, so a cached session is not ' +
-        'reused? Either the dedicated withMaxAge(0) builder or a "max_age" entry inside withParameters(...) counts.',
-      GraderLevel.L5,
-    ),
-    judge(
-      'Is the step-up request built with the current v2+ builder API — WebAuthProvider.login(account) ' +
-        'with withScheme and withParameters/withMaxAge — rather than by hand-building an /authorize URL ' +
-        'or using the removed WebAuthProvider.init entry point?',
+      'Does the solution use the SDK MFA client API — authentication.mfaClient(mfaToken) with ' +
+        'getAuthenticators / challenge / verify — rather than hand-building /oauth/token MFA-grant HTTP ' +
+        'requests or the removed WebAuthProvider.init entry point?',
       GraderLevel.L5,
     ),
 
     // ── Holistic judge (no level — always runs) ───────────────────────────
     judge(
-      'Does the solution correctly implement MFA step-up authentication in an Android app — reading the amr ' +
-        'claim from the ID token (via credentials.user.getExtraInfo() or the jwtdecode library), requesting ' +
-        'step-up through WebAuthProvider.login with acr_values and max_age 0 when MFA is not present, and ' +
-        'gating the Transfer Funds action behind MFA verification?',
+      'Does the solution correctly complete MFA at login in an Android app using Auth0.Android’s MFA API — ' +
+        'detecting the MFA-required error, reading the mfaToken, challenging (or enrolling) a factor and ' +
+        'verifying the code through authentication.mfaClient(...), and storing the resulting credentials so ' +
+        'the user finishes signing in?',
     ),
   ];
 }

--- a/apps/auth0-evals/src/evals/mfa/angular/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/angular/graders.ts
@@ -1,11 +1,11 @@
-import { contains, notContains, matches, judge, compiles, GraderLevel } from '@a0/evals-graders';
+import { contains, notContains, judge, compiles, GraderLevel } from '@a0/evals-graders';
 
 export function defineGraders() {
   return [
     // ── L1: Required step-up symbols present ───────────────────────────
-    matches(
-      String.raw`interactiveErrorHandler|acr_values`,
-      'Step-up configured via interactiveErrorHandler (SDK default) or acr_values (manual approach)',
+    contains(
+      'interactiveErrorHandler',
+      'Step-up configured via interactiveErrorHandler ("popup") — the pattern the SDK examples teach',
       GraderLevel.L1,
     ),
     contains(
@@ -43,19 +43,14 @@ export function defineGraders() {
     ),
 
     // ── L5: Current API patterns ──────────────────────────────────────────
-    judge(
-      'Is interactiveErrorHandler set to "popup" in the provideAuth0 configuration? ' +
-        '(If using the manual acr_values approach instead, are acr_values ' +
-        'and max_age: 0 passed inside authorizationParams on loginWithRedirect?)',
-      GraderLevel.L5,
-    ),
+    judge('Is interactiveErrorHandler set to "popup" in the provideAuth0 configuration?', GraderLevel.L5),
 
     // ── Holistic judge (no level — always runs) ───────────────────────────
     judge(
       'Does the solution correctly implement MFA step-up authentication in an Angular app using ' +
-        '@auth0/auth0-angular — either by configuring interactiveErrorHandler: "popup" ' +
+        '@auth0/auth0-angular — by configuring interactiveErrorHandler: "popup" ' +
         'so that getAccessTokenSilently automatically triggers an MFA popup ' +
-        'when the API requires it, or by explicitly requesting step-up via acr_values — and gating ' +
+        'when the API requires it — and gating ' +
         'the Transfer Funds action behind successful MFA completion?',
     ),
   ];

--- a/apps/auth0-evals/src/evals/mfa/auth0-server-js/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/auth0-server-js/graders.ts
@@ -14,7 +14,7 @@ export function defineGraders() {
     contains('barcodeUri', 'Surfaces the OTP barcodeUri for QR enrollment', GraderLevel.L1),
     contains('oobCode', 'Carries the oobCode returned by an SMS challenge', GraderLevel.L1),
     contains('bindingCode', 'Verifies the SMS factor with the bindingCode', GraderLevel.L1),
-    contains('recoveryCode', 'Surfaces the recovery code returned by enrollment', GraderLevel.L1),
+    contains('recoveryCode', 'Surfaces the recovery code returned by mfa.verify on first enrollment', GraderLevel.L1),
 
     // ── L2: Hallucination / wrong approach ────────────────────────────────
     // ServerMfaClient has only listAuthenticators, enrollAuthenticator, challengeAuthenticator

--- a/apps/auth0-evals/src/evals/mfa/express-api/PROMPT.md
+++ b/apps/auth0-evals/src/evals/mfa/express-api/PROMPT.md
@@ -9,16 +9,14 @@ compile_command: node --check server.js
 
 ## Task
 
-My Express API validates Auth0 JWT access tokens with `express-oauth2-jwt-bearer`. I need to gate the `POST /api/transfers` route behind MFA step-up: only callers whose access token contains `"mfa"` in the `amr` claim may execute a transfer.
+My Express API validates Auth0 JWT access tokens with `express-oauth2-jwt-bearer`. Transfers are a high-value action, so my tenant is configured to issue the `transfer:funds` scope only after the user completes MFA step-up. The API does not run MFA itself — its job is to enforce that only stepped-up callers can transfer, by requiring that scope.
 
 Domain: dev-barkbook.us.auth0.com
 Audience: https://api.barkbook.com
 
 Requirements:
-- Protect `POST /api/transfers` so that requests where `amr` does not include `"mfa"` are rejected with a `403` response and a JSON body containing `code: "mfa_required"`.
+- Gate `POST /api/transfers` on the `transfer:funds` scope so that a caller whose token lacks it is rejected (the SDK returns a `403` `insufficient_scope`). This is the step-up gate.
+- Keep the existing `write:transfers` scope check on `POST /api/transfers`.
 - Keep the existing `read:balance` scope check on `GET /api/balance` working.
-- Keep the existing `write:transfers` scope check on `POST /api/transfers` working (MFA check comes on top of it).
-
-Note: Auth0 requires a custom Action to add the `amr` claim to access tokens. Assume the tenant already has this Action configured.
 
 There is a `.env.example` in the project — create the real `.env` from it with the values above.

--- a/apps/auth0-evals/src/evals/mfa/express-api/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/express-api/graders.ts
@@ -2,10 +2,10 @@ import { contains, notContains, notContainsInSource, judge, wroteFile, compiles,
 
 export function defineGraders() {
   return [
-    // ── L1: Required MFA step-up symbols present ──────────────────────────
+    // ── L1: Required step-up symbols present ──────────────────────────────
     contains('express-oauth2-jwt-bearer', 'Uses express-oauth2-jwt-bearer SDK', GraderLevel.L1),
-    contains('amr', 'AMR claim referenced to detect MFA completion', GraderLevel.L1),
-    contains('mfa_required', 'Returns mfa_required error code on step-up failure', GraderLevel.L1),
+    contains('requiredScopes', 'Enforces the scope with the SDK requiredScopes middleware', GraderLevel.L1),
+    contains('transfer:funds', 'Gates the transfer on the step-up scope transfer:funds', GraderLevel.L1),
 
     // ── L2: Hallucination / wrong approach ───────────────────────────────
     notContains('jsonwebtoken', 'No manual JWT decoding with jsonwebtoken', GraderLevel.L2),
@@ -13,13 +13,6 @@ export function defineGraders() {
     notContains('otplib', 'No server-side TOTP library (otplib)', GraderLevel.L2),
     notContains('@auth0/guardian', 'No fake Guardian server SDK', GraderLevel.L2),
     notContains('mfa/challenge', 'Does not call the raw MFA challenge endpoint', GraderLevel.L2),
-    // The amr check must be on payload — req.auth.amr is the express-jwt (not
-    // express-oauth2-jwt-bearer) path; the correct path is req.auth.payload.amr.
-    notContains(
-      'req.auth.amr',
-      'Does not read amr from req.auth.amr (express-jwt path) — correct path is req.auth.payload.amr',
-      GraderLevel.L2,
-    ),
 
     // ── L3: Security checks ──────────────────────────────────────────────
     notContainsInSource(
@@ -35,31 +28,26 @@ export function defineGraders() {
       'api.barkbook.com',
     ]),
     compiles('Project compiles (node --check succeeds)', GraderLevel.L4),
-    contains('requiredScopes', 'Existing requiredScopes() scope checks retained', GraderLevel.L4),
-    // Grade the outcome (a 403 on the gated route), not the exact call shape — a solution may
-    // send the 403 through res.status(403), next(err) into an error handler, or a helper.
+    contains('read:balance', 'Existing read:balance scope check on GET /api/balance retained', GraderLevel.L4),
+    // Grade the outcome (the transfer is gated on the step-up scope), not the exact call shape — a solution
+    // may require the scope with a second requiredScopes call, a combined requiredScopes('write:transfers',
+    // 'transfer:funds'), or a claimCheck on the scope claim.
     judge(
-      'When a token whose amr does not include "mfa" calls POST /api/transfers, does the API respond ' +
-        'with HTTP 403 and code: "mfa_required" — regardless of whether that response is produced by ' +
-        'res.status(403), next(err) into an error handler, or a helper?',
+      'Does POST /api/transfers require the transfer:funds scope so a token that lacks it is rejected — ' +
+        'while the existing write:transfers requirement is retained — using the SDK (requiredScopes, or a ' +
+        'claimCheck/claimIncludes on the scope claim) rather than proceeding with the transfer?',
       GraderLevel.L4,
     ),
     judge(
-      'Does the code read the amr claim from req.auth.payload.amr (not req.auth.amr, which is the ' +
-        'express-jwt path), check whether it includes "mfa", and return a 403 with code: "mfa_required" ' +
-        'when MFA has not been completed?',
+      'Is the transfer:funds gate applied specifically to POST /api/transfers (not globally or to ' +
+        'GET /api/balance), and does read:balance scope enforcement still apply to GET /api/balance?',
       GraderLevel.L4,
     ),
     judge(
-      'Is the MFA check applied specifically to POST /api/transfers (not globally or only to ' +
-        'GET /api/balance), and does write:transfers scope enforcement still apply to that route?',
-      GraderLevel.L4,
-    ),
-    judge(
-      'Does the MFA middleware run AFTER checkJwt in the route middleware chain for POST /api/transfers? ' +
-        'The amr claim is only available on req.auth.payload after checkJwt has validated the token — ' +
-        'if the MFA check is registered before checkJwt, req.auth is undefined and every request is ' +
-        'rejected with a 403 regardless of whether the caller completed MFA.',
+      'Does the scope-checking middleware run AFTER checkJwt in the route middleware chain for ' +
+        'POST /api/transfers? The scope claim is only available on req.auth.payload after checkJwt has ' +
+        'validated the token — if the scope check is registered before checkJwt, req.auth is undefined and ' +
+        'every request is rejected regardless of the scopes the caller actually holds.',
       GraderLevel.L4,
     ),
 
@@ -69,23 +57,23 @@ export function defineGraders() {
       'No req.user (express-oauth2-jwt-bearer exposes claims on req.auth.payload)',
       GraderLevel.L5,
     ),
-    // The required outcome is a 403 mfa_required; claimIncludes("amr","mfa") returns 401
-    // invalid_token, so it fails the outcome — but any path that yields the 403 is acceptable.
+    // requiredScopes / claimCheck raise the SDK's own 403 insufficient_scope — the pattern the SDK
+    // examples teach. Manually parsing the space-delimited scope string or hand-decoding the JWT is the
+    // deprecated path this check rules out.
     judge(
-      'Does the MFA check ultimately return a 403 with code: "mfa_required" (not a 401 invalid_token) ' +
-        'when amr lacks "mfa"? Any implementation that yields that 403 is acceptable — custom ' +
-        'middleware reading req.auth.payload.amr is the natural fit, but the grade is on the 403 ' +
-        'mfa_required outcome, not on avoiding a specific API.',
+      'Does the solution enforce the scope through the SDK — requiredScopes, or claimCheck/claimIncludes ' +
+        'reading the scope claim off req.auth.payload — rather than manually splitting the space-delimited ' +
+        'scope string or hand-decoding the access token?',
       GraderLevel.L5,
     ),
 
     // ── Holistic judge (no level — always runs) ───────────────────────────
     judge(
-      'Does the solution correctly add MFA step-up enforcement to the Express API using ' +
-        'express-oauth2-jwt-bearer? POST /api/transfers must be gated behind both the write:transfers ' +
-        'scope check and an amr check that returns 403 with code: "mfa_required" when the token does ' +
-        'not include "mfa" in the amr claim. GET /api/balance must still require read:balance. ' +
-        'The amr claim must be read from req.auth.payload.amr. The issuer and audience may come from ' +
+      'Does the solution correctly add step-up enforcement to the Express API using ' +
+        'express-oauth2-jwt-bearer? POST /api/transfers must be gated on the transfer:funds scope — the ' +
+        'scope the tenant issues only after MFA step-up — so a token without it is rejected with the SDK’s ' +
+        '403 insufficient_scope, while the existing write:transfers check is retained. GET /api/balance must ' +
+        'still require read:balance. Claims are read from req.auth.payload, and issuer/audience come from ' +
         'ISSUER_BASE_URL / AUDIENCE environment variables — judge only from source code.',
     ),
   ];

--- a/apps/auth0-evals/src/evals/mfa/express-api/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/express-api/graders.ts
@@ -1,13 +1,4 @@
-import {
-  contains,
-  notContains,
-  notContainsInSource,
-  matches,
-  judge,
-  wroteFile,
-  compiles,
-  GraderLevel,
-} from '@a0/evals-graders';
+import { contains, notContains, notContainsInSource, judge, wroteFile, compiles, GraderLevel } from '@a0/evals-graders';
 
 export function defineGraders() {
   return [
@@ -45,11 +36,12 @@ export function defineGraders() {
     ]),
     compiles('Project compiles (node --check succeeds)', GraderLevel.L4),
     contains('requiredScopes', 'Existing requiredScopes() scope checks retained', GraderLevel.L4),
-    // The MFA check must respond with HTTP 403, not 401. claimIncludes returns 401
-    // (invalid_token), so the correct approach is custom middleware with res.status(403).
-    matches(
-      String.raw`res\.status\s*\(\s*403\s*\)`,
-      'MFA step-up failure responds with HTTP 403',
+    // Grade the outcome (a 403 on the gated route), not the exact call shape — a solution may
+    // send the 403 through res.status(403), next(err) into an error handler, or a helper.
+    judge(
+      'When a token whose amr does not include "mfa" calls POST /api/transfers, does the API respond ' +
+        'with HTTP 403 and code: "mfa_required" — regardless of whether that response is produced by ' +
+        'res.status(403), next(err) into an error handler, or a helper?',
       GraderLevel.L4,
     ),
     judge(
@@ -77,13 +69,13 @@ export function defineGraders() {
       'No req.user (express-oauth2-jwt-bearer exposes claims on req.auth.payload)',
       GraderLevel.L5,
     ),
-    // Using claimIncludes for the amr check is wrong here because it returns 401
-    // invalid_token instead of the required 403 mfa_required. Flag it.
+    // The required outcome is a 403 mfa_required; claimIncludes("amr","mfa") returns 401
+    // invalid_token, so it fails the outcome — but any path that yields the 403 is acceptable.
     judge(
-      'Does the solution use custom middleware (rather than claimIncludes) for the MFA check, so ' +
-        'that the response is a 403 with code: "mfa_required" rather than a 401 invalid_token? ' +
-        'claimIncludes("amr", "mfa") would silently return 401 — the correct pattern reads ' +
-        'req.auth.payload.amr in its own middleware and responds with 403.',
+      'Does the MFA check ultimately return a 403 with code: "mfa_required" (not a 401 invalid_token) ' +
+        'when amr lacks "mfa"? Any implementation that yields that 403 is acceptable — custom ' +
+        'middleware reading req.auth.payload.amr is the natural fit, but the grade is on the 403 ' +
+        'mfa_required outcome, not on avoiding a specific API.',
       GraderLevel.L5,
     ),
 

--- a/apps/auth0-evals/src/evals/mfa/express-oidc/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/express-oidc/graders.ts
@@ -4,7 +4,6 @@ export function defineGraders() {
   return [
     // ── L1: Required MFA step-up symbols present ───────────────────────────
     contains('acr_values', 'Step-up request uses acr_values parameter', GraderLevel.L1),
-    contains('amr', 'AMR claim checked to detect prior MFA completion', GraderLevel.L1),
     contains('idTokenClaims', 'Reads claims from req.oidc.idTokenClaims (server-side)', GraderLevel.L1),
     contains('oidc.login', 'Triggers step-up via res.oidc.login()', GraderLevel.L1),
 
@@ -13,11 +12,7 @@ export function defineGraders() {
     notContains('otplib', 'No server-side TOTP library (otplib) used', GraderLevel.L2),
     notContains('@auth0/guardian', 'No fake Guardian client SDK referenced', GraderLevel.L2),
     notContains('mfa/challenge', 'Does not call raw MFA challenge endpoint directly', GraderLevel.L2),
-    notContains(
-      'loginWithRedirect',
-      'Does not use SPA loginWithRedirect in a server-side Express app',
-      GraderLevel.L2,
-    ),
+    notContains('loginWithRedirect', 'Does not use SPA loginWithRedirect in a server-side Express app', GraderLevel.L2),
 
     // ── L3: Security checks ──────────────────────────────────────────────────
     notContainsInSource(
@@ -45,7 +40,7 @@ export function defineGraders() {
     // ── L4: Structural / behavioral correctness ───────────────────────────────
     compiles('Project passes syntax check (node --check)', GraderLevel.L4),
     judge(
-      'Does the code check the amr claim on req.oidc.idTokenClaims to detect whether the ' +
+      'Does the code check the amr (or acr) claim on req.oidc.idTokenClaims to detect whether the ' +
         'current session reflects completed MFA (e.g. amr includes "mfa") before allowing ' +
         'the transfer to proceed?',
       GraderLevel.L4,

--- a/apps/auth0-evals/src/evals/mfa/nextjs/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/nextjs/graders.ts
@@ -3,11 +3,10 @@ import { contains, notContains, notContainsInSource, judge, compiles, GraderLeve
 export function defineGraders() {
   return [
     // ── L1: Required MFA step-up symbols present ───────────────────────────
-    contains('acr_values', 'Step-up request uses acr_values parameter', GraderLevel.L1),
-    contains('amr', 'AMR claim checked to detect prior MFA completion', GraderLevel.L1),
+    contains('MfaRequiredError', 'Detects the mfa_required signal via MfaRequiredError', GraderLevel.L1),
     contains(
-      'schemas.openid.net/pape/policies/2007/06/multi-factor',
-      'Uses correct multi-factor acr_values policy URI',
+      'getAccessToken',
+      'Requests the access token via getAccessToken to trigger the MFA challenge',
       GraderLevel.L1,
     ),
 
@@ -23,7 +22,7 @@ export function defineGraders() {
     ),
     notContains(
       'getIdTokenClaims',
-      'Does not use React SPA getIdTokenClaims — reads amr via server session',
+      'Does not use the React SPA getIdTokenClaims in a server-side Next.js app',
       GraderLevel.L2,
     ),
 
@@ -53,13 +52,15 @@ export function defineGraders() {
     // ── L4: Structural / behavioral correctness ───────────────────────────────
     compiles('Project compiles (build succeeds)', GraderLevel.L4),
     judge(
-      'Does the code read the amr claim from the server-side session (e.g. session.user.amr) ' +
-        'and check whether "mfa" is present in that array before allowing the transfer to proceed?',
+      'Does the code call getAccessToken (e.g. with { refresh: true }) for the sensitive operation and ' +
+        'catch the resulting MfaRequiredError to detect that step-up is required before allowing the ' +
+        'transfer to proceed?',
       GraderLevel.L4,
     ),
     judge(
-      'When the amr claim is missing or does not contain "mfa", does the code redirect the user ' +
-        'to /auth/login with acr_values set to the multi-factor policy URI and max_age set to 0?',
+      'When MfaRequiredError is raised, does the code drive the user through an MFA challenge — e.g. ' +
+        'mfa.challengeWithPopup() or a redirect to an /mfa-challenge route — rather than proceeding or ' +
+        'simply returning an error?',
       GraderLevel.L4,
     ),
 
@@ -67,19 +68,14 @@ export function defineGraders() {
     notContains('handleAuth', 'Does not use v3 handleAuth (v4 uses middleware)', GraderLevel.L5),
     notContains('/api/auth/', 'Does not use v3 route prefix /api/auth/ (v4 uses /auth/)', GraderLevel.L5),
     notContains('AUTH0_ISSUER_BASE_URL', 'Does not use v3 env var AUTH0_ISSUER_BASE_URL', GraderLevel.L5),
-    judge(
-      'Does the Auth0Client instantiation use the beforeSessionSaved hook to copy the amr claim ' +
-        'from the incoming session user object into the persisted session, so that amr is available ' +
-        'on subsequent calls to auth0.getSession()?',
-      GraderLevel.L5,
-    ),
 
     // ── Holistic judge (no level — always runs) ───────────────────────────
     judge(
       'Does the solution correctly implement MFA step-up authentication in a Next.js App Router app ' +
-        'using @auth0/nextjs-auth0 v4 — checking the amr claim to detect prior MFA completion, ' +
-        'redirecting to /auth/login with acr_values and max_age=0 when MFA is absent, ' +
-        'and gating the Transfer Funds action behind that verification?',
+        'using @auth0/nextjs-auth0 v4 — calling getAccessToken for the sensitive operation, catching ' +
+        'MfaRequiredError to detect that MFA is required, driving the user through an MFA challenge ' +
+        '(mfa.challengeWithPopup() or an /mfa-challenge redirect), and gating the Transfer Funds ' +
+        'action behind that verification?',
     ),
   ];
 }

--- a/apps/auth0-evals/src/evals/mfa/react/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/react/graders.ts
@@ -1,11 +1,11 @@
-import { contains, notContains, matches, judge, compiles, GraderLevel } from '@a0/evals-graders';
+import { contains, notContains, judge, compiles, GraderLevel } from '@a0/evals-graders';
 
 export function defineGraders() {
   return [
     // ── L1: Required step-up symbols present ───────────────────────────
-    matches(
-      String.raw`interactiveErrorHandler|acr_values`,
-      'Step-up configured via interactiveErrorHandler (SDK default) or acr_values (manual approach)',
+    contains(
+      'interactiveErrorHandler',
+      'Step-up configured via interactiveErrorHandler ("popup") — the pattern the SDK examples teach',
       GraderLevel.L1,
     ),
     contains(
@@ -32,33 +32,17 @@ export function defineGraders() {
     compiles('Project compiles (build succeeds)', GraderLevel.L4),
     judge(
       'Does the code gate the Transfer Funds action behind MFA step-up so the transfer cannot run ' +
-        'without MFA — either by calling getAccessTokenSilently for the sensitive scope so the SDK ' +
-        'triggers an interactiveErrorHandler popup when the API signals mfa_required, or by checking ' +
-        'the amr claim and requesting step-up via acr_values when "mfa" is not present?',
+        'without MFA — by calling getAccessTokenSilently for the sensitive scope so the SDK ' +
+        'triggers an interactiveErrorHandler popup when the API signals mfa_required?',
       GraderLevel.L4,
-    ),
-
-    // ── L5: Current API patterns ──────────────────────────────────────────
-    judge(
-      'If the code takes the manual acr_values approach, are acr_values and max_age: 0 passed inside ' +
-        'an authorizationParams object (rather than as top-level properties) on getAccessTokenSilently, ' +
-        'getAccessTokenWithPopup or loginWithRedirect? (Not applicable when relying on interactiveErrorHandler.)',
-      GraderLevel.L5,
-    ),
-    judge(
-      'If the code takes the manual acr_values approach, is the value the multi-factor policy URI ' +
-        'http://schemas.openid.net/pape/policies/2007/06/multi-factor rather than an invented or ' +
-        'misspelled value? (Not applicable when relying on interactiveErrorHandler.)',
-      GraderLevel.L5,
     ),
 
     // ── Holistic judge (no level — always runs) ───────────────────────────
     judge(
       'Does the solution correctly implement MFA step-up authentication in a React app using ' +
-        '@auth0/auth0-react — either by configuring interactiveErrorHandler: "popup" so that ' +
-        'getAccessTokenSilently automatically triggers an MFA popup when the API requires it, or by ' +
-        'explicitly requesting step-up via acr_values — and gating the Transfer Funds action behind ' +
-        'successful MFA completion?',
+        '@auth0/auth0-react — by configuring interactiveErrorHandler: "popup" so that ' +
+        'getAccessTokenSilently automatically triggers an MFA popup when the API requires it — ' +
+        'and gating the Transfer Funds action behind successful MFA completion?',
     ),
   ];
 }

--- a/apps/auth0-evals/src/evals/mfa/server-python/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/server-python/graders.ts
@@ -1,37 +1,19 @@
-import {
-  contains,
-  notContains,
-  notContainsInSource,
-  matches,
-  judge,
-  compiles,
-  GraderLevel,
-} from '@a0/evals-graders';
+import { contains, notContains, notContainsInSource, matches, judge, compiles, GraderLevel } from '@a0/evals-graders';
 
 export function defineGraders() {
   return [
     // ── L1: Required MFA step-up symbols present ───────────────────────────
-    contains('acr_values', 'Step-up login request uses the acr_values parameter', GraderLevel.L1),
-    contains('amr', 'AMR claim referenced to detect prior MFA completion', GraderLevel.L1, {
-      caseSensitive: false,
-    }),
-    contains(
-      'schemas.openid.net/pape/policies/2007/06/multi-factor',
-      'Uses the correct multi-factor acr_values policy URI',
-      GraderLevel.L1,
-    ),
-    contains(
-      'start_interactive_login',
-      'Triggers step-up via the SDK start_interactive_login method',
-      GraderLevel.L1,
-    ),
+    contains('MfaRequiredError', 'Detects the mfa_required signal via MfaRequiredError', GraderLevel.L1),
+    contains('mfa_token', 'Reads the MFA token off the error', GraderLevel.L1),
+    contains('list_authenticators', 'Lists enrolled authenticators', GraderLevel.L1),
+    contains('challenge_authenticator', 'Challenges an enrolled authenticator', GraderLevel.L1),
 
     // ── L2: Hallucination / wrong approach ────────────────────────────────
     notContains('pyotp', 'No server-side TOTP library (pyotp) — Auth0 performs the MFA', GraderLevel.L2),
     notContains('otplib', 'No JS TOTP library (otplib) — wrong ecosystem for this SDK', GraderLevel.L2),
     notContains(
       'mfa/challenge',
-      'Does not hand-roll the raw /mfa/challenge endpoint (wrong approach for a redirect web app)',
+      'Does not hand-roll the raw /mfa/challenge endpoint — use the SDK mfa client',
       GraderLevel.L2,
     ),
     notContains('jwt.decode', 'No manual JWT decoding — read claims through the SDK, not by hand', GraderLevel.L2),
@@ -67,37 +49,38 @@ export function defineGraders() {
       GraderLevel.L4,
     ),
     matches(
-      String.raw`start_interactive_login\s*\(\s*\{[^}]*authorization_params[^}]*acr_values`,
-      'Step-up authorization params are passed into start_interactive_login',
+      String.raw`verify\s*\([^)]*mfa_token`,
+      'Completes MFA through mfa.verify with the mfa_token from the error',
       GraderLevel.L4,
     ),
     judge(
-      'Does the code check the amr claim from the authenticated user (via the SDK — e.g. ' +
-        'get_user()/get_session() or the complete_interactive_login result) and only run the funds ' +
-        'transfer when "mfa" is present in amr, otherwise sending the user into step-up login first?',
+      'Does the code catch MfaRequiredError from the token request, read the mfa_token off the error, ' +
+        'and drive the MFA API flow (list_authenticators, then challenge_authenticator and verify) ' +
+        'before allowing the funds transfer to proceed?',
       GraderLevel.L4,
     ),
 
     // ── L5: Current API patterns ──────────────────────────────────────────
     judge(
-      'Does the code pass acr_values inside the authorization_params dict given to ' +
-        'start_interactive_login (e.g. start_interactive_login({"authorization_params": {...}})) ' +
-        'rather than as a top-level keyword argument?',
+      'For a user with no enrolled factor, does the code branch on the result of list_authenticators ' +
+        '(or the mfa_requirements on the error) — enrolling an authenticator when there is none and ' +
+        'challenging an existing one when there is — before calling verify?',
       GraderLevel.L5,
     ),
     judge(
-      'Does the code read the amr claim through the SDK session (get_user() or the ' +
-        'complete_interactive_login result) rather than manually decoding the raw ID/access token — ' +
-        "e.g. splitting the token on '.', base64-decoding a segment, or calling jwt.decode by hand?",
+      'Does the code persist the session after a successful mfa.verify (e.g. verify(..., persist=True) ' +
+        'or the SDK equivalent) so subsequent requests stay authenticated without repeating the MFA ' +
+        'flow, rather than manually decoding the raw token — e.g. base64-decoding a segment or calling ' +
+        'jwt.decode by hand?',
       GraderLevel.L5,
     ),
 
     // ── Holistic judge (no level — always runs) ───────────────────────────
     judge(
-      'Does the solution correctly implement MFA step-up in a framework-agnostic Python web app using ' +
-        'auth0-server-python — inspecting the amr claim to detect prior MFA, requesting step-up via ' +
-        'start_interactive_login with acr_values set to the multi-factor policy URI when MFA is absent, ' +
-        'and gating the Transfer Funds action behind MFA verification?',
+      'Does the solution correctly implement MFA API sign-in in a framework-agnostic Python web app ' +
+        'using auth0-server-python — detecting mfa_required via MfaRequiredError and reading the ' +
+        'mfa_token off the error, listing then challenging or enrolling the right factor, and finishing ' +
+        'through mfa.verify (persisting the session) so the Transfer Funds action is gated behind MFA?',
     ),
   ];
 }

--- a/apps/auth0-evals/src/evals/mfa/spa-js/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/spa-js/graders.ts
@@ -1,11 +1,11 @@
-import { contains, notContainsInSource, matches, judge, compiles, GraderLevel } from '@a0/evals-graders';
+import { contains, notContainsInSource, judge, compiles, GraderLevel } from '@a0/evals-graders';
 
 export function defineGraders() {
   return [
     // ── L1: Required step-up symbols present ───────────────────────────
-    matches(
-      String.raw`interactiveErrorHandler|acr_values`,
-      'Step-up configured via interactiveErrorHandler (SDK default) or acr_values (manual approach)',
+    contains(
+      'interactiveErrorHandler',
+      'Step-up configured via interactiveErrorHandler ("popup") — the pattern the SDK examples teach',
       GraderLevel.L1,
     ),
     contains('getTokenSilently', 'Access token requested via getTokenSilently to trigger step-up', GraderLevel.L1),
@@ -47,23 +47,7 @@ export function defineGraders() {
     ),
 
     // ── L5: Current API patterns ──────────────────────────────────────────
-    judge(
-      'Is interactiveErrorHandler set to "popup" in the createAuth0Client configuration? ' +
-        '(If using the manual acr_values approach instead, are acr_values ' +
-        'and max_age: 0 passed inside authorizationParams on loginWithPopup?)',
-      GraderLevel.L5,
-    ),
-    judge(
-      'If the code uses the proactive approach (acr_values), is the value the multi-factor ' +
-        'policy URI http://schemas.openid.net/pape/policies/2007/06/multi-factor rather than an ' +
-        'invented or misspelled value? (Not applicable when using interactiveErrorHandler.)',
-      GraderLevel.L5,
-    ),
-    judge(
-      'If the code passes acr_values or max_age, are they inside an authorizationParams object ' +
-        'rather than as top-level properties? (Not applicable when using interactiveErrorHandler.)',
-      GraderLevel.L5,
-    ),
+    judge('Is interactiveErrorHandler set to "popup" in the createAuth0Client configuration?', GraderLevel.L5),
     judge(
       'Does the solution use the auth0-spa-js v2 API — authorizationParams for auth parameters, ' +
         'camelCase clientId, and argument-less getIdTokenClaims() — rather than the v1 patterns ' +
@@ -75,9 +59,9 @@ export function defineGraders() {
     // ── Holistic judge (no level — always runs) ───────────────────────────
     judge(
       'Does the solution correctly implement MFA step-up authentication in a vanilla JavaScript SPA ' +
-        'using @auth0/auth0-spa-js — either by configuring interactiveErrorHandler: "popup" ' +
+        'using @auth0/auth0-spa-js — by configuring interactiveErrorHandler: "popup" ' +
         'so that getTokenSilently automatically triggers an MFA popup ' +
-        'when the API requires it, or by explicitly requesting step-up via acr_values — and gating ' +
+        'when the API requires it — and gating ' +
         'the Transfer Funds action behind successful MFA completion?',
     ),
   ];

--- a/apps/auth0-evals/src/evals/mfa/swift/PROMPT.md
+++ b/apps/auth0-evals/src/evals/mfa/swift/PROMPT.md
@@ -7,7 +7,7 @@ skills: auth0
 
 ## Task
 
-My iOS app already has Auth0 login working through Universal Login. I want to add a Transfer Funds action where users must complete MFA before the transfer runs. If they haven't done MFA yet, prompt them for it.
+My iOS app signs users in against a database connection with the Authentication API. Accounts with MFA enabled don't return credentials on login — the login call fails with an "MFA required" error instead. I need to handle that in-app: read the `mfaToken` off the error, then complete MFA through the SDK's MFA API — challenge an enrolled authenticator and verify the one-time code (enrolling a factor first if the user has none) — so login finishes and the credentials are stored.
 
 Domain: dev-barkbook.us.auth0.com
 Client ID: barkbook_client_abc123xyz

--- a/apps/auth0-evals/src/evals/mfa/swift/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/swift/graders.ts
@@ -2,33 +2,22 @@ import { contains, notContains, notContainsInSource, matches, judge, GraderLevel
 
 export function defineGraders() {
   return [
-    // ── L1: Required MFA step-up symbols present ───────────────────────────
-    contains('acr_values', 'Step-up request uses acr_values parameter', GraderLevel.L1),
-    contains('amr', 'AMR claim checked to detect prior MFA completion', GraderLevel.L1),
+    // ── L1: Required MFA-API symbols present ───────────────────────────────
     contains(
-      'schemas.openid.net/pape/policies/2007/06/multi-factor',
-      'Uses correct multi-factor acr_values policy URI',
+      'mfaRequiredErrorPayload',
+      'Detects the MFA-required signal via error.mfaRequiredErrorPayload',
       GraderLevel.L1,
     ),
-    // Auth0.swift exposes claims two legitimate ways: JWTDecode (a public
-    // dependency of the SDK) or CredentialsManager.userProfile()?.customClaims.
-    matches(
-      String.raw`decode\(jwt:|customClaims`,
-      'Reads ID token claims via JWTDecode or UserProfile.customClaims',
-      GraderLevel.L1,
-    ),
+    contains('mfaToken', 'Reads the mfa_token off the error', GraderLevel.L1),
+    matches(String.raw`\.mfa\(|MFAClient`, 'Drives the flow through the SDK MFA client (Auth0.mfa())', GraderLevel.L1),
 
     // ── L2: Hallucination / wrong approach ────────────────────────────────
     notContains('Auth0SDK', 'No hallucinated Auth0SDK package name (correct package is Auth0)', GraderLevel.L2),
-    // Every embedded-MFA path carries the mfa_token, whether or not the
-    // MFAClient type is ever named (Auth0.mfa().verify(otp:mfaToken:)).
     notContains(
-      'mfaToken',
-      'Does not use the embedded MFA grant (Auth0.mfa()/MFAClient) — wrong approach for a Universal Login app',
+      'mfa/challenge',
+      'Does not hand-roll the raw /mfa/challenge endpoint — use the SDK MFA client',
       GraderLevel.L2,
-      { caseSensitive: false },
     ),
-    notContains('mfa/challenge', 'Does not call the raw MFA challenge endpoint', GraderLevel.L2),
 
     // ── L3: Security ──────────────────────────────────────────────────────
     notContainsInSource(
@@ -44,45 +33,38 @@ export function defineGraders() {
     judge(
       'Does the code let CredentialsManager handle token storage rather than persisting Auth0 tokens ' +
         '(access tokens, ID tokens, refresh tokens) by hand in UserDefaults or the Keychain? Storing ' +
-        'application state such as a pending transfer is acceptable — only manual token storage is a violation.',
+        'application state is acceptable — only manual token storage is a violation.',
       GraderLevel.L3,
     ),
 
     // ── L4: Structural correctness ────────────────────────────────────────
     judge(
-      'Does the code check the amr claim before executing the transfer action, and only proceed when ' +
-        '"mfa" is present in the amr array? Reading amr via JWTDecode (decode(jwt:).claim(name: "amr")) ' +
-        'or via CredentialsManager.userProfile()?.customClaims are both acceptable.',
+      'Does the code catch the MFA-required error from the Authentication API login (a non-nil ' +
+        'error.mfaRequiredErrorPayload), read the mfaToken, and drive the MFA API flow through Auth0.mfa() — ' +
+        'challenging an enrolled factor and verifying the code (enrolling one first when the user has none) — ' +
+        'before the login is treated as complete?',
       GraderLevel.L4,
     ),
     judge(
-      'When MFA is missing, is step-up performed by starting a new Universal Login web auth session — ' +
-        'Auth0.webAuth() with the MFA acr_values — rather than by calling the Authentication API MFA ' +
-        'endpoints (challenge/verify) directly?',
+      'After a successful verify, does the code store the returned Credentials via the CredentialsManager, ' +
+        'rather than calling the raw /mfa endpoints directly or managing the returned tokens by hand?',
       GraderLevel.L4,
     ),
 
     // ── L5: Current API patterns ──────────────────────────────────────────
-    // `.parameters` / `.maxAge` are the current builders for extra authorization
-    // parameters. The scaffold's login call uses neither, so this only passes if
-    // the agent built the step-up request itself.
-    matches(
-      String.raw`\.parameters\(|\.maxAge\(`,
-      'Step-up parameters passed through the current .parameters/.maxAge builders',
-      GraderLevel.L5,
-    ),
     judge(
-      'Does the step-up request force fresh authentication with a max_age of 0, so a cached session is ' +
-        'not reused? Either the dedicated .maxAge(0) builder or "max_age" inside .parameters([...]) counts.',
+      'Does the solution use the current MFA client API — Auth0.mfa() with getAuthenticators / challenge / ' +
+        'verify(otp:mfaToken:) (or the oobCode/recoveryCode verify variants) — rather than hand-building ' +
+        '/oauth/token MFA-grant HTTP requests?',
       GraderLevel.L5,
     ),
 
     // ── Holistic judge (no level — always runs) ───────────────────────────
     judge(
-      'Does the solution correctly implement MFA step-up authentication in a Swift iOS app — reading the ' +
-        'amr claim from the ID token (via JWTDecode or UserProfile.customClaims), requesting step-up ' +
-        'through Auth0.webAuth() with acr_values and max_age 0 when MFA is not present, and gating the ' +
-        'Transfer Funds action behind MFA verification?',
+      'Does the solution correctly complete MFA at login in a Swift iOS app using Auth0.swift’s MFA API — ' +
+        'detecting the MFA-required error, reading the mfaToken, challenging (or enrolling) a factor and ' +
+        'verifying the code through Auth0.mfa(), and storing the resulting credentials so the user finishes ' +
+        'signing in?',
     ),
   ];
 }

--- a/apps/auth0-evals/src/evals/mfa/vue/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/vue/graders.ts
@@ -1,11 +1,11 @@
-import { contains, notContains, matches, judge, compiles, GraderLevel } from '@a0/evals-graders';
+import { contains, notContains, judge, compiles, GraderLevel } from '@a0/evals-graders';
 
 export function defineGraders() {
   return [
     // ── L1: Required step-up symbols present ───────────────────────────
-    matches(
-      String.raw`interactiveErrorHandler|acr_values`,
-      'Step-up configured via interactiveErrorHandler (SDK default) or acr_values (manual approach)',
+    contains(
+      'interactiveErrorHandler',
+      'Step-up configured via interactiveErrorHandler ("popup") — the pattern the SDK examples teach',
       GraderLevel.L1,
     ),
     contains(
@@ -44,19 +44,14 @@ export function defineGraders() {
     ),
 
     // ── L5: Current API patterns ──────────────────────────────────────────
-    judge(
-      'Is interactiveErrorHandler set to "popup" in the createAuth0 plugin configuration? ' +
-        '(If using the manual acr_values approach instead, are acr_values ' +
-        'and max_age: 0 passed inside authorizationParams on loginWithRedirect?)',
-      GraderLevel.L5,
-    ),
+    judge('Is interactiveErrorHandler set to "popup" in the createAuth0 plugin configuration?', GraderLevel.L5),
 
     // ── Holistic judge (no level — always runs) ───────────────────────────
     judge(
       'Does the solution correctly implement MFA step-up authentication in a Vue 3 app using ' +
-        '@auth0/auth0-vue — either by configuring interactiveErrorHandler: "popup" ' +
+        '@auth0/auth0-vue — by configuring interactiveErrorHandler: "popup" ' +
         'so that getAccessTokenSilently automatically triggers an MFA popup ' +
-        'when the API requires it, or by explicitly requesting step-up via acr_values — and gating ' +
+        'when the API requires it — and gating ' +
         'the Transfer Funds action behind successful MFA completion?',
     ),
   ];


### PR DESCRIPTION
The MFA evals were all graded against one generic step-up ideal — request
acr_values, then check the amr claim — but each SDK's own examples teach a
different, SDK-specific flow. This realigns seven graders to what the examples
actually demonstrate, while keeping a real MFA gate in each.

- react / spa-js: gate on interactiveErrorHandler: "popup" plus the silent
  token call; drop the acr_values/amr demands.
- nextjs: reactive getAccessToken → catch MfaRequiredError → challenge, instead
  of reading amr off the session and redirecting with acr_values.
- server-python: the embedded MFA-API flow (MfaRequiredError →
  list/challenge_authenticator → mfa.verify) its examples teach, instead of
  start_interactive_login/acr_values.
- express-oidc: relax the rigid amr presence check (gating on acr shouldn't
  fail); keep acr_values via res.oidc.login, this SDK's only step-up mechanism.
- express-api: grade the 403 mfa_required outcome rather than the literal
  res.status(403) call.
- auth0-server-js: description fix (recovery code comes from mfa.verify).

Native (android/swift) and the no-example SDKs (vue/angular) are left out on
purpose — aligning them literally would either invert or empty the eval, which
is really an upstream example gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated MFA implementation guidance for Android and Swift to cover handling MFA-required login errors, authenticator challenges, verification, enrollment, and credential storage.
  - Refined Express API guidance to enforce transfer access through the `transfer:funds` scope.

- **Tests**
  - Updated MFA evaluations across supported platforms to validate current SDK-based challenge, popup, scope, and error-handling flows.
  - Improved checks for authenticator enrollment, verification, recovery codes, and secure session persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->