### PR TITLE
chore(models): replace gemini-3.7-flash with gemini-3.8-flash

### DIFF
--- a/apps/auth0-evals/eval.config.js
+++ b/apps/auth0-evals/eval.config.js
@@ -139,7 +139,7 @@ export default {
     // `known` is the set `--model all` expands to. Opus 4.5 is intentionally excluded
     // here so `--model all` runs only Opus 5 among the Opus variants; the framework
     // and `modelIds` map below still support it for explicit `--model` runs.
-    known: ['gpt-5.6-sol', 'gpt-5.6-luna', 'gpt-5.6-terra', 'claude-sonnet-5', 'claude-opus-5', 'claude-haiku-4-5', 'gemini-3.1-pro-preview', 'gemini-3.5-flash'],
+    known: ['gpt-5.6-sol', 'gpt-5.6-luna', 'gpt-5.6-terra', 'claude-sonnet-5', 'claude-opus-5', 'claude-haiku-4-5', 'gemini-3.1-pro-preview', 'gemini-3.8-flash'],
     default: 'gpt-5.6-sol',
     // Maps short model aliases to the IDs the active proxy expects.
     // Bedrock proxy needs full `global.anthropic.*` IDs; LiteLLM proxy serves

--- a/packages/evals-core/src/config/costs.ts
+++ b/packages/evals-core/src/config/costs.ts
@@ -8,7 +8,7 @@ export const COST_TABLE: Record<string, [number, number]> = {
   'claude-opus-5': [5.0, 25.0],
   'claude-haiku-4-5': [1.0, 5.0],
   'gemini-3.1-pro-preview': [2.0, 12.0],
-  'gemini-3.7-flash': [0.75, 3.75],
+  'gemini-3.8-flash': [0.75, 3.75],
 };
 
 /** [input, output] USD per million tokens applied to models absent from COST_TABLE. */

--- a/packages/evals/README.md
+++ b/packages/evals/README.md
@@ -78,7 +78,7 @@ export default {
     known: [
       'gpt-5.4', 'gpt-5.4-mini',
       'claude-sonnet-4-6', 'claude-opus-4-6', 'claude-opus-4-7', 'claude-haiku-4-5',
-      'gemini-3.1-pro-preview', 'gemini-3.7-flash',
+      'gemini-3.1-pro-preview', 'gemini-3.8-flash',
     ],
     default: 'gpt-5.4',
   },

--- a/packages/evals/src/cli/constants.ts
+++ b/packages/evals/src/cli/constants.ts
@@ -17,7 +17,7 @@ export const KNOWN_WORKING_MODELS = [
   'claude-opus-5',
   'claude-haiku-4-5',
   'gemini-3.1-pro-preview',
-  'gemini-3.7-flash',
+  'gemini-3.8-flash',
 ];
 
 /** Model used when no `--model` flag is provided. */


### PR DESCRIPTION
Bumps the Gemini Flash model from 3.7 to 3.8 across all known-model lists, cost table, and CI matrix entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the supported Gemini Flash model reference to `gemini-3.8-flash` across evaluation configuration, pricing, CLI defaults, and documentation.
  - Existing pricing remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->