### PR TITLE
fix(scorer): fix CLI efficiency endpoint extraction for bash-wrapped and GET commands

### DIFF
--- a/apps/auth0-evals/src/evals/mfa/nextjs/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/nextjs/graders.ts
@@ -3,14 +3,19 @@ import { contains, notContains, notContainsInSource, judge, compiles, GraderLeve
 export function defineGraders() {
   return [
     // ── L1: Required MFA step-up symbols present ───────────────────────────
-    contains('MfaRequiredError', 'MfaRequiredError imported from SDK', GraderLevel.L1),
-    contains('getAccessToken', 'getAccessToken called to trigger mfa_required check', GraderLevel.L1),
-    contains('instanceof MfaRequiredError', 'MfaRequiredError caught and identified', GraderLevel.L1),
+    contains('acr_values', 'Step-up request uses acr_values parameter', GraderLevel.L1),
+    contains('amr', 'AMR claim checked to detect prior MFA completion', GraderLevel.L1),
+    contains(
+      'schemas.openid.net/pape/policies/2007/06/multi-factor',
+      'Uses correct multi-factor acr_values policy URI',
+      GraderLevel.L1,
+    ),
 
     // ── L2: Hallucination / wrong approach ────────────────────────────────
     notContains('speakeasy', 'No server-side TOTP library (speakeasy) used', GraderLevel.L2),
     notContains('otplib', 'No server-side TOTP library (otplib) used', GraderLevel.L2),
     notContains('@auth0/guardian', 'No fake Guardian client SDK referenced', GraderLevel.L2),
+    notContains('mfa/challenge', 'Does not call raw MFA challenge endpoint', GraderLevel.L2),
     notContains(
       'loginWithRedirect',
       'Does not use React SPA loginWithRedirect in a server-side Next.js app',
@@ -18,7 +23,7 @@ export function defineGraders() {
     ),
     notContains(
       'getIdTokenClaims',
-      'Does not use React SPA getIdTokenClaims — reads session server-side',
+      'Does not use React SPA getIdTokenClaims — reads amr via server session',
       GraderLevel.L2,
     ),
 
@@ -48,14 +53,13 @@ export function defineGraders() {
     // ── L4: Structural / behavioral correctness ───────────────────────────────
     compiles('Project compiles (build succeeds)', GraderLevel.L4),
     judge(
-      'Does the code call auth0.getAccessToken() with the API audience (https://api.barkbook.com) ' +
-        'and wrap it in a try/catch that handles MfaRequiredError to trigger step-up authentication?',
+      'Does the code read the amr claim from the server-side session (e.g. session.user.amr) ' +
+        'and check whether "mfa" is present in that array before allowing the transfer to proceed?',
       GraderLevel.L4,
     ),
     judge(
-      'When MfaRequiredError is caught, does the code redirect the user to an MFA challenge — ' +
-        'either via a redirect to a challenge page, using mfa.challengeWithPopup(), or an equivalent ' +
-        'SDK-supported mechanism — rather than silently failing or exposing the mfa_token to the client?',
+      'When the amr claim is missing or does not contain "mfa", does the code redirect the user ' +
+        'to /auth/login with acr_values set to the multi-factor policy URI and max_age set to 0?',
       GraderLevel.L4,
     ),
 
@@ -64,17 +68,18 @@ export function defineGraders() {
     notContains('/api/auth/', 'Does not use v3 route prefix /api/auth/ (v4 uses /auth/)', GraderLevel.L5),
     notContains('AUTH0_ISSUER_BASE_URL', 'Does not use v3 env var AUTH0_ISSUER_BASE_URL', GraderLevel.L5),
     judge(
-      'Is MfaRequiredError imported from "@auth0/nextjs-auth0/server" (the correct v4 server import path) ' +
-        'rather than from the root "@auth0/nextjs-auth0" package or a non-existent path?',
+      'Does the Auth0Client instantiation use the beforeSessionSaved hook to copy the amr claim ' +
+        'from the incoming session user object into the persisted session, so that amr is available ' +
+        'on subsequent calls to auth0.getSession()?',
       GraderLevel.L5,
     ),
 
     // ── Holistic judge (no level — always runs) ───────────────────────────
     judge(
       'Does the solution correctly implement MFA step-up authentication in a Next.js App Router app ' +
-        'using @auth0/nextjs-auth0 v4 — calling getAccessToken() with the API audience, catching ' +
-        'MfaRequiredError when Auth0 requires MFA, directing the user through an MFA challenge, ' +
-        'and gating the Transfer Funds action so it only proceeds after MFA is satisfied?',
+        'using @auth0/nextjs-auth0 v4 — checking the amr claim to detect prior MFA completion, ' +
+        'redirecting to /auth/login with acr_values and max_age=0 when MFA is absent, ' +
+        'and gating the Transfer Funds action behind that verification?',
     ),
   ];
 }

--- a/apps/auth0-evals/src/evals/mfa/nextjs/graders.ts
+++ b/apps/auth0-evals/src/evals/mfa/nextjs/graders.ts
@@ -3,21 +3,14 @@ import { contains, notContains, notContainsInSource, judge, compiles, GraderLeve
 export function defineGraders() {
   return [
     // ── L1: Required MFA step-up symbols present ───────────────────────────
-    contains('acr_values', 'Step-up request uses acr_values parameter', GraderLevel.L1),
-    contains('amr', 'AMR claim checked to detect prior MFA completion', GraderLevel.L1),
-    contains('beforeSessionSaved', 'Uses beforeSessionSaved hook to preserve amr in session', GraderLevel.L1),
-    contains('session.user.amr', 'AMR claim read from server-side session', GraderLevel.L1),
-    contains(
-      'schemas.openid.net/pape/policies/2007/06/multi-factor',
-      'Uses correct multi-factor acr_values policy URI',
-      GraderLevel.L1,
-    ),
+    contains('MfaRequiredError', 'MfaRequiredError imported from SDK', GraderLevel.L1),
+    contains('getAccessToken', 'getAccessToken called to trigger mfa_required check', GraderLevel.L1),
+    contains('instanceof MfaRequiredError', 'MfaRequiredError caught and identified', GraderLevel.L1),
 
     // ── L2: Hallucination / wrong approach ────────────────────────────────
     notContains('speakeasy', 'No server-side TOTP library (speakeasy) used', GraderLevel.L2),
     notContains('otplib', 'No server-side TOTP library (otplib) used', GraderLevel.L2),
     notContains('@auth0/guardian', 'No fake Guardian client SDK referenced', GraderLevel.L2),
-    notContains('mfa/challenge', 'Does not call raw MFA challenge endpoint', GraderLevel.L2),
     notContains(
       'loginWithRedirect',
       'Does not use React SPA loginWithRedirect in a server-side Next.js app',
@@ -25,7 +18,7 @@ export function defineGraders() {
     ),
     notContains(
       'getIdTokenClaims',
-      'Does not use React SPA getIdTokenClaims — reads amr via server session',
+      'Does not use React SPA getIdTokenClaims — reads session server-side',
       GraderLevel.L2,
     ),
 
@@ -55,13 +48,14 @@ export function defineGraders() {
     // ── L4: Structural / behavioral correctness ───────────────────────────────
     compiles('Project compiles (build succeeds)', GraderLevel.L4),
     judge(
-      'Does the code read the amr claim from the server-side session (e.g. session.user.amr) ' +
-        'and check whether "mfa" is present in that array before allowing the transfer to proceed?',
+      'Does the code call auth0.getAccessToken() with the API audience (https://api.barkbook.com) ' +
+        'and wrap it in a try/catch that handles MfaRequiredError to trigger step-up authentication?',
       GraderLevel.L4,
     ),
     judge(
-      'When the amr claim is missing or does not contain "mfa", does the code redirect the user ' +
-        'to /auth/login with acr_values set to the multi-factor policy URI and max_age set to 0?',
+      'When MfaRequiredError is caught, does the code redirect the user to an MFA challenge — ' +
+        'either via a redirect to a challenge page, using mfa.challengeWithPopup(), or an equivalent ' +
+        'SDK-supported mechanism — rather than silently failing or exposing the mfa_token to the client?',
       GraderLevel.L4,
     ),
 
@@ -70,18 +64,17 @@ export function defineGraders() {
     notContains('/api/auth/', 'Does not use v3 route prefix /api/auth/ (v4 uses /auth/)', GraderLevel.L5),
     notContains('AUTH0_ISSUER_BASE_URL', 'Does not use v3 env var AUTH0_ISSUER_BASE_URL', GraderLevel.L5),
     judge(
-      'Does the Auth0Client instantiation use the beforeSessionSaved hook to copy the amr claim ' +
-        'from the incoming session user object into the persisted session, so that amr is available ' +
-        'on subsequent calls to auth0.getSession()?',
+      'Is MfaRequiredError imported from "@auth0/nextjs-auth0/server" (the correct v4 server import path) ' +
+        'rather than from the root "@auth0/nextjs-auth0" package or a non-existent path?',
       GraderLevel.L5,
     ),
 
     // ── Holistic judge (no level — always runs) ───────────────────────────
     judge(
       'Does the solution correctly implement MFA step-up authentication in a Next.js App Router app ' +
-        'using @auth0/nextjs-auth0 v4 — preserving the amr claim via beforeSessionSaved, reading it ' +
-        'server-side via auth0.getSession(), redirecting to /auth/login with acr_values and max_age=0 ' +
-        'when MFA is absent, and gating the Transfer Funds action behind that verification?',
+        'using @auth0/nextjs-auth0 v4 — calling getAccessToken() with the API audience, catching ' +
+        'MfaRequiredError when Auth0 requires MFA, directing the user through an MFA challenge, ' +
+        'and gating the Transfer Funds action so it only proceeds after MFA is satisfied?',
     ),
   ];
 }

--- a/packages/evals/src/scorer.ts
+++ b/packages/evals/src/scorer.ts
@@ -154,6 +154,9 @@ function extractCliEndpoint(command: string): string {
 function isCliDiscoveryCall(command: string): boolean {
   const lower = command.toLowerCase().trim();
   const tokens = lower.split(/\s+/);
+  // Treat read-only verbs as discovery — GET calls verify state and should not
+  // be counted as corrective attempts against write (PUT/POST/PATCH/DELETE) ops.
+  if (tokens.some((t) => t === 'get') && tokens.some((t) => t === 'api')) return true;
   return tokens.some((t) => t === 'list' || t === 'show') || lower.includes('--help');
 }
 

--- a/packages/evals/src/scorer.ts
+++ b/packages/evals/src/scorer.ts
@@ -151,13 +151,11 @@ function extractCliEndpoint(command: string): string {
   return positional[positional.length - 1] ?? command.trim();
 }
 
-function isCliDiscoveryCall(command: string): boolean {
-  const lower = command.toLowerCase().trim();
-  const tokens = lower.split(/\s+/);
-  // Treat read-only verbs as discovery — GET calls verify state and should not
-  // be counted as corrective attempts against write (PUT/POST/PATCH/DELETE) ops.
-  if (tokens.some((t) => t === 'get') && tokens.some((t) => t === 'api')) return true;
-  return tokens.some((t) => t === 'list' || t === 'show') || lower.includes('--help');
+function isAuth0ApiWriteCall(command: string): boolean {
+  const lower = command.toLowerCase();
+  if (!lower.includes('auth0') || !lower.includes('api')) return false;
+  // Only count write verbs — GET reads state and should not count as an endpoint operation.
+  return /\bauth0\s+api\s+(put|post|patch|delete)\b/.test(lower);
 }
 
 function scoreEfficiency(record: RunRecord, opts?: ScoringOptions): [number, string] {
@@ -168,9 +166,13 @@ function scoreEfficiency(record: RunRecord, opts?: ScoringOptions): [number, str
     return [100.0, 'N/A (no tools in baseline/skills mode)'];
   }
 
-  const cliCalls = record.toolCalls.filter(
-    (tc) => tc.name === 'run_command' && !isCliDiscoveryCall(String((tc.args['command'] as string) ?? '')),
-  );
+  const cliCalls = record.toolCalls.filter((tc) => {
+    if (tc.name !== 'run_command') return false;
+    const cmd = String((tc.args['command'] as string) ?? '');
+    // Only count auth0 api write commands — shell utilities (sed, rg, bash, etc.)
+    // and auth0 api get calls are not API endpoint operations.
+    return isAuth0ApiWriteCall(cmd);
+  });
   if (record.evalType === 'cli' && cliCalls.length > 0) {
     const endpointCounts: Record<string, number> = {};
     for (const tc of cliCalls) {

--- a/packages/evals/src/scorer.ts
+++ b/packages/evals/src/scorer.ts
@@ -145,6 +145,14 @@ function scoreSpeed(record: RunRecord, opts?: ScoringOptions): [number, string] 
 }
 
 function extractCliEndpoint(command: string): string {
+  // For auth0 api commands (including bash-wrapped ones like `/bin/bash -lc '...'`),
+  // extract the path argument directly. Positional tokenization breaks when the
+  // command is wrapped in bash because `/bin/bash` becomes the last pre-flag token.
+  // Match the Guardian path whether it is unquoted, single-quoted, double-quoted,
+  // or backslash-escaped double-quoted (the form Codex emits inside bash -lc "...").
+  const auth0Match = command.match(/\bauth0\s+api\s+(?:put|post|patch|delete|get)\s+(?:\\?"?|'?)([a-zA-Z0-9_\-/]+)/i);
+  if (auth0Match) return auth0Match[1]!;
+
   const tokens = command.trim().split(/\s+/);
   const firstFlag = tokens.findIndex((t) => t.startsWith('-'));
   const positional = firstFlag === -1 ? tokens : tokens.slice(0, firstFlag);

--- a/packages/evals/tests/scorer.test.ts
+++ b/packages/evals/tests/scorer.test.ts
@@ -311,14 +311,17 @@ describe('score - Efficiency (CLI mode)', () => {
     expect(getDim(result, 'Efficiency').notes).toContain('no repeated endpoints');
   });
 
-  it('auth0 api get calls are excluded from CLI precision (pre-check + post-verify pattern)', () => {
+  it('auth0 api get and shell utility calls are excluded — only write commands count', () => {
     const dir = tmpDir();
     const record = makeRecord({ workspace: dir, evalType: 'cli' });
     record.toolCalls = [
-      // pre-check reads
+      // skill-loading shell commands (sed, rg) — must not count
+      makeToolCall('run_command', 1, { args: { command: "sed -n '1,240p' /tmp/workspace/SKILL.md" } }),
+      makeToolCall('run_command', 1, { args: { command: 'rg "feature-mfa" /tmp/workspace' } }),
+      // pre-check reads — must not count
       makeToolCall('run_command', 1, { args: { command: 'auth0 api get guardian/factors' } }),
       makeToolCall('run_command', 1, { args: { command: 'auth0 api get guardian/policies' } }),
-      // config writes
+      // config writes — only these count
       makeToolCall('run_command', 1, {
         args: { command: 'auth0 api put guardian/factors/sms --data \'{"enabled":true}\'' },
       }),
@@ -334,11 +337,13 @@ describe('score - Efficiency (CLI mode)', () => {
       makeToolCall('run_command', 1, {
         args: { command: 'auth0 api put guardian/policies --data \'["all-applications"]\'' },
       }),
-      // post-verify read
-      makeToolCall('run_command', 1, { args: { command: 'auth0 api get guardian/factors' } }),
+      // post-verify read — must not count
+      makeToolCall('run_command', 1, {
+        args: { command: 'auth0 api get "guardian/factors" && auth0 api get "guardian/policies"' },
+      }),
     ];
     const result = score(record);
-    // GET calls are discovery — only the 5 PUTs count, all unique → 100
+    // only the 5 PUTs count, all unique → 100
     expect(getDim(result, 'Efficiency').rawScore).toBe(100.0);
     expect(getDim(result, 'Efficiency').notes).toContain('no repeated endpoints');
   });

--- a/packages/evals/tests/scorer.test.ts
+++ b/packages/evals/tests/scorer.test.ts
@@ -348,6 +348,40 @@ describe('score - Efficiency (CLI mode)', () => {
     expect(getDim(result, 'Efficiency').notes).toContain('no repeated endpoints');
   });
 
+  it('bash-wrapped auth0 api commands extract the correct endpoint path', () => {
+    const dir = tmpDir();
+    const record = makeRecord({ workspace: dir, evalType: 'cli' });
+    record.toolCalls = [
+      makeToolCall('run_command', 1, {
+        args: { command: '/bin/bash -lc \'auth0 api put "guardian/factors/sms" --data \\\'{ "enabled": true }\\\'\' ' },
+      }),
+      makeToolCall('run_command', 1, {
+        args: {
+          command:
+            '/bin/bash -lc \'auth0 api put "guardian/factors/phone/message-types" --data \'{"message_types":["sms"]}\'\'',
+        },
+      }),
+      makeToolCall('run_command', 1, {
+        args: {
+          command:
+            '/bin/bash -lc \'auth0 api put "guardian/factors/phone/selected-provider" --data \\\'{ "provider": "auth0" }\\\'\' ',
+        },
+      }),
+      makeToolCall('run_command', 1, {
+        args: {
+          command: '/bin/bash -lc \'auth0 api put "guardian/factors/email" --data \\\'{ "enabled": true }\\\'\' ',
+        },
+      }),
+      makeToolCall('run_command', 1, {
+        args: { command: '/bin/bash -lc \'auth0 api put "guardian/policies" --data \\\'["all-applications"]\\\'\' ' },
+      }),
+    ];
+    const result = score(record);
+    // 5 bash-wrapped PUTs, all unique endpoints → 100
+    expect(getDim(result, 'Efficiency').rawScore).toBe(100.0);
+    expect(getDim(result, 'Efficiency').notes).toContain('no repeated endpoints');
+  });
+
   it('commands with --data body are grouped by path, not by JSON payload', () => {
     const dir = tmpDir();
     const record = makeRecord({ workspace: dir, evalType: 'cli' });

--- a/packages/evals/tests/scorer.test.ts
+++ b/packages/evals/tests/scorer.test.ts
@@ -311,6 +311,38 @@ describe('score - Efficiency (CLI mode)', () => {
     expect(getDim(result, 'Efficiency').notes).toContain('no repeated endpoints');
   });
 
+  it('auth0 api get calls are excluded from CLI precision (pre-check + post-verify pattern)', () => {
+    const dir = tmpDir();
+    const record = makeRecord({ workspace: dir, evalType: 'cli' });
+    record.toolCalls = [
+      // pre-check reads
+      makeToolCall('run_command', 1, { args: { command: 'auth0 api get guardian/factors' } }),
+      makeToolCall('run_command', 1, { args: { command: 'auth0 api get guardian/policies' } }),
+      // config writes
+      makeToolCall('run_command', 1, {
+        args: { command: 'auth0 api put guardian/factors/sms --data \'{"enabled":true}\'' },
+      }),
+      makeToolCall('run_command', 1, {
+        args: { command: 'auth0 api put guardian/factors/phone/message-types --data \'{"message_types":["sms"]}\'' },
+      }),
+      makeToolCall('run_command', 1, {
+        args: { command: 'auth0 api put guardian/factors/phone/selected-provider --data \'{"provider":"auth0"}\'' },
+      }),
+      makeToolCall('run_command', 1, {
+        args: { command: 'auth0 api put guardian/factors/email --data \'{"enabled":true}\'' },
+      }),
+      makeToolCall('run_command', 1, {
+        args: { command: 'auth0 api put guardian/policies --data \'["all-applications"]\'' },
+      }),
+      // post-verify read
+      makeToolCall('run_command', 1, { args: { command: 'auth0 api get guardian/factors' } }),
+    ];
+    const result = score(record);
+    // GET calls are discovery — only the 5 PUTs count, all unique → 100
+    expect(getDim(result, 'Efficiency').rawScore).toBe(100.0);
+    expect(getDim(result, 'Efficiency').notes).toContain('no repeated endpoints');
+  });
+
   it('commands with --data body are grouped by path, not by JSON payload', () => {
     const dir = tmpDir();
     const record = makeRecord({ workspace: dir, evalType: 'cli' });


### PR DESCRIPTION
## Problem

CLI efficiency scores for GPT models on the MFA eval were collapsing to F (20)
even when all 5 Guardian config writes ran correctly. Two compounding bugs:

1. **GET calls counted as endpoint operations.** The scorer's endpoint-repeat
   check treated `GET guardian/policies` and `PUT guardian/policies` as the
   same repeated call, so a normal pre-check-GET + write-PUT + verify-GET
   pattern scored 50 instead of 100 — indistinguishable from a failed retry
   loop.
2. **Bash-wrapped commands all resolved to the same fake endpoint.** Codex
   wraps every shell command in `/bin/bash -lc "..."`. The old
   `extractCliEndpoint` tokenized positionally (last token before the first
   `-` flag), so for `/bin/bash -lc "auth0 api put \"guardian/factors/sms\" ..."`
   the extracted "endpoint" was `/bin/bash` — for every command, regardless of
   the actual Guardian path. All 5 distinct PUTs collapsed into one repeated
   "endpoint", scoring `100/5 = 20`.

## Fix

- Added `isAuth0ApiWriteCall` — only `auth0 api put/post/patch/delete` count
  toward efficiency; GET calls and shell utilities (`sed`, `rg`, etc.) are
  excluded entirely.
- Rewrote `extractCliEndpoint` to pull the Guardian path directly via regex
  (`\bauth0\s+api\s+(?:put|post|patch|delete|get)\s+...`) before falling back
  to positional tokenization. Handles unquoted, single-quoted, double-quoted,
  and backslash-escaped-double-quoted paths — the last form is what Codex
  emits inside `bash -lc "..."`.

Verified against the actual `session_trace` from eval-report-34571701094:
the 5 bash-wrapped PUTs now extract distinct Guardian paths
(`guardian/factors/sms`, `.../phone/message-types`,
`.../phone/selected-provider`, `guardian/factors/email`,
`guardian/policies`) and score 100 instead of 20.

## Tests

- GET calls + shell utilities excluded, only write commands count (100)
- Bash-wrapped `auth0 api put` commands extract the correct endpoint path (100)
- Existing repeat-detection tests unchanged (e.g. `guardian/factors/otp`
  called twice still scores 50)

All 725 tests pass.